### PR TITLE
Fix AntaresFilterDevKit notebook outdated documentation

### DIFF
--- a/05_Contrib/TimeDomain/AntaresDevKit/AntaresFilterDevKit.html
+++ b/05_Contrib/TimeDomain/AntaresDevKit/AntaresFilterDevKit.html
@@ -276,8 +276,8 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
 | The full license is in the file LICENSE, distributed with this software.
 |----------------------------------------------------------------------------*/
 
-
-/* <DEPRECATED> */ .p-Widget, /* </DEPRECATED> */
+/* <DEPRECATED> */
+.p-Widget, /* </DEPRECATED> */
 .lm-Widget {
   box-sizing: border-box;
   position: relative;
@@ -285,10 +285,17 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
   cursor: default;
 }
 
-
-/* <DEPRECATED> */ .p-Widget.p-mod-hidden, /* </DEPRECATED> */
+/* <DEPRECATED> */
+.p-Widget.p-mod-hidden, /* </DEPRECATED> */
 .lm-Widget.lm-mod-hidden {
   display: none !important;
+}
+
+.lm-AccordionPanel[data-orientation='horizontal'] > .lm-AccordionPanel-title {
+  /* Title is rotated for horizontal accordion panel using CSS */
+  display: block;
+  transform-origin: top left;
+  transform: rotate(-90deg) translate(-100%);
 }
 
 /*-----------------------------------------------------------------------------
@@ -300,8 +307,8 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
 | The full license is in the file LICENSE, distributed with this software.
 |----------------------------------------------------------------------------*/
 
-
-/* <DEPRECATED> */ .p-CommandPalette, /* </DEPRECATED> */
+/* <DEPRECATED> */
+.p-CommandPalette, /* </DEPRECATED> */
 .lm-CommandPalette {
   display: flex;
   flex-direction: column;
@@ -311,14 +318,14 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
   user-select: none;
 }
 
-
-/* <DEPRECATED> */ .p-CommandPalette-search, /* </DEPRECATED> */
+/* <DEPRECATED> */
+.p-CommandPalette-search, /* </DEPRECATED> */
 .lm-CommandPalette-search {
   flex: 0 0 auto;
 }
 
-
-/* <DEPRECATED> */ .p-CommandPalette-content, /* </DEPRECATED> */
+/* <DEPRECATED> */
+.p-CommandPalette-content, /* </DEPRECATED> */
 .lm-CommandPalette-content {
   flex: 1 1 auto;
   margin: 0;
@@ -328,42 +335,42 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
   list-style-type: none;
 }
 
-
-/* <DEPRECATED> */ .p-CommandPalette-header, /* </DEPRECATED> */
+/* <DEPRECATED> */
+.p-CommandPalette-header, /* </DEPRECATED> */
 .lm-CommandPalette-header {
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;
 }
 
-
-/* <DEPRECATED> */ .p-CommandPalette-item, /* </DEPRECATED> */
+/* <DEPRECATED> */
+.p-CommandPalette-item, /* </DEPRECATED> */
 .lm-CommandPalette-item {
   display: flex;
   flex-direction: row;
 }
 
-
-/* <DEPRECATED> */ .p-CommandPalette-itemIcon, /* </DEPRECATED> */
+/* <DEPRECATED> */
+.p-CommandPalette-itemIcon, /* </DEPRECATED> */
 .lm-CommandPalette-itemIcon {
   flex: 0 0 auto;
 }
 
-
-/* <DEPRECATED> */ .p-CommandPalette-itemContent, /* </DEPRECATED> */
+/* <DEPRECATED> */
+.p-CommandPalette-itemContent, /* </DEPRECATED> */
 .lm-CommandPalette-itemContent {
   flex: 1 1 auto;
   overflow: hidden;
 }
 
-
-/* <DEPRECATED> */ .p-CommandPalette-itemShortcut, /* </DEPRECATED> */
+/* <DEPRECATED> */
+.p-CommandPalette-itemShortcut, /* </DEPRECATED> */
 .lm-CommandPalette-itemShortcut {
   flex: 0 0 auto;
 }
 
-
-/* <DEPRECATED> */ .p-CommandPalette-itemLabel, /* </DEPRECATED> */
+/* <DEPRECATED> */
+.p-CommandPalette-itemLabel, /* </DEPRECATED> */
 .lm-CommandPalette-itemLabel {
   overflow: hidden;
   white-space: nowrap;
@@ -371,30 +378,30 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
 }
 
 .lm-close-icon {
-	border:1px solid transparent;
+  border: 1px solid transparent;
   background-color: transparent;
   position: absolute;
-	z-index:1;
-	right:3%;
-	top: 0;
-	bottom: 0;
-	margin: auto;
-	padding: 7px 0;
-	display: none;
-	vertical-align: middle;
+  z-index: 1;
+  right: 3%;
+  top: 0;
+  bottom: 0;
+  margin: auto;
+  padding: 7px 0;
+  display: none;
+  vertical-align: middle;
   outline: 0;
   cursor: pointer;
 }
 .lm-close-icon:after {
-	content: "X";
-	display: block;
-	width: 15px;
-	height: 15px;
-	text-align: center;
-	color:#000;
-	font-weight: normal;
-	font-size: 12px;
-	cursor: pointer;
+  content: 'X';
+  display: block;
+  width: 15px;
+  height: 15px;
+  text-align: center;
+  color: #000;
+  font-weight: normal;
+  font-size: 12px;
+  cursor: pointer;
 }
 
 /*-----------------------------------------------------------------------------
@@ -406,38 +413,38 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
 | The full license is in the file LICENSE, distributed with this software.
 |----------------------------------------------------------------------------*/
 
-
-/* <DEPRECATED> */ .p-DockPanel, /* </DEPRECATED> */
+/* <DEPRECATED> */
+.p-DockPanel, /* </DEPRECATED> */
 .lm-DockPanel {
   z-index: 0;
 }
 
-
-/* <DEPRECATED> */ .p-DockPanel-widget, /* </DEPRECATED> */
+/* <DEPRECATED> */
+.p-DockPanel-widget, /* </DEPRECATED> */
 .lm-DockPanel-widget {
   z-index: 0;
 }
 
-
-/* <DEPRECATED> */ .p-DockPanel-tabBar, /* </DEPRECATED> */
+/* <DEPRECATED> */
+.p-DockPanel-tabBar, /* </DEPRECATED> */
 .lm-DockPanel-tabBar {
   z-index: 1;
 }
 
-
-/* <DEPRECATED> */ .p-DockPanel-handle, /* </DEPRECATED> */
+/* <DEPRECATED> */
+.p-DockPanel-handle, /* </DEPRECATED> */
 .lm-DockPanel-handle {
   z-index: 2;
 }
 
-
-/* <DEPRECATED> */ .p-DockPanel-handle.p-mod-hidden, /* </DEPRECATED> */
+/* <DEPRECATED> */
+.p-DockPanel-handle.p-mod-hidden, /* </DEPRECATED> */
 .lm-DockPanel-handle.lm-mod-hidden {
   display: none !important;
 }
 
-
-/* <DEPRECATED> */ .p-DockPanel-handle:after, /* </DEPRECATED> */
+/* <DEPRECATED> */
+.p-DockPanel-handle:after, /* </DEPRECATED> */
 .lm-DockPanel-handle:after {
   position: absolute;
   top: 0;
@@ -447,7 +454,6 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
   content: '';
 }
 
-
 /* <DEPRECATED> */
 .p-DockPanel-handle[data-orientation='horizontal'],
 /* </DEPRECATED> */
@@ -455,14 +461,12 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
   cursor: ew-resize;
 }
 
-
 /* <DEPRECATED> */
 .p-DockPanel-handle[data-orientation='vertical'],
 /* </DEPRECATED> */
 .lm-DockPanel-handle[data-orientation='vertical'] {
   cursor: ns-resize;
 }
-
 
 /* <DEPRECATED> */
 .p-DockPanel-handle[data-orientation='horizontal']:after,
@@ -473,7 +477,6 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
   transform: translateX(-50%);
 }
 
-
 /* <DEPRECATED> */
 .p-DockPanel-handle[data-orientation='vertical']:after,
 /* </DEPRECATED> */
@@ -483,16 +486,16 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
   transform: translateY(-50%);
 }
 
-
-/* <DEPRECATED> */ .p-DockPanel-overlay, /* </DEPRECATED> */
+/* <DEPRECATED> */
+.p-DockPanel-overlay, /* </DEPRECATED> */
 .lm-DockPanel-overlay {
   z-index: 3;
   box-sizing: border-box;
   pointer-events: none;
 }
 
-
-/* <DEPRECATED> */ .p-DockPanel-overlay.p-mod-hidden, /* </DEPRECATED> */
+/* <DEPRECATED> */
+.p-DockPanel-overlay.p-mod-hidden, /* </DEPRECATED> */
 .lm-DockPanel-overlay.lm-mod-hidden {
   display: none !important;
 }
@@ -506,8 +509,8 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
 | The full license is in the file LICENSE, distributed with this software.
 |----------------------------------------------------------------------------*/
 
-
-/* <DEPRECATED> */ .p-Menu, /* </DEPRECATED> */
+/* <DEPRECATED> */
+.p-Menu, /* </DEPRECATED> */
 .lm-Menu {
   z-index: 10000;
   position: absolute;
@@ -521,8 +524,8 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
   user-select: none;
 }
 
-
-/* <DEPRECATED> */ .p-Menu-content, /* </DEPRECATED> */
+/* <DEPRECATED> */
+.p-Menu-content, /* </DEPRECATED> */
 .lm-Menu-content {
   margin: 0;
   padding: 0;
@@ -530,12 +533,11 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
   list-style-type: none;
 }
 
-
-/* <DEPRECATED> */ .p-Menu-item, /* </DEPRECATED> */
+/* <DEPRECATED> */
+.p-Menu-item, /* </DEPRECATED> */
 .lm-Menu-item {
   display: table-row;
 }
-
 
 /* <DEPRECATED> */
 .p-Menu-item.p-mod-hidden,
@@ -545,7 +547,6 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
 .lm-Menu-item.lm-mod-collapsed {
   display: none !important;
 }
-
 
 /* <DEPRECATED> */
 .p-Menu-itemIcon,
@@ -557,15 +558,15 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
   text-align: center;
 }
 
-
-/* <DEPRECATED> */ .p-Menu-itemLabel, /* </DEPRECATED> */
+/* <DEPRECATED> */
+.p-Menu-itemLabel, /* </DEPRECATED> */
 .lm-Menu-itemLabel {
   display: table-cell;
   text-align: left;
 }
 
-
-/* <DEPRECATED> */ .p-Menu-itemShortcut, /* </DEPRECATED> */
+/* <DEPRECATED> */
+.p-Menu-itemShortcut, /* </DEPRECATED> */
 .lm-Menu-itemShortcut {
   display: table-cell;
   text-align: right;
@@ -580,8 +581,8 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
 | The full license is in the file LICENSE, distributed with this software.
 |----------------------------------------------------------------------------*/
 
-
-/* <DEPRECATED> */ .p-MenuBar, /* </DEPRECATED> */
+/* <DEPRECATED> */
+.p-MenuBar, /* </DEPRECATED> */
 .lm-MenuBar {
   outline: none;
   -webkit-user-select: none;
@@ -590,8 +591,8 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
   user-select: none;
 }
 
-
-/* <DEPRECATED> */ .p-MenuBar-content, /* </DEPRECATED> */
+/* <DEPRECATED> */
+.p-MenuBar-content, /* </DEPRECATED> */
 .lm-MenuBar-content {
   margin: 0;
   padding: 0;
@@ -600,12 +601,11 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
   list-style-type: none;
 }
 
-
-/* <DEPRECATED> */ .p--MenuBar-item, /* </DEPRECATED> */
+/* <DEPRECATED> */
+.p--MenuBar-item, /* </DEPRECATED> */
 .lm-MenuBar-item {
   box-sizing: border-box;
 }
-
 
 /* <DEPRECATED> */
 .p-MenuBar-itemIcon,
@@ -625,8 +625,8 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
 | The full license is in the file LICENSE, distributed with this software.
 |----------------------------------------------------------------------------*/
 
-
-/* <DEPRECATED> */ .p-ScrollBar, /* </DEPRECATED> */
+/* <DEPRECATED> */
+.p-ScrollBar, /* </DEPRECATED> */
 .lm-ScrollBar {
   display: flex;
   -webkit-user-select: none;
@@ -635,14 +635,12 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
   user-select: none;
 }
 
-
 /* <DEPRECATED> */
 .p-ScrollBar[data-orientation='horizontal'],
 /* </DEPRECATED> */
 .lm-ScrollBar[data-orientation='horizontal'] {
   flex-direction: row;
 }
-
 
 /* <DEPRECATED> */
 .p-ScrollBar[data-orientation='vertical'],
@@ -651,15 +649,15 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
   flex-direction: column;
 }
 
-
-/* <DEPRECATED> */ .p-ScrollBar-button, /* </DEPRECATED> */
+/* <DEPRECATED> */
+.p-ScrollBar-button, /* </DEPRECATED> */
 .lm-ScrollBar-button {
   box-sizing: border-box;
   flex: 0 0 auto;
 }
 
-
-/* <DEPRECATED> */ .p-ScrollBar-track, /* </DEPRECATED> */
+/* <DEPRECATED> */
+.p-ScrollBar-track, /* </DEPRECATED> */
 .lm-ScrollBar-track {
   box-sizing: border-box;
   position: relative;
@@ -667,8 +665,8 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
   flex: 1 1 auto;
 }
 
-
-/* <DEPRECATED> */ .p-ScrollBar-thumb, /* </DEPRECATED> */
+/* <DEPRECATED> */
+.p-ScrollBar-thumb, /* </DEPRECATED> */
 .lm-ScrollBar-thumb {
   box-sizing: border-box;
   position: absolute;
@@ -683,26 +681,26 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
 | The full license is in the file LICENSE, distributed with this software.
 |----------------------------------------------------------------------------*/
 
-
-/* <DEPRECATED> */ .p-SplitPanel-child, /* </DEPRECATED> */
+/* <DEPRECATED> */
+.p-SplitPanel-child, /* </DEPRECATED> */
 .lm-SplitPanel-child {
   z-index: 0;
 }
 
-
-/* <DEPRECATED> */ .p-SplitPanel-handle, /* </DEPRECATED> */
+/* <DEPRECATED> */
+.p-SplitPanel-handle, /* </DEPRECATED> */
 .lm-SplitPanel-handle {
   z-index: 1;
 }
 
-
-/* <DEPRECATED> */ .p-SplitPanel-handle.p-mod-hidden, /* </DEPRECATED> */
+/* <DEPRECATED> */
+.p-SplitPanel-handle.p-mod-hidden, /* </DEPRECATED> */
 .lm-SplitPanel-handle.lm-mod-hidden {
   display: none !important;
 }
 
-
-/* <DEPRECATED> */ .p-SplitPanel-handle:after, /* </DEPRECATED> */
+/* <DEPRECATED> */
+.p-SplitPanel-handle:after, /* </DEPRECATED> */
 .lm-SplitPanel-handle:after {
   position: absolute;
   top: 0;
@@ -712,7 +710,6 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
   content: '';
 }
 
-
 /* <DEPRECATED> */
 .p-SplitPanel[data-orientation='horizontal'] > .p-SplitPanel-handle,
 /* </DEPRECATED> */
@@ -720,14 +717,12 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
   cursor: ew-resize;
 }
 
-
 /* <DEPRECATED> */
 .p-SplitPanel[data-orientation='vertical'] > .p-SplitPanel-handle,
 /* </DEPRECATED> */
 .lm-SplitPanel[data-orientation='vertical'] > .lm-SplitPanel-handle {
   cursor: ns-resize;
 }
-
 
 /* <DEPRECATED> */
 .p-SplitPanel[data-orientation='horizontal'] > .p-SplitPanel-handle:after,
@@ -737,7 +732,6 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
   min-width: 8px;
   transform: translateX(-50%);
 }
-
 
 /* <DEPRECATED> */
 .p-SplitPanel[data-orientation='vertical'] > .p-SplitPanel-handle:after,
@@ -757,8 +751,8 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
 | The full license is in the file LICENSE, distributed with this software.
 |----------------------------------------------------------------------------*/
 
-
-/* <DEPRECATED> */ .p-TabBar, /* </DEPRECATED> */
+/* <DEPRECATED> */
+.p-TabBar, /* </DEPRECATED> */
 .lm-TabBar {
   display: flex;
   -webkit-user-select: none;
@@ -767,22 +761,22 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
   user-select: none;
 }
 
-
-/* <DEPRECATED> */ .p-TabBar[data-orientation='horizontal'], /* </DEPRECATED> */
+/* <DEPRECATED> */
+.p-TabBar[data-orientation='horizontal'], /* </DEPRECATED> */
 .lm-TabBar[data-orientation='horizontal'] {
   flex-direction: row;
   align-items: flex-end;
 }
 
-
-/* <DEPRECATED> */ .p-TabBar[data-orientation='vertical'], /* </DEPRECATED> */
+/* <DEPRECATED> */
+.p-TabBar[data-orientation='vertical'], /* </DEPRECATED> */
 .lm-TabBar[data-orientation='vertical'] {
   flex-direction: column;
   align-items: flex-end;
 }
 
-
-/* <DEPRECATED> */ .p-TabBar-content, /* </DEPRECATED> */
+/* <DEPRECATED> */
+.p-TabBar-content, /* </DEPRECATED> */
 .lm-TabBar-content {
   margin: 0;
   padding: 0;
@@ -791,14 +785,12 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
   list-style-type: none;
 }
 
-
 /* <DEPRECATED> */
 .p-TabBar[data-orientation='horizontal'] > .p-TabBar-content,
 /* </DEPRECATED> */
 .lm-TabBar[data-orientation='horizontal'] > .lm-TabBar-content {
   flex-direction: row;
 }
-
 
 /* <DEPRECATED> */
 .p-TabBar[data-orientation='vertical'] > .p-TabBar-content,
@@ -807,15 +799,15 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
   flex-direction: column;
 }
 
-
-/* <DEPRECATED> */ .p-TabBar-tab, /* </DEPRECATED> */
+/* <DEPRECATED> */
+.p-TabBar-tab, /* </DEPRECATED> */
 .lm-TabBar-tab {
   display: flex;
   flex-direction: row;
   box-sizing: border-box;
   overflow: hidden;
+  touch-action: none; /* Disable native Drag/Drop */
 }
-
 
 /* <DEPRECATED> */
 .p-TabBar-tabIcon,
@@ -826,38 +818,35 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
   flex: 0 0 auto;
 }
 
-
-/* <DEPRECATED> */ .p-TabBar-tabLabel, /* </DEPRECATED> */
+/* <DEPRECATED> */
+.p-TabBar-tabLabel, /* </DEPRECATED> */
 .lm-TabBar-tabLabel {
   flex: 1 1 auto;
   overflow: hidden;
   white-space: nowrap;
 }
 
-
 .lm-TabBar-tabInput {
   user-select: all;
   width: 100%;
-  box-sizing : border-box;
+  box-sizing: border-box;
 }
 
-
-/* <DEPRECATED> */ .p-TabBar-tab.p-mod-hidden, /* </DEPRECATED> */
+/* <DEPRECATED> */
+.p-TabBar-tab.p-mod-hidden, /* </DEPRECATED> */
 .lm-TabBar-tab.lm-mod-hidden {
   display: none !important;
 }
-
 
 .lm-TabBar-addButton.lm-mod-hidden {
   display: none !important;
 }
 
-
-/* <DEPRECATED> */ .p-TabBar.p-mod-dragging .p-TabBar-tab, /* </DEPRECATED> */
+/* <DEPRECATED> */
+.p-TabBar.p-mod-dragging .p-TabBar-tab, /* </DEPRECATED> */
 .lm-TabBar.lm-mod-dragging .lm-TabBar-tab {
   position: relative;
 }
-
 
 /* <DEPRECATED> */
 .p-TabBar.p-mod-dragging[data-orientation='horizontal'] .p-TabBar-tab,
@@ -867,7 +856,6 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
   transition: left 150ms ease;
 }
 
-
 /* <DEPRECATED> */
 .p-TabBar.p-mod-dragging[data-orientation='vertical'] .p-TabBar-tab,
 /* </DEPRECATED> */
@@ -875,7 +863,6 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
   top: 0;
   transition: top 150ms ease;
 }
-
 
 /* <DEPRECATED> */
 .p-TabBar.p-mod-dragging .p-TabBar-tab.p-mod-dragging,
@@ -887,7 +874,7 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
 .lm-TabBar-tabLabel .lm-TabBar-tabInput {
   user-select: all;
   width: 100%;
-  box-sizing : border-box;
+  box-sizing: border-box;
   background: inherit;
 }
 
@@ -900,14 +887,14 @@ span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 
 | The full license is in the file LICENSE, distributed with this software.
 |----------------------------------------------------------------------------*/
 
-
-/* <DEPRECATED> */ .p-TabPanel-tabBar, /* </DEPRECATED> */
+/* <DEPRECATED> */
+.p-TabPanel-tabBar, /* </DEPRECATED> */
 .lm-TabPanel-tabBar {
   z-index: 1;
 }
 
-
-/* <DEPRECATED> */ .p-TabPanel-stackedPanel, /* </DEPRECATED> */
+/* <DEPRECATED> */
+.p-TabPanel-stackedPanel, /* </DEPRECATED> */
 .lm-TabPanel-stackedPanel {
   z-index: 0;
 }
@@ -9364,7 +9351,11 @@ span.bp3-popover-target{
 /* Icons urls */
 
 :root {
+  --jp-icon-add-above: url(data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTQiIGhlaWdodD0iMTQiIHZpZXdCb3g9IjAgMCAxNCAxNCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPGcgY2xpcC1wYXRoPSJ1cmwoI2NsaXAwXzEzN18xOTQ5MikiPgo8cGF0aCBjbGFzcz0ianAtaWNvbjMiIGQ9Ik00Ljc1IDQuOTMwNjZINi42MjVWNi44MDU2NkM2LjYyNSA3LjAxMTkxIDYuNzkzNzUgNy4xODA2NiA3IDcuMTgwNjZDNy4yMDYyNSA3LjE4MDY2IDcuMzc1IDcuMDExOTEgNy4zNzUgNi44MDU2NlY0LjkzMDY2SDkuMjVDOS40NTYyNSA0LjkzMDY2IDkuNjI1IDQuNzYxOTEgOS42MjUgNC41NTU2NkM5LjYyNSA0LjM0OTQxIDkuNDU2MjUgNC4xODA2NiA5LjI1IDQuMTgwNjZINy4zNzVWMi4zMDU2NkM3LjM3NSAyLjA5OTQxIDcuMjA2MjUgMS45MzA2NiA3IDEuOTMwNjZDNi43OTM3NSAxLjkzMDY2IDYuNjI1IDIuMDk5NDEgNi42MjUgMi4zMDU2NlY0LjE4MDY2SDQuNzVDNC41NDM3NSA0LjE4MDY2IDQuMzc1IDQuMzQ5NDEgNC4zNzUgNC41NTU2NkM0LjM3NSA0Ljc2MTkxIDQuNTQzNzUgNC45MzA2NiA0Ljc1IDQuOTMwNjZaIiBmaWxsPSIjNjE2MTYxIiBzdHJva2U9IiM2MTYxNjEiIHN0cm9rZS13aWR0aD0iMC43Ii8+CjwvZz4KPHBhdGggY2xhc3M9ImpwLWljb24zIiBmaWxsLXJ1bGU9ImV2ZW5vZGQiIGNsaXAtcnVsZT0iZXZlbm9kZCIgZD0iTTExLjUgOS41VjExLjVMMi41IDExLjVWOS41TDExLjUgOS41Wk0xMiA4QzEyLjU1MjMgOCAxMyA4LjQ0NzcyIDEzIDlWMTJDMTMgMTIuNTUyMyAxMi41NTIzIDEzIDEyIDEzTDIgMTNDMS40NDc3MiAxMyAxIDEyLjU1MjMgMSAxMlY5QzEgOC40NDc3MiAxLjQ0NzcxIDggMiA4TDEyIDhaIiBmaWxsPSIjNjE2MTYxIi8+CjxkZWZzPgo8Y2xpcFBhdGggaWQ9ImNsaXAwXzEzN18xOTQ5MiI+CjxyZWN0IGNsYXNzPSJqcC1pY29uMyIgd2lkdGg9IjYiIGhlaWdodD0iNiIgZmlsbD0id2hpdGUiIHRyYW5zZm9ybT0ibWF0cml4KC0xIDAgMCAxIDEwIDEuNTU1NjYpIi8+CjwvY2xpcFBhdGg+CjwvZGVmcz4KPC9zdmc+Cg==);
+  --jp-icon-add-below: url(data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTQiIGhlaWdodD0iMTQiIHZpZXdCb3g9IjAgMCAxNCAxNCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPGcgY2xpcC1wYXRoPSJ1cmwoI2NsaXAwXzEzN18xOTQ5OCkiPgo8cGF0aCBjbGFzcz0ianAtaWNvbjMiIGQ9Ik05LjI1IDEwLjA2OTNMNy4zNzUgMTAuMDY5M0w3LjM3NSA4LjE5NDM0QzcuMzc1IDcuOTg4MDkgNy4yMDYyNSA3LjgxOTM0IDcgNy44MTkzNEM2Ljc5Mzc1IDcuODE5MzQgNi42MjUgNy45ODgwOSA2LjYyNSA4LjE5NDM0TDYuNjI1IDEwLjA2OTNMNC43NSAxMC4wNjkzQzQuNTQzNzUgMTAuMDY5MyA0LjM3NSAxMC4yMzgxIDQuMzc1IDEwLjQ0NDNDNC4zNzUgMTAuNjUwNiA0LjU0Mzc1IDEwLjgxOTMgNC43NSAxMC44MTkzTDYuNjI1IDEwLjgxOTNMNi42MjUgMTIuNjk0M0M2LjYyNSAxMi45MDA2IDYuNzkzNzUgMTMuMDY5MyA3IDEzLjA2OTNDNy4yMDYyNSAxMy4wNjkzIDcuMzc1IDEyLjkwMDYgNy4zNzUgMTIuNjk0M0w3LjM3NSAxMC44MTkzTDkuMjUgMTAuODE5M0M5LjQ1NjI1IDEwLjgxOTMgOS42MjUgMTAuNjUwNiA5LjYyNSAxMC40NDQzQzkuNjI1IDEwLjIzODEgOS40NTYyNSAxMC4wNjkzIDkuMjUgMTAuMDY5M1oiIGZpbGw9IiM2MTYxNjEiIHN0cm9rZT0iIzYxNjE2MSIgc3Ryb2tlLXdpZHRoPSIwLjciLz4KPC9nPgo8cGF0aCBjbGFzcz0ianAtaWNvbjMiIGZpbGwtcnVsZT0iZXZlbm9kZCIgY2xpcC1ydWxlPSJldmVub2RkIiBkPSJNMi41IDUuNUwyLjUgMy41TDExLjUgMy41TDExLjUgNS41TDIuNSA1LjVaTTIgN0MxLjQ0NzcyIDcgMSA2LjU1MjI4IDEgNkwxIDNDMSAyLjQ0NzcyIDEuNDQ3NzIgMiAyIDJMMTIgMkMxMi41NTIzIDIgMTMgMi40NDc3MiAxMyAzTDEzIDZDMTMgNi41NTIyOSAxMi41NTIzIDcgMTIgN0wyIDdaIiBmaWxsPSIjNjE2MTYxIi8+CjxkZWZzPgo8Y2xpcFBhdGggaWQ9ImNsaXAwXzEzN18xOTQ5OCI+CjxyZWN0IGNsYXNzPSJqcC1pY29uMyIgd2lkdGg9IjYiIGhlaWdodD0iNiIgZmlsbD0id2hpdGUiIHRyYW5zZm9ybT0ibWF0cml4KDEgMS43NDg0NmUtMDcgMS43NDg0NmUtMDcgLTEgNCAxMy40NDQzKSIvPgo8L2NsaXBQYXRoPgo8L2RlZnM+Cjwvc3ZnPgo=);
   --jp-icon-add: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgdmlld0JveD0iMCAwIDI0IDI0Ij4KICA8ZyBjbGFzcz0ianAtaWNvbjMiIGZpbGw9IiM2MTYxNjEiPgogICAgPHBhdGggZD0iTTE5IDEzaC02djZoLTJ2LTZINXYtMmg2VjVoMnY2aDZ2MnoiLz4KICA8L2c+Cjwvc3ZnPgo=);
+  --jp-icon-bell: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgdmlld0JveD0iMCAwIDE2IDE2IiB2ZXJzaW9uPSIxLjEiPgogICA8cGF0aCBjbGFzcz0ianAtaWNvbjIganAtaWNvbi1zZWxlY3RhYmxlIiBmaWxsPSIjMzMzMzMzIgogICAgICBkPSJtOCAwLjI5Yy0xLjQgMC0yLjcgMC43My0zLjYgMS44LTEuMiAxLjUtMS40IDMuNC0xLjUgNS4yLTAuMTggMi4yLTAuNDQgNC0yLjMgNS4zbDAuMjggMS4zaDVjMC4wMjYgMC42NiAwLjMyIDEuMSAwLjcxIDEuNSAwLjg0IDAuNjEgMiAwLjYxIDIuOCAwIDAuNTItMC40IDAuNi0xIDAuNzEtMS41aDVsMC4yOC0xLjNjLTEuOS0wLjk3LTIuMi0zLjMtMi4zLTUuMy0wLjEzLTEuOC0wLjI2LTMuNy0xLjUtNS4yLTAuODUtMS0yLjItMS44LTMuNi0xLjh6bTAgMS40YzAuODggMCAxLjkgMC41NSAyLjUgMS4zIDAuODggMS4xIDEuMSAyLjcgMS4yIDQuNCAwLjEzIDEuNyAwLjIzIDMuNiAxLjMgNS4yaC0xMGMxLjEtMS42IDEuMi0zLjQgMS4zLTUuMiAwLjEzLTEuNyAwLjMtMy4zIDEuMi00LjQgMC41OS0wLjcyIDEuNi0xLjMgMi41LTEuM3ptLTAuNzQgMTJoMS41Yy0wLjAwMTUgMC4yOCAwLjAxNSAwLjc5LTAuNzQgMC43OS0wLjczIDAuMDAxNi0wLjcyLTAuNTMtMC43NC0wLjc5eiIgLz4KPC9zdmc+Cg==);
+  --jp-icon-bug-dot: url(data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjQiIGhlaWdodD0iMjQiIHZpZXdCb3g9IjAgMCAyNCAyNCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KICAgIDxnIGNsYXNzPSJqcC1pY29uMyBqcC1pY29uLXNlbGVjdGFibGUiIGZpbGw9IiM2MTYxNjEiPgogICAgICAgIDxwYXRoIGZpbGwtcnVsZT0iZXZlbm9kZCIgY2xpcC1ydWxlPSJldmVub2RkIiBkPSJNMTcuMTkgOEgyMFYxMEgxNy45MUMxNy45NiAxMC4zMyAxOCAxMC42NiAxOCAxMVYxMkgyMFYxNEgxOC41SDE4VjE0LjAyNzVDMTUuNzUgMTQuMjc2MiAxNCAxNi4xODM3IDE0IDE4LjVDMTQgMTkuMjA4IDE0LjE2MzUgMTkuODc3OSAxNC40NTQ5IDIwLjQ3MzlDMTMuNzA2MyAyMC44MTE3IDEyLjg3NTcgMjEgMTIgMjFDOS43OCAyMSA3Ljg1IDE5Ljc5IDYuODEgMThINFYxNkg2LjA5QzYuMDQgMTUuNjcgNiAxNS4zNCA2IDE1VjE0SDRWMTJINlYxMUM2IDEwLjY2IDYuMDQgMTAuMzMgNi4wOSAxMEg0VjhINi44MUM3LjI2IDcuMjIgNy44OCA2LjU1IDguNjIgNi4wNEw3IDQuNDFMOC40MSAzTDEwLjU5IDUuMTdDMTEuMDQgNS4wNiAxMS41MSA1IDEyIDVDMTIuNDkgNSAxMi45NiA1LjA2IDEzLjQyIDUuMTdMMTUuNTkgM0wxNyA0LjQxTDE1LjM3IDYuMDRDMTYuMTIgNi41NSAxNi43NCA3LjIyIDE3LjE5IDhaTTEwIDE2SDE0VjE0SDEwVjE2Wk0xMCAxMkgxNFYxMEgxMFYxMloiIGZpbGw9IiM2MTYxNjEiLz4KICAgICAgICA8cGF0aCBkPSJNMjIgMTguNUMyMiAyMC40MzMgMjAuNDMzIDIyIDE4LjUgMjJDMTYuNTY3IDIyIDE1IDIwLjQzMyAxNSAxOC41QzE1IDE2LjU2NyAxNi41NjcgMTUgMTguNSAxNUMyMC40MzMgMTUgMjIgMTYuNTY3IDIyIDE4LjVaIiBmaWxsPSIjNjE2MTYxIi8+CiAgICA8L2c+Cjwvc3ZnPgo=);
   --jp-icon-bug: url(data:image/svg+xml;base64,PHN2ZyB2aWV3Qm94PSIwIDAgMjQgMjQiIHdpZHRoPSIxNiIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KICA8ZyBjbGFzcz0ianAtaWNvbjMganAtaWNvbi1zZWxlY3RhYmxlIiBmaWxsPSIjNjE2MTYxIj4KICAgIDxwYXRoIGQ9Ik0yMCA4aC0yLjgxYy0uNDUtLjc4LTEuMDctMS40NS0xLjgyLTEuOTZMMTcgNC40MSAxNS41OSAzbC0yLjE3IDIuMTdDMTIuOTYgNS4wNiAxMi40OSA1IDEyIDVjLS40OSAwLS45Ni4wNi0xLjQxLjE3TDguNDEgMyA3IDQuNDFsMS42MiAxLjYzQzcuODggNi41NSA3LjI2IDcuMjIgNi44MSA4SDR2MmgyLjA5Yy0uMDUuMzMtLjA5LjY2LS4wOSAxdjFINHYyaDJ2MWMwIC4zNC4wNC42Ny4wOSAxSDR2MmgyLjgxYzEuMDQgMS43OSAyLjk3IDMgNS4xOSAzczQuMTUtMS4yMSA1LjE5LTNIMjB2LTJoLTIuMDljLjA1LS4zMy4wOS0uNjYuMDktMXYtMWgydi0yaC0ydi0xYzAtLjM0LS4wNC0uNjctLjA5LTFIMjBWOHptLTYgOGgtNHYtMmg0djJ6bTAtNGgtNHYtMmg0djJ6Ii8+CiAgPC9nPgo8L3N2Zz4K);
   --jp-icon-build: url(data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTYiIHZpZXdCb3g9IjAgMCAyNCAyNCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KICA8ZyBjbGFzcz0ianAtaWNvbjMiIGZpbGw9IiM2MTYxNjEiPgogICAgPHBhdGggZD0iTTE0LjkgMTcuNDVDMTYuMjUgMTcuNDUgMTcuMzUgMTYuMzUgMTcuMzUgMTVDMTcuMzUgMTMuNjUgMTYuMjUgMTIuNTUgMTQuOSAxMi41NUMxMy41NCAxMi41NSAxMi40NSAxMy42NSAxMi40NSAxNUMxMi40NSAxNi4zNSAxMy41NCAxNy40NSAxNC45IDE3LjQ1Wk0yMC4xIDE1LjY4TDIxLjU4IDE2Ljg0QzIxLjcxIDE2Ljk1IDIxLjc1IDE3LjEzIDIxLjY2IDE3LjI5TDIwLjI2IDE5LjcxQzIwLjE3IDE5Ljg2IDIwIDE5LjkyIDE5LjgzIDE5Ljg2TDE4LjA5IDE5LjE2QzE3LjczIDE5LjQ0IDE3LjMzIDE5LjY3IDE2LjkxIDE5Ljg1TDE2LjY0IDIxLjdDMTYuNjIgMjEuODcgMTYuNDcgMjIgMTYuMyAyMkgxMy41QzEzLjMyIDIyIDEzLjE4IDIxLjg3IDEzLjE1IDIxLjdMMTIuODkgMTkuODVDMTIuNDYgMTkuNjcgMTIuMDcgMTkuNDQgMTEuNzEgMTkuMTZMOS45NjAwMiAxOS44NkM5LjgxMDAyIDE5LjkyIDkuNjIwMDIgMTkuODYgOS41NDAwMiAxOS43MUw4LjE0MDAyIDE3LjI5QzguMDUwMDIgMTcuMTMgOC4wOTAwMiAxNi45NSA4LjIyMDAyIDE2Ljg0TDkuNzAwMDIgMTUuNjhMOS42NTAwMSAxNUw5LjcwMDAyIDE0LjMxTDguMjIwMDIgMTMuMTZDOC4wOTAwMiAxMy4wNSA4LjA1MDAyIDEyLjg2IDguMTQwMDIgMTIuNzFMOS41NDAwMiAxMC4yOUM5LjYyMDAyIDEwLjEzIDkuODEwMDIgMTAuMDcgOS45NjAwMiAxMC4xM0wxMS43MSAxMC44NEMxMi4wNyAxMC41NiAxMi40NiAxMC4zMiAxMi44OSAxMC4xNUwxMy4xNSA4LjI4OTk4QzEzLjE4IDguMTI5OTggMTMuMzIgNy45OTk5OCAxMy41IDcuOTk5OThIMTYuM0MxNi40NyA3Ljk5OTk4IDE2LjYyIDguMTI5OTggMTYuNjQgOC4yODk5OEwxNi45MSAxMC4xNUMxNy4zMyAxMC4zMiAxNy43MyAxMC41NiAxOC4wOSAxMC44NEwxOS44MyAxMC4xM0MyMCAxMC4wNyAyMC4xNyAxMC4xMyAyMC4yNiAxMC4yOUwyMS42NiAxMi43MUMyMS43NSAxMi44NiAyMS43MSAxMy4wNSAyMS41OCAxMy4xNkwyMC4xIDE0LjMxTDIwLjE1IDE1TDIwLjEgMTUuNjhaIi8+CiAgICA8cGF0aCBkPSJNNy4zMjk2NiA3LjQ0NDU0QzguMDgzMSA3LjAwOTU0IDguMzM5MzIgNi4wNTMzMiA3LjkwNDMyIDUuMjk5ODhDNy40NjkzMiA0LjU0NjQzIDYuNTA4MSA0LjI4MTU2IDUuNzU0NjYgNC43MTY1NkM1LjM5MTc2IDQuOTI2MDggNS4xMjY5NSA1LjI3MTE4IDUuMDE4NDkgNS42NzU5NEM0LjkxMDA0IDYuMDgwNzEgNC45NjY4MiA2LjUxMTk4IDUuMTc2MzQgNi44NzQ4OEM1LjYxMTM0IDcuNjI4MzIgNi41NzYyMiA3Ljg3OTU0IDcuMzI5NjYgNy40NDQ1NFpNOS42NTcxOCA0Ljc5NTkzTDEwLjg2NzIgNC45NTE3OUMxMC45NjI4IDQuOTc3NDEgMTEuMDQwMiA1LjA3MTMzIDExLjAzODIgNS4xODc5M0wxMS4wMzg4IDYuOTg4OTNDMTEuMDQ1NSA3LjEwMDU0IDEwLjk2MTYgNy4xOTUxOCAxMC44NTUgNy4yMTA1NEw5LjY2MDAxIDcuMzgwODNMOS4yMzkxNSA4LjEzMTg4TDkuNjY5NjEgOS4yNTc0NUM5LjcwNzI5IDkuMzYyNzEgOS42NjkzNCA5LjQ3Njk5IDkuNTc0MDggOS41MzE5OUw4LjAxNTIzIDEwLjQzMkM3LjkxMTMxIDEwLjQ5MiA3Ljc5MzM3IDEwLjQ2NzcgNy43MjEwNSAxMC4zODI0TDYuOTg3NDggOS40MzE4OEw2LjEwOTMxIDkuNDMwODNMNS4zNDcwNCAxMC4zOTA1QzUuMjg5MDkgMTAuNDcwMiA1LjE3MzgzIDEwLjQ5MDUgNS4wNzE4NyAxMC40MzM5TDMuNTEyNDUgOS41MzI5M0MzLjQxMDQ5IDkuNDc2MzMgMy4zNzY0NyA5LjM1NzQxIDMuNDEwNzUgOS4yNTY3OUwzLjg2MzQ3IDguMTQwOTNMMy42MTc0OSA3Ljc3NDg4TDMuNDIzNDcgNy4zNzg4M0wyLjIzMDc1IDcuMjEyOTdDMi4xMjY0NyA3LjE5MjM1IDIuMDQwNDkgNy4xMDM0MiAyLjA0MjQ1IDYuOTg2ODJMMi4wNDE4NyA1LjE4NTgyQzIuMDQzODMgNS4wNjkyMiAyLjExOTA5IDQuOTc5NTggMi4yMTcwNCA0Ljk2OTIyTDMuNDIwNjUgNC43OTM5M0wzLjg2NzQ5IDQuMDI3ODhMMy40MTEwNSAyLjkxNzMxQzMuMzczMzcgMi44MTIwNCAzLjQxMTMxIDIuNjk3NzYgMy41MTUyMyAyLjYzNzc2TDUuMDc0MDggMS43Mzc3NkM1LjE2OTM0IDEuNjgyNzYgNS4yODcyOSAxLjcwNzA0IDUuMzU5NjEgMS43OTIzMUw2LjExOTE1IDIuNzI3ODhMNi45ODAwMSAyLjczODkzTDcuNzI0OTYgMS43ODkyMkM3Ljc5MTU2IDEuNzA0NTggNy45MTU0OCAxLjY3OTIyIDguMDA4NzkgMS43NDA4Mkw5LjU2ODIxIDIuNjQxODJDOS42NzAxNyAyLjY5ODQyIDkuNzEyODUgMi44MTIzNCA5LjY4NzIzIDIuOTA3OTdMOS4yMTcxOCA0LjAzMzgzTDkuNDYzMTYgNC4zOTk4OEw5LjY1NzE4IDQuNzk1OTNaIi8+CiAgPC9nPgo8L3N2Zz4K);
   --jp-icon-caret-down-empty-thin: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgdmlld0JveD0iMCAwIDIwIDIwIj4KCTxnIGNsYXNzPSJqcC1pY29uMyIgZmlsbD0iIzYxNjE2MSIgc2hhcGUtcmVuZGVyaW5nPSJnZW9tZXRyaWNQcmVjaXNpb24iPgoJCTxwb2x5Z29uIGNsYXNzPSJzdDEiIHBvaW50cz0iOS45LDEzLjYgMy42LDcuNCA0LjQsNi42IDkuOSwxMi4yIDE1LjQsNi43IDE2LjEsNy40ICIvPgoJPC9nPgo8L3N2Zz4K);
@@ -9381,11 +9372,13 @@ span.bp3-popover-target{
   --jp-icon-clear: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgdmlld0JveD0iMCAwIDI0IDI0Ij4KICA8bWFzayBpZD0iZG9udXRIb2xlIj4KICAgIDxyZWN0IHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgZmlsbD0id2hpdGUiIC8+CiAgICA8Y2lyY2xlIGN4PSIxMiIgY3k9IjEyIiByPSI4IiBmaWxsPSJibGFjayIvPgogIDwvbWFzaz4KCiAgPGcgY2xhc3M9ImpwLWljb24zIiBmaWxsPSIjNjE2MTYxIj4KICAgIDxyZWN0IGhlaWdodD0iMTgiIHdpZHRoPSIyIiB4PSIxMSIgeT0iMyIgdHJhbnNmb3JtPSJyb3RhdGUoMzE1LCAxMiwgMTIpIi8+CiAgICA8Y2lyY2xlIGN4PSIxMiIgY3k9IjEyIiByPSIxMCIgbWFzaz0idXJsKCNkb251dEhvbGUpIi8+CiAgPC9nPgo8L3N2Zz4K);
   --jp-icon-close: url(data:image/svg+xml;base64,PHN2ZyB2aWV3Qm94PSIwIDAgMjQgMjQiIHdpZHRoPSIxNiIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KICA8ZyBjbGFzcz0ianAtaWNvbi1ub25lIGpwLWljb24tc2VsZWN0YWJsZS1pbnZlcnNlIGpwLWljb24zLWhvdmVyIiBmaWxsPSJub25lIj4KICAgIDxjaXJjbGUgY3g9IjEyIiBjeT0iMTIiIHI9IjExIi8+CiAgPC9nPgoKICA8ZyBjbGFzcz0ianAtaWNvbjMganAtaWNvbi1zZWxlY3RhYmxlIGpwLWljb24tYWNjZW50Mi1ob3ZlciIgZmlsbD0iIzYxNjE2MSI+CiAgICA8cGF0aCBkPSJNMTkgNi40MUwxNy41OSA1IDEyIDEwLjU5IDYuNDEgNSA1IDYuNDEgMTAuNTkgMTIgNSAxNy41OSA2LjQxIDE5IDEyIDEzLjQxIDE3LjU5IDE5IDE5IDE3LjU5IDEzLjQxIDEyeiIvPgogIDwvZz4KCiAgPGcgY2xhc3M9ImpwLWljb24tbm9uZSBqcC1pY29uLWJ1c3kiIGZpbGw9Im5vbmUiPgogICAgPGNpcmNsZSBjeD0iMTIiIGN5PSIxMiIgcj0iNyIvPgogIDwvZz4KPC9zdmc+Cg==);
   --jp-icon-code: url(data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjIiIGhlaWdodD0iMjIiIHZpZXdCb3g9IjAgMCAyOCAyOCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KCTxnIGNsYXNzPSJqcC1pY29uMyIgZmlsbD0iIzYxNjE2MSI+CgkJPHBhdGggZD0iTTExLjQgMTguNkw2LjggMTRMMTEuNCA5LjRMMTAgOEw0IDE0TDEwIDIwTDExLjQgMTguNlpNMTYuNiAxOC42TDIxLjIgMTRMMTYuNiA5LjRMMTggOEwyNCAxNEwxOCAyMEwxNi42IDE4LjZWMTguNloiLz4KCTwvZz4KPC9zdmc+Cg==);
-  --jp-icon-console: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgdmlld0JveD0iMCAwIDIwMCAyMDAiPgogIDxnIGNsYXNzPSJqcC1pY29uLWJyYW5kMSBqcC1pY29uLXNlbGVjdGFibGUiIGZpbGw9IiMwMjg4RDEiPgogICAgPHBhdGggZD0iTTIwIDE5LjhoMTYwdjE1OS45SDIweiIvPgogIDwvZz4KICA8ZyBjbGFzcz0ianAtaWNvbi1zZWxlY3RhYmxlLWludmVyc2UiIGZpbGw9IiNmZmYiPgogICAgPHBhdGggZD0iTTEwNSAxMjcuM2g0MHYxMi44aC00MHpNNTEuMSA3N0w3NCA5OS45bC0yMy4zIDIzLjMgMTAuNSAxMC41IDIzLjMtMjMuM0w5NSA5OS45IDg0LjUgODkuNCA2MS42IDY2LjV6Ii8+CiAgPC9nPgo8L3N2Zz4K);
+  --jp-icon-console: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgdmlld0JveD0iMCAwIDIwMCAyMDAiPgogIDxnIGNsYXNzPSJqcC1jb25zb2xlLWljb24tYmFja2dyb3VuZC1jb2xvciBqcC1pY29uLXNlbGVjdGFibGUiIGZpbGw9IiMwMjg4RDEiPgogICAgPHBhdGggZD0iTTIwIDE5LjhoMTYwdjE1OS45SDIweiIvPgogIDwvZz4KICA8ZyBjbGFzcz0ianAtY29uc29sZS1pY29uLWNvbG9yIGpwLWljb24tc2VsZWN0YWJsZS1pbnZlcnNlIiBmaWxsPSIjZmZmIj4KICAgIDxwYXRoIGQ9Ik0xMDUgMTI3LjNoNDB2MTIuOGgtNDB6TTUxLjEgNzdMNzQgOTkuOWwtMjMuMyAyMy4zIDEwLjUgMTAuNSAyMy4zLTIzLjNMOTUgOTkuOSA4NC41IDg5LjQgNjEuNiA2Ni41eiIvPgogIDwvZz4KPC9zdmc+Cg==);
   --jp-icon-copy: url(data:image/svg+xml;base64,PHN2ZyB2aWV3Qm94PSIwIDAgMTggMTgiIHdpZHRoPSIxNiIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KICA8ZyBjbGFzcz0ianAtaWNvbjMiIGZpbGw9IiM2MTYxNjEiPgogICAgPHBhdGggZD0iTTExLjksMUgzLjJDMi40LDEsMS43LDEuNywxLjcsMi41djEwLjJoMS41VjIuNWg4LjdWMXogTTE0LjEsMy45aC04Yy0wLjgsMC0xLjUsMC43LTEuNSwxLjV2MTAuMmMwLDAuOCwwLjcsMS41LDEuNSwxLjVoOCBjMC44LDAsMS41LTAuNywxLjUtMS41VjUuNEMxNS41LDQuNiwxNC45LDMuOSwxNC4xLDMuOXogTTE0LjEsMTUuNWgtOFY1LjRoOFYxNS41eiIvPgogIDwvZz4KPC9zdmc+Cg==);
   --jp-icon-copyright: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGVuYWJsZS1iYWNrZ3JvdW5kPSJuZXcgMCAwIDI0IDI0IiBoZWlnaHQ9IjI0IiB2aWV3Qm94PSIwIDAgMjQgMjQiIHdpZHRoPSIyNCI+CiAgPGcgY2xhc3M9ImpwLWljb24zIiBmaWxsPSIjNjE2MTYxIj4KICAgIDxwYXRoIGQ9Ik0xMS44OCw5LjE0YzEuMjgsMC4wNiwxLjYxLDEuMTUsMS42MywxLjY2aDEuNzljLTAuMDgtMS45OC0xLjQ5LTMuMTktMy40NS0zLjE5QzkuNjQsNy42MSw4LDksOCwxMi4xNCBjMCwxLjk0LDAuOTMsNC4yNCwzLjg0LDQuMjRjMi4yMiwwLDMuNDEtMS42NSwzLjQ0LTIuOTVoLTEuNzljLTAuMDMsMC41OS0wLjQ1LDEuMzgtMS42MywxLjQ0QzEwLjU1LDE0LjgzLDEwLDEzLjgxLDEwLDEyLjE0IEMxMCw5LjI1LDExLjI4LDkuMTYsMTEuODgsOS4xNHogTTEyLDJDNi40OCwyLDIsNi40OCwyLDEyczQuNDgsMTAsMTAsMTBzMTAtNC40OCwxMC0xMFMxNy41MiwyLDEyLDJ6IE0xMiwyMGMtNC40MSwwLTgtMy41OS04LTggczMuNTktOCw4LThzOCwzLjU5LDgsOFMxNi40MSwyMCwxMiwyMHoiLz4KICA8L2c+Cjwvc3ZnPgo=);
   --jp-icon-cut: url(data:image/svg+xml;base64,PHN2ZyB2aWV3Qm94PSIwIDAgMjQgMjQiIHdpZHRoPSIxNiIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KICA8ZyBjbGFzcz0ianAtaWNvbjMiIGZpbGw9IiM2MTYxNjEiPgogICAgPHBhdGggZD0iTTkuNjQgNy42NGMuMjMtLjUuMzYtMS4wNS4zNi0xLjY0IDAtMi4yMS0xLjc5LTQtNC00UzIgMy43OSAyIDZzMS43OSA0IDQgNGMuNTkgMCAxLjE0LS4xMyAxLjY0LS4zNkwxMCAxMmwtMi4zNiAyLjM2QzcuMTQgMTQuMTMgNi41OSAxNCA2IDE0Yy0yLjIxIDAtNCAxLjc5LTQgNHMxLjc5IDQgNCA0IDQtMS43OSA0LTRjMC0uNTktLjEzLTEuMTQtLjM2LTEuNjRMMTIgMTRsNyA3aDN2LTFMOS42NCA3LjY0ek02IDhjLTEuMSAwLTItLjg5LTItMnMuOS0yIDItMiAyIC44OSAyIDItLjkgMi0yIDJ6bTAgMTJjLTEuMSAwLTItLjg5LTItMnMuOS0yIDItMiAyIC44OSAyIDItLjkgMi0yIDJ6bTYtNy41Yy0uMjggMC0uNS0uMjItLjUtLjVzLjIyLS41LjUtLjUuNS4yMi41LjUtLjIyLjUtLjUuNXpNMTkgM2wtNiA2IDIgMiA3LTdWM3oiLz4KICA8L2c+Cjwvc3ZnPgo=);
+  --jp-icon-delete: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCIgd2lkdGg9IjE2cHgiIGhlaWdodD0iMTZweCI+CiAgICA8cGF0aCBkPSJNMCAwaDI0djI0SDB6IiBmaWxsPSJub25lIiAvPgogICAgPHBhdGggY2xhc3M9ImpwLWljb24zIiBmaWxsPSIjNjI2MjYyIiBkPSJNNiAxOWMwIDEuMS45IDIgMiAyaDhjMS4xIDAgMi0uOSAyLTJWN0g2djEyek0xOSA0aC0zLjVsLTEtMWgtNWwtMSAxSDV2MmgxNFY0eiIgLz4KPC9zdmc+Cg==);
   --jp-icon-download: url(data:image/svg+xml;base64,PHN2ZyB2aWV3Qm94PSIwIDAgMjQgMjQiIHdpZHRoPSIxNiIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KICA8ZyBjbGFzcz0ianAtaWNvbjMiIGZpbGw9IiM2MTYxNjEiPgogICAgPHBhdGggZD0iTTE5IDloLTRWM0g5djZINWw3IDcgNy03ek01IDE4djJoMTR2LTJINXoiLz4KICA8L2c+Cjwvc3ZnPgo=);
+  --jp-icon-duplicate: url(data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTQiIGhlaWdodD0iMTQiIHZpZXdCb3g9IjAgMCAxNCAxNCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggY2xhc3M9ImpwLWljb24zIiBmaWxsLXJ1bGU9ImV2ZW5vZGQiIGNsaXAtcnVsZT0iZXZlbm9kZCIgZD0iTTIuNzk5OTggMC44NzVIOC44OTU4MkM5LjIwMDYxIDAuODc1IDkuNDQ5OTggMS4xMzkxNCA5LjQ0OTk4IDEuNDYxOThDOS40NDk5OCAxLjc4NDgyIDkuMjAwNjEgMi4wNDg5NiA4Ljg5NTgyIDIuMDQ4OTZIMy4zNTQxNUMzLjA0OTM2IDIuMDQ4OTYgMi43OTk5OCAyLjMxMzEgMi43OTk5OCAyLjYzNTk0VjkuNjc5NjlDMi43OTk5OCAxMC4wMDI1IDIuNTUwNjEgMTAuMjY2NyAyLjI0NTgyIDEwLjI2NjdDMS45NDEwMyAxMC4yNjY3IDEuNjkxNjUgMTAuMDAyNSAxLjY5MTY1IDkuNjc5NjlWMi4wNDg5NkMxLjY5MTY1IDEuNDAzMjggMi4xOTA0IDAuODc1IDIuNzk5OTggMC44NzVaTTUuMzY2NjUgMTEuOVY0LjU1SDExLjA4MzNWMTEuOUg1LjM2NjY1Wk00LjE0MTY1IDQuMTQxNjdDNC4xNDE2NSAzLjY5MDYzIDQuNTA3MjggMy4zMjUgNC45NTgzMiAzLjMyNUgxMS40OTE3QzExLjk0MjcgMy4zMjUgMTIuMzA4MyAzLjY5MDYzIDEyLjMwODMgNC4xNDE2N1YxMi4zMDgzQzEyLjMwODMgMTIuNzU5NCAxMS45NDI3IDEzLjEyNSAxMS40OTE3IDEzLjEyNUg0Ljk1ODMyQzQuNTA3MjggMTMuMTI1IDQuMTQxNjUgMTIuNzU5NCA0LjE0MTY1IDEyLjMwODNWNC4xNDE2N1oiIGZpbGw9IiM2MTYxNjEiLz4KPHBhdGggY2xhc3M9ImpwLWljb24zIiBkPSJNOS40MzU3NCA4LjI2NTA3SDguMzY0MzFWOS4zMzY1QzguMzY0MzEgOS40NTQzNSA4LjI2Nzg4IDkuNTUwNzggOC4xNTAwMiA5LjU1MDc4QzguMDMyMTcgOS41NTA3OCA3LjkzNTc0IDkuNDU0MzUgNy45MzU3NCA5LjMzNjVWOC4yNjUwN0g2Ljg2NDMxQzYuNzQ2NDUgOC4yNjUwNyA2LjY1MDAyIDguMTY4NjQgNi42NTAwMiA4LjA1MDc4QzYuNjUwMDIgNy45MzI5MiA2Ljc0NjQ1IDcuODM2NSA2Ljg2NDMxIDcuODM2NUg3LjkzNTc0VjYuNzY1MDdDNy45MzU3NCA2LjY0NzIxIDguMDMyMTcgNi41NTA3OCA4LjE1MDAyIDYuNTUwNzhDOC4yNjc4OCA2LjU1MDc4IDguMzY0MzEgNi42NDcyMSA4LjM2NDMxIDYuNzY1MDdWNy44MzY1SDkuNDM1NzRDOS41NTM2IDcuODM2NSA5LjY1MDAyIDcuOTMyOTIgOS42NTAwMiA4LjA1MDc4QzkuNjUwMDIgOC4xNjg2NCA5LjU1MzYgOC4yNjUwNyA5LjQzNTc0IDguMjY1MDdaIiBmaWxsPSIjNjE2MTYxIiBzdHJva2U9IiM2MTYxNjEiIHN0cm9rZS13aWR0aD0iMC41Ii8+Cjwvc3ZnPgo=);
   --jp-icon-edit: url(data:image/svg+xml;base64,PHN2ZyB2aWV3Qm94PSIwIDAgMjQgMjQiIHdpZHRoPSIxNiIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KICA8ZyBjbGFzcz0ianAtaWNvbjMiIGZpbGw9IiM2MTYxNjEiPgogICAgPHBhdGggZD0iTTMgMTcuMjVWMjFoMy43NUwxNy44MSA5Ljk0bC0zLjc1LTMuNzVMMyAxNy4yNXpNMjAuNzEgNy4wNGMuMzktLjM5LjM5LTEuMDIgMC0xLjQxbC0yLjM0LTIuMzRjLS4zOS0uMzktMS4wMi0uMzktMS40MSAwbC0xLjgzIDEuODMgMy43NSAzLjc1IDEuODMtMS44M3oiLz4KICA8L2c+Cjwvc3ZnPgo=);
   --jp-icon-ellipses: url(data:image/svg+xml;base64,PHN2ZyB2aWV3Qm94PSIwIDAgMjQgMjQiIHdpZHRoPSIxNiIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KICA8ZyBjbGFzcz0ianAtaWNvbjMiIGZpbGw9IiM2MTYxNjEiPgogICAgPGNpcmNsZSBjeD0iNSIgY3k9IjEyIiByPSIyIi8+CiAgICA8Y2lyY2xlIGN4PSIxMiIgY3k9IjEyIiByPSIyIi8+CiAgICA8Y2lyY2xlIGN4PSIxOSIgY3k9IjEyIiByPSIyIi8+CiAgPC9nPgo8L3N2Zz4K);
   --jp-icon-extension: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgdmlld0JveD0iMCAwIDI0IDI0Ij4KICA8ZyBjbGFzcz0ianAtaWNvbjMiIGZpbGw9IiM2MTYxNjEiPgogICAgPHBhdGggZD0iTTIwLjUgMTFIMTlWN2MwLTEuMS0uOS0yLTItMmgtNFYzLjVDMTMgMi4xMiAxMS44OCAxIDEwLjUgMVM4IDIuMTIgOCAzLjVWNUg0Yy0xLjEgMC0xLjk5LjktMS45OSAydjMuOEgzLjVjMS40OSAwIDIuNyAxLjIxIDIuNyAyLjdzLTEuMjEgMi43LTIuNyAyLjdIMlYyMGMwIDEuMS45IDIgMiAyaDMuOHYtMS41YzAtMS40OSAxLjIxLTIuNyAyLjctMi43IDEuNDkgMCAyLjcgMS4yMSAyLjcgMi43VjIySDE3YzEuMSAwIDItLjkgMi0ydi00aDEuNWMxLjM4IDAgMi41LTEuMTIgMi41LTIuNVMyMS44OCAxMSAyMC41IDExeiIvPgogIDwvZz4KPC9zdmc+Cg==);
@@ -9393,32 +9386,37 @@ span.bp3-popover-target{
   --jp-icon-file-upload: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgdmlld0JveD0iMCAwIDI0IDI0Ij4KICA8ZyBjbGFzcz0ianAtaWNvbjMiIGZpbGw9IiM2MTYxNjEiPgogICAgPHBhdGggZD0iTTkgMTZoNnYtNmg0bC03LTctNyA3aDR6bS00IDJoMTR2Mkg1eiIvPgogIDwvZz4KPC9zdmc+Cg==);
   --jp-icon-file: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgdmlld0JveD0iMCAwIDIyIDIyIj4KICA8cGF0aCBjbGFzcz0ianAtaWNvbjMganAtaWNvbi1zZWxlY3RhYmxlIiBmaWxsPSIjNjE2MTYxIiBkPSJNMTkuMyA4LjJsLTUuNS01LjVjLS4zLS4zLS43LS41LTEuMi0uNUgzLjljLS44LjEtMS42LjktMS42IDEuOHYxNC4xYzAgLjkuNyAxLjYgMS42IDEuNmgxNC4yYy45IDAgMS42LS43IDEuNi0xLjZWOS40Yy4xLS41LS4xLS45LS40LTEuMnptLTUuOC0zLjNsMy40IDMuNmgtMy40VjQuOXptMy45IDEyLjdINC43Yy0uMSAwLS4yIDAtLjItLjJWNC43YzAtLjIuMS0uMy4yLS4zaDcuMnY0LjRzMCAuOC4zIDEuMWMuMy4zIDEuMS4zIDEuMS4zaDQuM3Y3LjJzLS4xLjItLjIuMnoiLz4KPC9zdmc+Cg==);
   --jp-icon-filter-list: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgdmlld0JveD0iMCAwIDI0IDI0Ij4KICA8ZyBjbGFzcz0ianAtaWNvbjMiIGZpbGw9IiM2MTYxNjEiPgogICAgPHBhdGggZD0iTTEwIDE4aDR2LTJoLTR2MnpNMyA2djJoMThWNkgzem0zIDdoMTJ2LTJINnYyeiIvPgogIDwvZz4KPC9zdmc+Cg==);
+  --jp-icon-folder-favorite: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGhlaWdodD0iMjRweCIgdmlld0JveD0iMCAwIDI0IDI0IiB3aWR0aD0iMjRweCIgZmlsbD0iIzAwMDAwMCI+CiAgPHBhdGggZD0iTTAgMGgyNHYyNEgwVjB6IiBmaWxsPSJub25lIi8+PHBhdGggY2xhc3M9ImpwLWljb24zIGpwLWljb24tc2VsZWN0YWJsZSIgZmlsbD0iIzYxNjE2MSIgZD0iTTIwIDZoLThsLTItMkg0Yy0xLjEgMC0yIC45LTIgMnYxMmMwIDEuMS45IDIgMiAyaDE2YzEuMSAwIDItLjkgMi0yVjhjMC0xLjEtLjktMi0yLTJ6bS0yLjA2IDExTDE1IDE1LjI4IDEyLjA2IDE3bC43OC0zLjMzLTIuNTktMi4yNCAzLjQxLS4yOUwxNSA4bDEuMzQgMy4xNCAzLjQxLjI5LTIuNTkgMi4yNC43OCAzLjMzeiIvPgo8L3N2Zz4K);
   --jp-icon-folder: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgdmlld0JveD0iMCAwIDI0IDI0Ij4KICA8cGF0aCBjbGFzcz0ianAtaWNvbjMganAtaWNvbi1zZWxlY3RhYmxlIiBmaWxsPSIjNjE2MTYxIiBkPSJNMTAgNEg0Yy0xLjEgMC0xLjk5LjktMS45OSAyTDIgMThjMCAxLjEuOSAyIDIgMmgxNmMxLjEgMCAyLS45IDItMlY4YzAtMS4xLS45LTItMi0yaC04bC0yLTJ6Ii8+Cjwvc3ZnPgo=);
+  --jp-icon-home: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGhlaWdodD0iMjRweCIgdmlld0JveD0iMCAwIDI0IDI0IiB3aWR0aD0iMjRweCIgZmlsbD0iIzAwMDAwMCI+CiAgPHBhdGggZD0iTTAgMGgyNHYyNEgweiIgZmlsbD0ibm9uZSIvPjxwYXRoIGNsYXNzPSJqcC1pY29uMyBqcC1pY29uLXNlbGVjdGFibGUiIGZpbGw9IiM2MTYxNjEiIGQ9Ik0xMCAyMHYtNmg0djZoNXYtOGgzTDEyIDMgMiAxMmgzdjh6Ii8+Cjwvc3ZnPgo=);
   --jp-icon-html5: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgdmlld0JveD0iMCAwIDUxMiA1MTIiPgogIDxwYXRoIGNsYXNzPSJqcC1pY29uMCBqcC1pY29uLXNlbGVjdGFibGUiIGZpbGw9IiMwMDAiIGQ9Ik0xMDguNCAwaDIzdjIyLjhoMjEuMlYwaDIzdjY5aC0yM1Y0NmgtMjF2MjNoLTIzLjJNMjA2IDIzaC0yMC4zVjBoNjMuN3YyM0gyMjl2NDZoLTIzbTUzLjUtNjloMjQuMWwxNC44IDI0LjNMMzEzLjIgMGgyNC4xdjY5aC0yM1YzNC44bC0xNi4xIDI0LjgtMTYuMS0yNC44VjY5aC0yMi42bTg5LjItNjloMjN2NDYuMmgzMi42VjY5aC01NS42Ii8+CiAgPHBhdGggY2xhc3M9ImpwLWljb24tc2VsZWN0YWJsZSIgZmlsbD0iI2U0NGQyNiIgZD0iTTEwNy42IDQ3MWwtMzMtMzcwLjRoMzYyLjhsLTMzIDM3MC4yTDI1NS43IDUxMiIvPgogIDxwYXRoIGNsYXNzPSJqcC1pY29uLXNlbGVjdGFibGUiIGZpbGw9IiNmMTY1MjkiIGQ9Ik0yNTYgNDgwLjVWMTMxaDE0OC4zTDM3NiA0NDciLz4KICA8cGF0aCBjbGFzcz0ianAtaWNvbi1zZWxlY3RhYmxlLWludmVyc2UiIGZpbGw9IiNlYmViZWIiIGQ9Ik0xNDIgMTc2LjNoMTE0djQ1LjRoLTY0LjJsNC4yIDQ2LjVoNjB2NDUuM0gxNTQuNG0yIDIyLjhIMjAybDMuMiAzNi4zIDUwLjggMTMuNnY0Ny40bC05My4yLTI2Ii8+CiAgPHBhdGggY2xhc3M9ImpwLWljb24tc2VsZWN0YWJsZS1pbnZlcnNlIiBmaWxsPSIjZmZmIiBkPSJNMzY5LjYgMTc2LjNIMjU1Ljh2NDUuNGgxMDkuNm0tNC4xIDQ2LjVIMjU1Ljh2NDUuNGg1NmwtNS4zIDU5LTUwLjcgMTMuNnY0Ny4ybDkzLTI1LjgiLz4KPC9zdmc+Cg==);
   --jp-icon-image: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgdmlld0JveD0iMCAwIDIyIDIyIj4KICA8cGF0aCBjbGFzcz0ianAtaWNvbi1icmFuZDQganAtaWNvbi1zZWxlY3RhYmxlLWludmVyc2UiIGZpbGw9IiNGRkYiIGQ9Ik0yLjIgMi4yaDE3LjV2MTcuNUgyLjJ6Ii8+CiAgPHBhdGggY2xhc3M9ImpwLWljb24tYnJhbmQwIGpwLWljb24tc2VsZWN0YWJsZSIgZmlsbD0iIzNGNTFCNSIgZD0iTTIuMiAyLjJ2MTcuNWgxNy41bC4xLTE3LjVIMi4yem0xMi4xIDIuMmMxLjIgMCAyLjIgMSAyLjIgMi4ycy0xIDIuMi0yLjIgMi4yLTIuMi0xLTIuMi0yLjIgMS0yLjIgMi4yLTIuMnpNNC40IDE3LjZsMy4zLTguOCAzLjMgNi42IDIuMi0zLjIgNC40IDUuNEg0LjR6Ii8+Cjwvc3ZnPgo=);
-  --jp-icon-inspector: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgdmlld0JveD0iMCAwIDI0IDI0Ij4KICA8cGF0aCBjbGFzcz0ianAtaWNvbjMganAtaWNvbi1zZWxlY3RhYmxlIiBmaWxsPSIjNjE2MTYxIiBkPSJNMjAgNEg0Yy0xLjEgMC0xLjk5LjktMS45OSAyTDIgMThjMCAxLjEuOSAyIDIgMmgxNmMxLjEgMCAyLS45IDItMlY2YzAtMS4xLS45LTItMi0yem0tNSAxNEg0di00aDExdjR6bTAtNUg0VjloMTF2NHptNSA1aC00VjloNHY5eiIvPgo8L3N2Zz4K);
-  --jp-icon-json: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgdmlld0JveD0iMCAwIDIyIDIyIj4KICA8ZyBjbGFzcz0ianAtaWNvbi13YXJuMSBqcC1pY29uLXNlbGVjdGFibGUiIGZpbGw9IiNGOUE4MjUiPgogICAgPHBhdGggZD0iTTIwLjIgMTEuOGMtMS42IDAtMS43LjUtMS43IDEgMCAuNC4xLjkuMSAxLjMuMS41LjEuOS4xIDEuMyAwIDEuNy0xLjQgMi4zLTMuNSAyLjNoLS45di0xLjloLjVjMS4xIDAgMS40IDAgMS40LS44IDAtLjMgMC0uNi0uMS0xIDAtLjQtLjEtLjgtLjEtMS4yIDAtMS4zIDAtMS44IDEuMy0yLTEuMy0uMi0xLjMtLjctMS4zLTIgMC0uNC4xLS44LjEtMS4yLjEtLjQuMS0uNy4xLTEgMC0uOC0uNC0uNy0xLjQtLjhoLS41VjQuMWguOWMyLjIgMCAzLjUuNyAzLjUgMi4zIDAgLjQtLjEuOS0uMSAxLjMtLjEuNS0uMS45LS4xIDEuMyAwIC41LjIgMSAxLjcgMXYxLjh6TTEuOCAxMC4xYzEuNiAwIDEuNy0uNSAxLjctMSAwLS40LS4xLS45LS4xLTEuMy0uMS0uNS0uMS0uOS0uMS0xLjMgMC0xLjYgMS40LTIuMyAzLjUtMi4zaC45djEuOWgtLjVjLTEgMC0xLjQgMC0xLjQuOCAwIC4zIDAgLjYuMSAxIDAgLjIuMS42LjEgMSAwIDEuMyAwIDEuOC0xLjMgMkM2IDExLjIgNiAxMS43IDYgMTNjMCAuNC0uMS44LS4xIDEuMi0uMS4zLS4xLjctLjEgMSAwIC44LjMuOCAxLjQuOGguNXYxLjloLS45Yy0yLjEgMC0zLjUtLjYtMy41LTIuMyAwLS40LjEtLjkuMS0xLjMuMS0uNS4xLS45LjEtMS4zIDAtLjUtLjItMS0xLjctMXYtMS45eiIvPgogICAgPGNpcmNsZSBjeD0iMTEiIGN5PSIxMy44IiByPSIyLjEiLz4KICAgIDxjaXJjbGUgY3g9IjExIiBjeT0iOC4yIiByPSIyLjEiLz4KICA8L2c+Cjwvc3ZnPgo=);
+  --jp-icon-inspector: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgdmlld0JveD0iMCAwIDI0IDI0Ij4KICA8cGF0aCBjbGFzcz0ianAtaW5zcGVjdG9yLWljb24tY29sb3IganAtaWNvbi1zZWxlY3RhYmxlIiBmaWxsPSIjNjE2MTYxIiBkPSJNMjAgNEg0Yy0xLjEgMC0xLjk5LjktMS45OSAyTDIgMThjMCAxLjEuOSAyIDIgMmgxNmMxLjEgMCAyLS45IDItMlY2YzAtMS4xLS45LTItMi0yem0tNSAxNEg0di00aDExdjR6bTAtNUg0VjloMTF2NHptNSA1aC00VjloNHY5eiIvPgo8L3N2Zz4K);
+  --jp-icon-json: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgdmlld0JveD0iMCAwIDIyIDIyIj4KICA8ZyBjbGFzcz0ianAtanNvbi1pY29uLWNvbG9yIGpwLWljb24tc2VsZWN0YWJsZSIgZmlsbD0iI0Y5QTgyNSI+CiAgICA8cGF0aCBkPSJNMjAuMiAxMS44Yy0xLjYgMC0xLjcuNS0xLjcgMSAwIC40LjEuOS4xIDEuMy4xLjUuMS45LjEgMS4zIDAgMS43LTEuNCAyLjMtMy41IDIuM2gtLjl2LTEuOWguNWMxLjEgMCAxLjQgMCAxLjQtLjggMC0uMyAwLS42LS4xLTEgMC0uNC0uMS0uOC0uMS0xLjIgMC0xLjMgMC0xLjggMS4zLTItMS4zLS4yLTEuMy0uNy0xLjMtMiAwLS40LjEtLjguMS0xLjIuMS0uNC4xLS43LjEtMSAwLS44LS40LS43LTEuNC0uOGgtLjVWNC4xaC45YzIuMiAwIDMuNS43IDMuNSAyLjMgMCAuNC0uMS45LS4xIDEuMy0uMS41LS4xLjktLjEgMS4zIDAgLjUuMiAxIDEuNyAxdjEuOHpNMS44IDEwLjFjMS42IDAgMS43LS41IDEuNy0xIDAtLjQtLjEtLjktLjEtMS4zLS4xLS41LS4xLS45LS4xLTEuMyAwLTEuNiAxLjQtMi4zIDMuNS0yLjNoLjl2MS45aC0uNWMtMSAwLTEuNCAwLTEuNC44IDAgLjMgMCAuNi4xIDEgMCAuMi4xLjYuMSAxIDAgMS4zIDAgMS44LTEuMyAyQzYgMTEuMiA2IDExLjcgNiAxM2MwIC40LS4xLjgtLjEgMS4yLS4xLjMtLjEuNy0uMSAxIDAgLjguMy44IDEuNC44aC41djEuOWgtLjljLTIuMSAwLTMuNS0uNi0zLjUtMi4zIDAtLjQuMS0uOS4xLTEuMy4xLS41LjEtLjkuMS0xLjMgMC0uNS0uMi0xLTEuNy0xdi0xLjl6Ii8+CiAgICA8Y2lyY2xlIGN4PSIxMSIgY3k9IjEzLjgiIHI9IjIuMSIvPgogICAgPGNpcmNsZSBjeD0iMTEiIGN5PSI4LjIiIHI9IjIuMSIvPgogIDwvZz4KPC9zdmc+Cg==);
   --jp-icon-julia: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgdmlld0JveD0iMCAwIDMyNSAzMDAiPgogIDxnIGNsYXNzPSJqcC1icmFuZDAganAtaWNvbi1zZWxlY3RhYmxlIiBmaWxsPSIjY2IzYzMzIj4KICAgIDxwYXRoIGQ9Ik0gMTUwLjg5ODQzOCAyMjUgQyAxNTAuODk4NDM4IDI2Ni40MjE4NzUgMTE3LjMyMDMxMiAzMDAgNzUuODk4NDM4IDMwMCBDIDM0LjQ3NjU2MiAzMDAgMC44OTg0MzggMjY2LjQyMTg3NSAwLjg5ODQzOCAyMjUgQyAwLjg5ODQzOCAxODMuNTc4MTI1IDM0LjQ3NjU2MiAxNTAgNzUuODk4NDM4IDE1MCBDIDExNy4zMjAzMTIgMTUwIDE1MC44OTg0MzggMTgzLjU3ODEyNSAxNTAuODk4NDM4IDIyNSIvPgogIDwvZz4KICA8ZyBjbGFzcz0ianAtYnJhbmQwIGpwLWljb24tc2VsZWN0YWJsZSIgZmlsbD0iIzM4OTgyNiI+CiAgICA8cGF0aCBkPSJNIDIzNy41IDc1IEMgMjM3LjUgMTE2LjQyMTg3NSAyMDMuOTIxODc1IDE1MCAxNjIuNSAxNTAgQyAxMjEuMDc4MTI1IDE1MCA4Ny41IDExNi40MjE4NzUgODcuNSA3NSBDIDg3LjUgMzMuNTc4MTI1IDEyMS4wNzgxMjUgMCAxNjIuNSAwIEMgMjAzLjkyMTg3NSAwIDIzNy41IDMzLjU3ODEyNSAyMzcuNSA3NSIvPgogIDwvZz4KICA8ZyBjbGFzcz0ianAtYnJhbmQwIGpwLWljb24tc2VsZWN0YWJsZSIgZmlsbD0iIzk1NThiMiI+CiAgICA8cGF0aCBkPSJNIDMyNC4xMDE1NjIgMjI1IEMgMzI0LjEwMTU2MiAyNjYuNDIxODc1IDI5MC41MjM0MzggMzAwIDI0OS4xMDE1NjIgMzAwIEMgMjA3LjY3OTY4OCAzMDAgMTc0LjEwMTU2MiAyNjYuNDIxODc1IDE3NC4xMDE1NjIgMjI1IEMgMTc0LjEwMTU2MiAxODMuNTc4MTI1IDIwNy42Nzk2ODggMTUwIDI0OS4xMDE1NjIgMTUwIEMgMjkwLjUyMzQzOCAxNTAgMzI0LjEwMTU2MiAxODMuNTc4MTI1IDMyNC4xMDE1NjIgMjI1Ii8+CiAgPC9nPgo8L3N2Zz4K);
-  --jp-icon-jupyter-favicon: url(data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTUyIiBoZWlnaHQ9IjE2NSIgdmlld0JveD0iMCAwIDE1MiAxNjUiIHZlcnNpb249IjEuMSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KICA8ZyBjbGFzcz0ianAtaWNvbi13YXJuMCIgZmlsbD0iI0YzNzcyNiI+CiAgICA8cGF0aCB0cmFuc2Zvcm09InRyYW5zbGF0ZSgwLjA3ODk0NywgMTEwLjU4MjkyNykiIGQ9Ik03NS45NDIyODQyLDI5LjU4MDQ1NjEgQzQzLjMwMjM5NDcsMjkuNTgwNDU2MSAxNC43OTY3ODMyLDE3LjY1MzQ2MzQgMCwwIEM1LjUxMDgzMjExLDE1Ljg0MDY4MjkgMTUuNzgxNTM4OSwyOS41NjY3NzMyIDI5LjM5MDQ5NDcsMzkuMjc4NDE3MSBDNDIuOTk5Nyw0OC45ODk4NTM3IDU5LjI3MzcsNTQuMjA2NzgwNSA3NS45NjA1Nzg5LDU0LjIwNjc4MDUgQzkyLjY0NzQ1NzksNTQuMjA2NzgwNSAxMDguOTIxNDU4LDQ4Ljk4OTg1MzcgMTIyLjUzMDY2MywzOS4yNzg0MTcxIEMxMzYuMTM5NDUzLDI5LjU2Njc3MzIgMTQ2LjQxMDI4NCwxNS44NDA2ODI5IDE1MS45MjExNTgsMCBDMTM3LjA4Nzg2OCwxNy42NTM0NjM0IDEwOC41ODI1ODksMjkuNTgwNDU2MSA3NS45NDIyODQyLDI5LjU4MDQ1NjEgTDc1Ljk0MjI4NDIsMjkuNTgwNDU2MSBaIiAvPgogICAgPHBhdGggdHJhbnNmb3JtPSJ0cmFuc2xhdGUoMC4wMzczNjgsIDAuNzA0ODc4KSIgZD0iTTc1Ljk3ODQ1NzksMjQuNjI2NDA3MyBDMTA4LjYxODc2MywyNC42MjY0MDczIDEzNy4xMjQ0NTgsMzYuNTUzNDQxNSAxNTEuOTIxMTU4LDU0LjIwNjc4MDUgQzE0Ni40MTAyODQsMzguMzY2MjIyIDEzNi4xMzk0NTMsMjQuNjQwMTMxNyAxMjIuNTMwNjYzLDE0LjkyODQ4NzggQzEwOC45MjE0NTgsNS4yMTY4NDM5IDkyLjY0NzQ1NzksMCA3NS45NjA1Nzg5LDAgQzU5LjI3MzcsMCA0Mi45OTk3LDUuMjE2ODQzOSAyOS4zOTA0OTQ3LDE0LjkyODQ4NzggQzE1Ljc4MTUzODksMjQuNjQwMTMxNyA1LjUxMDgzMjExLDM4LjM2NjIyMiAwLDU0LjIwNjc4MDUgQzE0LjgzMzA4MTYsMzYuNTg5OTI5MyA0My4zMzg1Njg0LDI0LjYyNjQwNzMgNzUuOTc4NDU3OSwyNC42MjY0MDczIEw3NS45Nzg0NTc5LDI0LjYyNjQwNzMgWiIgLz4KICA8L2c+Cjwvc3ZnPgo=);
-  --jp-icon-jupyter: url(data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMzkiIGhlaWdodD0iNTEiIHZpZXdCb3g9IjAgMCAzOSA1MSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KICA8ZyB0cmFuc2Zvcm09InRyYW5zbGF0ZSgtMTYzOCAtMjI4MSkiPgogICAgPGcgY2xhc3M9ImpwLWljb24td2FybjAiIGZpbGw9IiNGMzc3MjYiPgogICAgICA8cGF0aCB0cmFuc2Zvcm09InRyYW5zbGF0ZSgxNjM5Ljc0IDIzMTEuOTgpIiBkPSJNIDE4LjI2NDYgNy4xMzQxMUMgMTAuNDE0NSA3LjEzNDExIDMuNTU4NzIgNC4yNTc2IDAgMEMgMS4zMjUzOSAzLjgyMDQgMy43OTU1NiA3LjEzMDgxIDcuMDY4NiA5LjQ3MzAzQyAxMC4zNDE3IDExLjgxNTIgMTQuMjU1NyAxMy4wNzM0IDE4LjI2OSAxMy4wNzM0QyAyMi4yODIzIDEzLjA3MzQgMjYuMTk2MyAxMS44MTUyIDI5LjQ2OTQgOS40NzMwM0MgMzIuNzQyNCA3LjEzMDgxIDM1LjIxMjYgMy44MjA0IDM2LjUzOCAwQyAzMi45NzA1IDQuMjU3NiAyNi4xMTQ4IDcuMTM0MTEgMTguMjY0NiA3LjEzNDExWiIvPgogICAgICA8cGF0aCB0cmFuc2Zvcm09InRyYW5zbGF0ZSgxNjM5LjczIDIyODUuNDgpIiBkPSJNIDE4LjI3MzMgNS45MzkzMUMgMjYuMTIzNSA1LjkzOTMxIDMyLjk3OTMgOC44MTU4MyAzNi41MzggMTMuMDczNEMgMzUuMjEyNiA5LjI1MzAzIDMyLjc0MjQgNS45NDI2MiAyOS40Njk0IDMuNjAwNEMgMjYuMTk2MyAxLjI1ODE4IDIyLjI4MjMgMCAxOC4yNjkgMEMgMTQuMjU1NyAwIDEwLjM0MTcgMS4yNTgxOCA3LjA2ODYgMy42MDA0QyAzLjc5NTU2IDUuOTQyNjIgMS4zMjUzOSA5LjI1MzAzIDAgMTMuMDczNEMgMy41Njc0NSA4LjgyNDYzIDEwLjQyMzIgNS45MzkzMSAxOC4yNzMzIDUuOTM5MzFaIi8+CiAgICA8L2c+CiAgICA8ZyBjbGFzcz0ianAtaWNvbjMiIGZpbGw9IiM2MTYxNjEiPgogICAgICA8cGF0aCB0cmFuc2Zvcm09InRyYW5zbGF0ZSgxNjY5LjMgMjI4MS4zMSkiIGQ9Ik0gNS44OTM1MyAyLjg0NEMgNS45MTg4OSAzLjQzMTY1IDUuNzcwODUgNC4wMTM2NyA1LjQ2ODE1IDQuNTE2NDVDIDUuMTY1NDUgNS4wMTkyMiA0LjcyMTY4IDUuNDIwMTUgNC4xOTI5OSA1LjY2ODUxQyAzLjY2NDMgNS45MTY4OCAzLjA3NDQ0IDYuMDAxNTEgMi40OTgwNSA1LjkxMTcxQyAxLjkyMTY2IDUuODIxOSAxLjM4NDYzIDUuNTYxNyAwLjk1NDg5OCA1LjE2NDAxQyAwLjUyNTE3IDQuNzY2MzMgMC4yMjIwNTYgNC4yNDkwMyAwLjA4MzkwMzcgMy42Nzc1N0MgLTAuMDU0MjQ4MyAzLjEwNjExIC0wLjAyMTIzIDIuNTA2MTcgMC4xNzg3ODEgMS45NTM2NEMgMC4zNzg3OTMgMS40MDExIDAuNzM2ODA5IDAuOTIwODE3IDEuMjA3NTQgMC41NzM1MzhDIDEuNjc4MjYgMC4yMjYyNTkgMi4yNDA1NSAwLjAyNzU5MTkgMi44MjMyNiAwLjAwMjY3MjI5QyAzLjYwMzg5IC0wLjAzMDcxMTUgNC4zNjU3MyAwLjI0OTc4OSA0Ljk0MTQyIDAuNzgyNTUxQyA1LjUxNzExIDEuMzE1MzEgNS44NTk1NiAyLjA1Njc2IDUuODkzNTMgMi44NDRaIi8+CiAgICAgIDxwYXRoIHRyYW5zZm9ybT0idHJhbnNsYXRlKDE2MzkuOCAyMzIzLjgxKSIgZD0iTSA3LjQyNzg5IDMuNTgzMzhDIDcuNDYwMDggNC4zMjQzIDcuMjczNTUgNS4wNTgxOSA2Ljg5MTkzIDUuNjkyMTNDIDYuNTEwMzEgNi4zMjYwNyA1Ljk1MDc1IDYuODMxNTYgNS4yODQxMSA3LjE0NDZDIDQuNjE3NDcgNy40NTc2MyAzLjg3MzcxIDcuNTY0MTQgMy4xNDcwMiA3LjQ1MDYzQyAyLjQyMDMyIDcuMzM3MTIgMS43NDMzNiA3LjAwODcgMS4yMDE4NCA2LjUwNjk1QyAwLjY2MDMyOCA2LjAwNTIgMC4yNzg2MSA1LjM1MjY4IDAuMTA1MDE3IDQuNjMyMDJDIC0wLjA2ODU3NTcgMy45MTEzNSAtMC4wMjYyMzYxIDMuMTU0OTQgMC4yMjY2NzUgMi40NTg1NkMgMC40Nzk1ODcgMS43NjIxNyAwLjkzMTY5NyAxLjE1NzEzIDEuNTI1NzYgMC43MjAwMzNDIDIuMTE5ODMgMC4yODI5MzUgMi44MjkxNCAwLjAzMzQzOTUgMy41NjM4OSAwLjAwMzEzMzQ0QyA0LjU0NjY3IC0wLjAzNzQwMzMgNS41MDUyOSAwLjMxNjcwNiA2LjIyOTYxIDAuOTg3ODM1QyA2Ljk1MzkzIDEuNjU4OTYgNy4zODQ4NCAyLjU5MjM1IDcuNDI3ODkgMy41ODMzOEwgNy40Mjc4OSAzLjU4MzM4WiIvPgogICAgICA8cGF0aCB0cmFuc2Zvcm09InRyYW5zbGF0ZSgxNjM4LjM2IDIyODYuMDYpIiBkPSJNIDIuMjc0NzEgNC4zOTYyOUMgMS44NDM2MyA0LjQxNTA4IDEuNDE2NzEgNC4zMDQ0NSAxLjA0Nzk5IDQuMDc4NDNDIDAuNjc5MjY4IDMuODUyNCAwLjM4NTMyOCAzLjUyMTE0IDAuMjAzMzcxIDMuMTI2NTZDIDAuMDIxNDEzNiAyLjczMTk4IC0wLjA0MDM3OTggMi4yOTE4MyAwLjAyNTgxMTYgMS44NjE4MUMgMC4wOTIwMDMxIDEuNDMxOCAwLjI4MzIwNCAxLjAzMTI2IDAuNTc1MjEzIDAuNzEwODgzQyAwLjg2NzIyMiAwLjM5MDUxIDEuMjQ2OTEgMC4xNjQ3MDggMS42NjYyMiAwLjA2MjA1OTJDIDIuMDg1NTMgLTAuMDQwNTg5NyAyLjUyNTYxIC0wLjAxNTQ3MTQgMi45MzA3NiAwLjEzNDIzNUMgMy4zMzU5MSAwLjI4Mzk0MSAzLjY4NzkyIDAuNTUxNTA1IDMuOTQyMjIgMC45MDMwNkMgNC4xOTY1MiAxLjI1NDYyIDQuMzQxNjkgMS42NzQzNiA0LjM1OTM1IDIuMTA5MTZDIDQuMzgyOTkgMi42OTEwNyA0LjE3Njc4IDMuMjU4NjkgMy43ODU5NyAzLjY4NzQ2QyAzLjM5NTE2IDQuMTE2MjQgMi44NTE2NiA0LjM3MTE2IDIuMjc0NzEgNC4zOTYyOUwgMi4yNzQ3MSA0LjM5NjI5WiIvPgogICAgPC9nPgogIDwvZz4+Cjwvc3ZnPgo=);
+  --jp-icon-jupyter-favicon: url(data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTUyIiBoZWlnaHQ9IjE2NSIgdmlld0JveD0iMCAwIDE1MiAxNjUiIHZlcnNpb249IjEuMSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KICAgPGcgY2xhc3M9ImpwLWp1cHl0ZXItaWNvbi1jb2xvciIgZmlsbD0iI0YzNzcyNiI+CiAgICA8cGF0aCB0cmFuc2Zvcm09InRyYW5zbGF0ZSgwLjA3ODk0NywgMTEwLjU4MjkyNykiIGQ9Ik03NS45NDIyODQyLDI5LjU4MDQ1NjEgQzQzLjMwMjM5NDcsMjkuNTgwNDU2MSAxNC43OTY3ODMyLDE3LjY1MzQ2MzQgMCwwIEM1LjUxMDgzMjExLDE1Ljg0MDY4MjkgMTUuNzgxNTM4OSwyOS41NjY3NzMyIDI5LjM5MDQ5NDcsMzkuMjc4NDE3MSBDNDIuOTk5Nyw0OC45ODk4NTM3IDU5LjI3MzcsNTQuMjA2NzgwNSA3NS45NjA1Nzg5LDU0LjIwNjc4MDUgQzkyLjY0NzQ1NzksNTQuMjA2NzgwNSAxMDguOTIxNDU4LDQ4Ljk4OTg1MzcgMTIyLjUzMDY2MywzOS4yNzg0MTcxIEMxMzYuMTM5NDUzLDI5LjU2Njc3MzIgMTQ2LjQxMDI4NCwxNS44NDA2ODI5IDE1MS45MjExNTgsMCBDMTM3LjA4Nzg2OCwxNy42NTM0NjM0IDEwOC41ODI1ODksMjkuNTgwNDU2MSA3NS45NDIyODQyLDI5LjU4MDQ1NjEgTDc1Ljk0MjI4NDIsMjkuNTgwNDU2MSBaIiAvPgogICAgPHBhdGggdHJhbnNmb3JtPSJ0cmFuc2xhdGUoMC4wMzczNjgsIDAuNzA0ODc4KSIgZD0iTTc1Ljk3ODQ1NzksMjQuNjI2NDA3MyBDMTA4LjYxODc2MywyNC42MjY0MDczIDEzNy4xMjQ0NTgsMzYuNTUzNDQxNSAxNTEuOTIxMTU4LDU0LjIwNjc4MDUgQzE0Ni40MTAyODQsMzguMzY2MjIyIDEzNi4xMzk0NTMsMjQuNjQwMTMxNyAxMjIuNTMwNjYzLDE0LjkyODQ4NzggQzEwOC45MjE0NTgsNS4yMTY4NDM5IDkyLjY0NzQ1NzksMCA3NS45NjA1Nzg5LDAgQzU5LjI3MzcsMCA0Mi45OTk3LDUuMjE2ODQzOSAyOS4zOTA0OTQ3LDE0LjkyODQ4NzggQzE1Ljc4MTUzODksMjQuNjQwMTMxNyA1LjUxMDgzMjExLDM4LjM2NjIyMiAwLDU0LjIwNjc4MDUgQzE0LjgzMzA4MTYsMzYuNTg5OTI5MyA0My4zMzg1Njg0LDI0LjYyNjQwNzMgNzUuOTc4NDU3OSwyNC42MjY0MDczIEw3NS45Nzg0NTc5LDI0LjYyNjQwNzMgWiIgLz4KICA8L2c+Cjwvc3ZnPgo=);
+  --jp-icon-jupyter: url(data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMzkiIGhlaWdodD0iNTEiIHZpZXdCb3g9IjAgMCAzOSA1MSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KICA8ZyB0cmFuc2Zvcm09InRyYW5zbGF0ZSgtMTYzOCAtMjI4MSkiPgogICAgIDxnIGNsYXNzPSJqcC1qdXB5dGVyLWljb24tY29sb3IiIGZpbGw9IiNGMzc3MjYiPgogICAgICA8cGF0aCB0cmFuc2Zvcm09InRyYW5zbGF0ZSgxNjM5Ljc0IDIzMTEuOTgpIiBkPSJNIDE4LjI2NDYgNy4xMzQxMUMgMTAuNDE0NSA3LjEzNDExIDMuNTU4NzIgNC4yNTc2IDAgMEMgMS4zMjUzOSAzLjgyMDQgMy43OTU1NiA3LjEzMDgxIDcuMDY4NiA5LjQ3MzAzQyAxMC4zNDE3IDExLjgxNTIgMTQuMjU1NyAxMy4wNzM0IDE4LjI2OSAxMy4wNzM0QyAyMi4yODIzIDEzLjA3MzQgMjYuMTk2MyAxMS44MTUyIDI5LjQ2OTQgOS40NzMwM0MgMzIuNzQyNCA3LjEzMDgxIDM1LjIxMjYgMy44MjA0IDM2LjUzOCAwQyAzMi45NzA1IDQuMjU3NiAyNi4xMTQ4IDcuMTM0MTEgMTguMjY0NiA3LjEzNDExWiIvPgogICAgICA8cGF0aCB0cmFuc2Zvcm09InRyYW5zbGF0ZSgxNjM5LjczIDIyODUuNDgpIiBkPSJNIDE4LjI3MzMgNS45MzkzMUMgMjYuMTIzNSA1LjkzOTMxIDMyLjk3OTMgOC44MTU4MyAzNi41MzggMTMuMDczNEMgMzUuMjEyNiA5LjI1MzAzIDMyLjc0MjQgNS45NDI2MiAyOS40Njk0IDMuNjAwNEMgMjYuMTk2MyAxLjI1ODE4IDIyLjI4MjMgMCAxOC4yNjkgMEMgMTQuMjU1NyAwIDEwLjM0MTcgMS4yNTgxOCA3LjA2ODYgMy42MDA0QyAzLjc5NTU2IDUuOTQyNjIgMS4zMjUzOSA5LjI1MzAzIDAgMTMuMDczNEMgMy41Njc0NSA4LjgyNDYzIDEwLjQyMzIgNS45MzkzMSAxOC4yNzMzIDUuOTM5MzFaIi8+CiAgICA8L2c+CiAgICA8ZyBjbGFzcz0ianAtaWNvbjMiIGZpbGw9IiM2MTYxNjEiPgogICAgICA8cGF0aCB0cmFuc2Zvcm09InRyYW5zbGF0ZSgxNjY5LjMgMjI4MS4zMSkiIGQ9Ik0gNS44OTM1MyAyLjg0NEMgNS45MTg4OSAzLjQzMTY1IDUuNzcwODUgNC4wMTM2NyA1LjQ2ODE1IDQuNTE2NDVDIDUuMTY1NDUgNS4wMTkyMiA0LjcyMTY4IDUuNDIwMTUgNC4xOTI5OSA1LjY2ODUxQyAzLjY2NDMgNS45MTY4OCAzLjA3NDQ0IDYuMDAxNTEgMi40OTgwNSA1LjkxMTcxQyAxLjkyMTY2IDUuODIxOSAxLjM4NDYzIDUuNTYxNyAwLjk1NDg5OCA1LjE2NDAxQyAwLjUyNTE3IDQuNzY2MzMgMC4yMjIwNTYgNC4yNDkwMyAwLjA4MzkwMzcgMy42Nzc1N0MgLTAuMDU0MjQ4MyAzLjEwNjExIC0wLjAyMTIzIDIuNTA2MTcgMC4xNzg3ODEgMS45NTM2NEMgMC4zNzg3OTMgMS40MDExIDAuNzM2ODA5IDAuOTIwODE3IDEuMjA3NTQgMC41NzM1MzhDIDEuNjc4MjYgMC4yMjYyNTkgMi4yNDA1NSAwLjAyNzU5MTkgMi44MjMyNiAwLjAwMjY3MjI5QyAzLjYwMzg5IC0wLjAzMDcxMTUgNC4zNjU3MyAwLjI0OTc4OSA0Ljk0MTQyIDAuNzgyNTUxQyA1LjUxNzExIDEuMzE1MzEgNS44NTk1NiAyLjA1Njc2IDUuODkzNTMgMi44NDRaIi8+CiAgICAgIDxwYXRoIHRyYW5zZm9ybT0idHJhbnNsYXRlKDE2MzkuOCAyMzIzLjgxKSIgZD0iTSA3LjQyNzg5IDMuNTgzMzhDIDcuNDYwMDggNC4zMjQzIDcuMjczNTUgNS4wNTgxOSA2Ljg5MTkzIDUuNjkyMTNDIDYuNTEwMzEgNi4zMjYwNyA1Ljk1MDc1IDYuODMxNTYgNS4yODQxMSA3LjE0NDZDIDQuNjE3NDcgNy40NTc2MyAzLjg3MzcxIDcuNTY0MTQgMy4xNDcwMiA3LjQ1MDYzQyAyLjQyMDMyIDcuMzM3MTIgMS43NDMzNiA3LjAwODcgMS4yMDE4NCA2LjUwNjk1QyAwLjY2MDMyOCA2LjAwNTIgMC4yNzg2MSA1LjM1MjY4IDAuMTA1MDE3IDQuNjMyMDJDIC0wLjA2ODU3NTcgMy45MTEzNSAtMC4wMjYyMzYxIDMuMTU0OTQgMC4yMjY2NzUgMi40NTg1NkMgMC40Nzk1ODcgMS43NjIxNyAwLjkzMTY5NyAxLjE1NzEzIDEuNTI1NzYgMC43MjAwMzNDIDIuMTE5ODMgMC4yODI5MzUgMi44MjkxNCAwLjAzMzQzOTUgMy41NjM4OSAwLjAwMzEzMzQ0QyA0LjU0NjY3IC0wLjAzNzQwMzMgNS41MDUyOSAwLjMxNjcwNiA2LjIyOTYxIDAuOTg3ODM1QyA2Ljk1MzkzIDEuNjU4OTYgNy4zODQ4NCAyLjU5MjM1IDcuNDI3ODkgMy41ODMzOEwgNy40Mjc4OSAzLjU4MzM4WiIvPgogICAgICA8cGF0aCB0cmFuc2Zvcm09InRyYW5zbGF0ZSgxNjM4LjM2IDIyODYuMDYpIiBkPSJNIDIuMjc0NzEgNC4zOTYyOUMgMS44NDM2MyA0LjQxNTA4IDEuNDE2NzEgNC4zMDQ0NSAxLjA0Nzk5IDQuMDc4NDNDIDAuNjc5MjY4IDMuODUyNCAwLjM4NTMyOCAzLjUyMTE0IDAuMjAzMzcxIDMuMTI2NTZDIDAuMDIxNDEzNiAyLjczMTk4IC0wLjA0MDM3OTggMi4yOTE4MyAwLjAyNTgxMTYgMS44NjE4MUMgMC4wOTIwMDMxIDEuNDMxOCAwLjI4MzIwNCAxLjAzMTI2IDAuNTc1MjEzIDAuNzEwODgzQyAwLjg2NzIyMiAwLjM5MDUxIDEuMjQ2OTEgMC4xNjQ3MDggMS42NjYyMiAwLjA2MjA1OTJDIDIuMDg1NTMgLTAuMDQwNTg5NyAyLjUyNTYxIC0wLjAxNTQ3MTQgMi45MzA3NiAwLjEzNDIzNUMgMy4zMzU5MSAwLjI4Mzk0MSAzLjY4NzkyIDAuNTUxNTA1IDMuOTQyMjIgMC45MDMwNkMgNC4xOTY1MiAxLjI1NDYyIDQuMzQxNjkgMS42NzQzNiA0LjM1OTM1IDIuMTA5MTZDIDQuMzgyOTkgMi42OTEwNyA0LjE3Njc4IDMuMjU4NjkgMy43ODU5NyAzLjY4NzQ2QyAzLjM5NTE2IDQuMTE2MjQgMi44NTE2NiA0LjM3MTE2IDIuMjc0NzEgNC4zOTYyOUwgMi4yNzQ3MSA0LjM5NjI5WiIvPgogICAgPC9nPgogIDwvZz4+Cjwvc3ZnPgo=);
   --jp-icon-jupyterlab-wordmark: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyMDAiIHZpZXdCb3g9IjAgMCAxODYwLjggNDc1Ij4KICA8ZyBjbGFzcz0ianAtaWNvbjIiIGZpbGw9IiM0RTRFNEUiIHRyYW5zZm9ybT0idHJhbnNsYXRlKDQ4MC4xMzY0MDEsIDY0LjI3MTQ5MykiPgogICAgPGcgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoMC4wMDAwMDAsIDU4Ljg3NTU2NikiPgogICAgICA8ZyB0cmFuc2Zvcm09InRyYW5zbGF0ZSgwLjA4NzYwMywgMC4xNDAyOTQpIj4KICAgICAgICA8cGF0aCBkPSJNLTQyNi45LDE2OS44YzAsNDguNy0zLjcsNjQuNy0xMy42LDc2LjRjLTEwLjgsMTAtMjUsMTUuNS0zOS43LDE1LjVsMy43LDI5IGMyMi44LDAuMyw0NC44LTcuOSw2MS45LTIzLjFjMTcuOC0xOC41LDI0LTQ0LjEsMjQtODMuM1YwSC00Mjd2MTcwLjFMLTQyNi45LDE2OS44TC00MjYuOSwxNjkuOHoiLz4KICAgICAgPC9nPgogICAgPC9nPgogICAgPGcgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoMTU1LjA0NTI5NiwgNTYuODM3MTA0KSI+CiAgICAgIDxnIHRyYW5zZm9ybT0idHJhbnNsYXRlKDEuNTYyNDUzLCAxLjc5OTg0MikiPgogICAgICAgIDxwYXRoIGQ9Ik0tMzEyLDE0OGMwLDIxLDAsMzkuNSwxLjcsNTUuNGgtMzEuOGwtMi4xLTMzLjNoLTAuOGMtNi43LDExLjYtMTYuNCwyMS4zLTI4LDI3LjkgYy0xMS42LDYuNi0yNC44LDEwLTM4LjIsOS44Yy0zMS40LDAtNjktMTcuNy02OS04OVYwaDM2LjR2MTEyLjdjMCwzOC43LDExLjYsNjQuNyw0NC42LDY0LjdjMTAuMy0wLjIsMjAuNC0zLjUsMjguOS05LjQgYzguNS01LjksMTUuMS0xNC4zLDE4LjktMjMuOWMyLjItNi4xLDMuMy0xMi41LDMuMy0xOC45VjAuMmgzNi40VjE0OEgtMzEyTC0zMTIsMTQ4eiIvPgogICAgICA8L2c+CiAgICA8L2c+CiAgICA8ZyB0cmFuc2Zvcm09InRyYW5zbGF0ZSgzOTAuMDEzMzIyLCA1My40Nzk2MzgpIj4KICAgICAgPGcgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoMS43MDY0NTgsIDAuMjMxNDI1KSI+CiAgICAgICAgPHBhdGggZD0iTS00NzguNiw3MS40YzAtMjYtMC44LTQ3LTEuNy02Ni43aDMyLjdsMS43LDM0LjhoMC44YzcuMS0xMi41LDE3LjUtMjIuOCwzMC4xLTI5LjcgYzEyLjUtNywyNi43LTEwLjMsNDEtOS44YzQ4LjMsMCw4NC43LDQxLjcsODQuNywxMDMuM2MwLDczLjEtNDMuNywxMDkuMi05MSwxMDkuMmMtMTIuMSwwLjUtMjQuMi0yLjItMzUtNy44IGMtMTAuOC01LjYtMTkuOS0xMy45LTI2LjYtMjQuMmgtMC44VjI5MWgtMzZ2LTIyMEwtNDc4LjYsNzEuNEwtNDc4LjYsNzEuNHogTS00NDIuNiwxMjUuNmMwLjEsNS4xLDAuNiwxMC4xLDEuNywxNS4xIGMzLDEyLjMsOS45LDIzLjMsMTkuOCwzMS4xYzkuOSw3LjgsMjIuMSwxMi4xLDM0LjcsMTIuMWMzOC41LDAsNjAuNy0zMS45LDYwLjctNzguNWMwLTQwLjctMjEuMS03NS42LTU5LjUtNzUuNiBjLTEyLjksMC40LTI1LjMsNS4xLTM1LjMsMTMuNGMtOS45LDguMy0xNi45LDE5LjctMTkuNiwzMi40Yy0xLjUsNC45LTIuMywxMC0yLjUsMTUuMVYxMjUuNkwtNDQyLjYsMTI1LjZMLTQ0Mi42LDEyNS42eiIvPgogICAgICA8L2c+CiAgICA8L2c+CiAgICA8ZyB0cmFuc2Zvcm09InRyYW5zbGF0ZSg2MDYuNzQwNzI2LCA1Ni44MzcxMDQpIj4KICAgICAgPGcgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoMC43NTEyMjYsIDEuOTg5Mjk5KSI+CiAgICAgICAgPHBhdGggZD0iTS00NDAuOCwwbDQzLjcsMTIwLjFjNC41LDEzLjQsOS41LDI5LjQsMTIuOCw0MS43aDAuOGMzLjctMTIuMiw3LjktMjcuNywxMi44LTQyLjQgbDM5LjctMTE5LjJoMzguNUwtMzQ2LjksMTQ1Yy0yNiw2OS43LTQzLjcsMTA1LjQtNjguNiwxMjcuMmMtMTIuNSwxMS43LTI3LjksMjAtNDQuNiwyMy45bC05LjEtMzEuMSBjMTEuNy0zLjksMjIuNS0xMC4xLDMxLjgtMTguMWMxMy4yLTExLjEsMjMuNy0yNS4yLDMwLjYtNDEuMmMxLjUtMi44LDIuNS01LjcsMi45LTguOGMtMC4zLTMuMy0xLjItNi42LTIuNS05LjdMLTQ4MC4yLDAuMSBoMzkuN0wtNDQwLjgsMEwtNDQwLjgsMHoiLz4KICAgICAgPC9nPgogICAgPC9nPgogICAgPGcgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoODIyLjc0ODEwNCwgMC4wMDAwMDApIj4KICAgICAgPGcgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoMS40NjQwNTAsIDAuMzc4OTE0KSI+CiAgICAgICAgPHBhdGggZD0iTS00MTMuNywwdjU4LjNoNTJ2MjguMmgtNTJWMTk2YzAsMjUsNywzOS41LDI3LjMsMzkuNWM3LjEsMC4xLDE0LjItMC43LDIxLjEtMi41IGwxLjcsMjcuN2MtMTAuMywzLjctMjEuMyw1LjQtMzIuMiw1Yy03LjMsMC40LTE0LjYtMC43LTIxLjMtMy40Yy02LjgtMi43LTEyLjktNi44LTE3LjktMTIuMWMtMTAuMy0xMC45LTE0LjEtMjktMTQuMS01Mi45IFY4Ni41aC0zMVY1OC4zaDMxVjkuNkwtNDEzLjcsMEwtNDEzLjcsMHoiLz4KICAgICAgPC9nPgogICAgPC9nPgogICAgPGcgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoOTc0LjQzMzI4NiwgNTMuNDc5NjM4KSI+CiAgICAgIDxnIHRyYW5zZm9ybT0idHJhbnNsYXRlKDAuOTkwMDM0LCAwLjYxMDMzOSkiPgogICAgICAgIDxwYXRoIGQ9Ik0tNDQ1LjgsMTEzYzAuOCw1MCwzMi4yLDcwLjYsNjguNiw3MC42YzE5LDAuNiwzNy45LTMsNTUuMy0xMC41bDYuMiwyNi40IGMtMjAuOSw4LjktNDMuNSwxMy4xLTY2LjIsMTIuNmMtNjEuNSwwLTk4LjMtNDEuMi05OC4zLTEwMi41Qy00ODAuMiw0OC4yLTQ0NC43LDAtMzg2LjUsMGM2NS4yLDAsODIuNyw1OC4zLDgyLjcsOTUuNyBjLTAuMSw1LjgtMC41LDExLjUtMS4yLDE3LjJoLTE0MC42SC00NDUuOEwtNDQ1LjgsMTEzeiBNLTMzOS4yLDg2LjZjMC40LTIzLjUtOS41LTYwLjEtNTAuNC02MC4xIGMtMzYuOCwwLTUyLjgsMzQuNC01NS43LDYwLjFILTMzOS4yTC0zMzkuMiw4Ni42TC0zMzkuMiw4Ni42eiIvPgogICAgICA8L2c+CiAgICA8L2c+CiAgICA8ZyB0cmFuc2Zvcm09InRyYW5zbGF0ZSgxMjAxLjk2MTA1OCwgNTMuNDc5NjM4KSI+CiAgICAgIDxnIHRyYW5zZm9ybT0idHJhbnNsYXRlKDEuMTc5NjQwLCAwLjcwNTA2OCkiPgogICAgICAgIDxwYXRoIGQ9Ik0tNDc4LjYsNjhjMC0yMy45LTAuNC00NC41LTEuNy02My40aDMxLjhsMS4yLDM5LjloMS43YzkuMS0yNy4zLDMxLTQ0LjUsNTUuMy00NC41IGMzLjUtMC4xLDcsMC40LDEwLjMsMS4ydjM0LjhjLTQuMS0wLjktOC4yLTEuMy0xMi40LTEuMmMtMjUuNiwwLTQzLjcsMTkuNy00OC43LDQ3LjRjLTEsNS43LTEuNiwxMS41LTEuNywxNy4ydjEwOC4zaC0zNlY2OCBMLTQ3OC42LDY4eiIvPgogICAgICA8L2c+CiAgICA8L2c+CiAgPC9nPgoKICA8ZyBjbGFzcz0ianAtaWNvbi13YXJuMCIgZmlsbD0iI0YzNzcyNiI+CiAgICA8cGF0aCBkPSJNMTM1Mi4zLDMyNi4yaDM3VjI4aC0zN1YzMjYuMnogTTE2MDQuOCwzMjYuMmMtMi41LTEzLjktMy40LTMxLjEtMy40LTQ4Ljd2LTc2IGMwLTQwLjctMTUuMS04My4xLTc3LjMtODMuMWMtMjUuNiwwLTUwLDcuMS02Ni44LDE4LjFsOC40LDI0LjRjMTQuMy05LjIsMzQtMTUuMSw1My0xNS4xYzQxLjYsMCw0Ni4yLDMwLjIsNDYuMiw0N3Y0LjIgYy03OC42LTAuNC0xMjIuMywyNi41LTEyMi4zLDc1LjZjMCwyOS40LDIxLDU4LjQsNjIuMiw1OC40YzI5LDAsNTAuOS0xNC4zLDYyLjItMzAuMmgxLjNsMi45LDI1LjZIMTYwNC44eiBNMTU2NS43LDI1Ny43IGMwLDMuOC0wLjgsOC0yLjEsMTEuOGMtNS45LDE3LjItMjIuNywzNC00OS4yLDM0Yy0xOC45LDAtMzQuOS0xMS4zLTM0LjktMzUuM2MwLTM5LjUsNDUuOC00Ni42LDg2LjItNDUuOFYyNTcuN3ogTTE2OTguNSwzMjYuMiBsMS43LTMzLjZoMS4zYzE1LjEsMjYuOSwzOC43LDM4LjIsNjguMSwzOC4yYzQ1LjQsMCw5MS4yLTM2LjEsOTEuMi0xMDguOGMwLjQtNjEuNy0zNS4zLTEwMy43LTg1LjctMTAzLjcgYy0zMi44LDAtNTYuMywxNC43LTY5LjMsMzcuNGgtMC44VjI4aC0zNi42djI0NS43YzAsMTguMS0wLjgsMzguNi0xLjcsNTIuNUgxNjk4LjV6IE0xNzA0LjgsMjA4LjJjMC01LjksMS4zLTEwLjksMi4xLTE1LjEgYzcuNi0yOC4xLDMxLjEtNDUuNCw1Ni4zLTQ1LjRjMzkuNSwwLDYwLjUsMzQuOSw2MC41LDc1LjZjMCw0Ni42LTIzLjEsNzguMS02MS44LDc4LjFjLTI2LjksMC00OC4zLTE3LjYtNTUuNS00My4zIGMtMC44LTQuMi0xLjctOC44LTEuNy0xMy40VjIwOC4yeiIvPgogIDwvZz4KPC9zdmc+Cg==);
   --jp-icon-kernel: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgdmlld0JveD0iMCAwIDI0IDI0Ij4KICAgIDxwYXRoIGNsYXNzPSJqcC1pY29uMiIgZmlsbD0iIzYxNjE2MSIgZD0iTTE1IDlIOXY2aDZWOXptLTIgNGgtMnYtMmgydjJ6bTgtMlY5aC0yVjdjMC0xLjEtLjktMi0yLTJoLTJWM2gtMnYyaC0yVjNIOXYySDdjLTEuMSAwLTIgLjktMiAydjJIM3YyaDJ2MkgzdjJoMnYyYzAgMS4xLjkgMiAyIDJoMnYyaDJ2LTJoMnYyaDJ2LTJoMmMxLjEgMCAyLS45IDItMnYtMmgydi0yaC0ydi0yaDJ6bS00IDZIN1Y3aDEwdjEweiIvPgo8L3N2Zz4K);
   --jp-icon-keyboard: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgdmlld0JveD0iMCAwIDI0IDI0Ij4KICA8cGF0aCBjbGFzcz0ianAtaWNvbjMganAtaWNvbi1zZWxlY3RhYmxlIiBmaWxsPSIjNjE2MTYxIiBkPSJNMjAgNUg0Yy0xLjEgMC0xLjk5LjktMS45OSAyTDIgMTdjMCAxLjEuOSAyIDIgMmgxNmMxLjEgMCAyLS45IDItMlY3YzAtMS4xLS45LTItMi0yem0tOSAzaDJ2MmgtMlY4em0wIDNoMnYyaC0ydi0yek04IDhoMnYySDhWOHptMCAzaDJ2Mkg4di0yem0tMSAySDV2LTJoMnYyem0wLTNINVY4aDJ2MnptOSA3SDh2LTJoOHYyem0wLTRoLTJ2LTJoMnYyem0wLTNoLTJWOGgydjJ6bTMgM2gtMnYtMmgydjJ6bTAtM2gtMlY4aDJ2MnoiLz4KPC9zdmc+Cg==);
+  --jp-icon-launch: url(data:image/svg+xml;base64,PHN2ZyB2aWV3Qm94PSIwIDAgMzIgMzIiIHdpZHRoPSIzMiIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KICA8ZyBjbGFzcz0ianAtaWNvbjMganAtaWNvbi1zZWxlY3RhYmxlIiBmaWxsPSIjNjE2MTYxIj4KICAgIDxwYXRoIGQ9Ik0yNiwyOEg2YTIuMDAyNywyLjAwMjcsMCwwLDEtMi0yVjZBMi4wMDI3LDIuMDAyNywwLDAsMSw2LDRIMTZWNkg2VjI2SDI2VjE2aDJWMjZBMi4wMDI3LDIuMDAyNywwLDAsMSwyNiwyOFoiLz4KICAgIDxwb2x5Z29uIHBvaW50cz0iMjAgMiAyMCA0IDI2LjU4NiA0IDE4IDEyLjU4NiAxOS40MTQgMTQgMjggNS40MTQgMjggMTIgMzAgMTIgMzAgMiAyMCAyIi8+CiAgPC9nPgo8L3N2Zz4K);
   --jp-icon-launcher: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgdmlld0JveD0iMCAwIDI0IDI0Ij4KICA8cGF0aCBjbGFzcz0ianAtaWNvbjMganAtaWNvbi1zZWxlY3RhYmxlIiBmaWxsPSIjNjE2MTYxIiBkPSJNMTkgMTlINVY1aDdWM0g1YTIgMiAwIDAwLTIgMnYxNGEyIDIgMCAwMDIgMmgxNGMxLjEgMCAyLS45IDItMnYtN2gtMnY3ek0xNCAzdjJoMy41OWwtOS44MyA5LjgzIDEuNDEgMS40MUwxOSA2LjQxVjEwaDJWM2gtN3oiLz4KPC9zdmc+Cg==);
   --jp-icon-line-form: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgdmlld0JveD0iMCAwIDI0IDI0Ij4KICAgIDxwYXRoIGZpbGw9IndoaXRlIiBkPSJNNS44OCA0LjEyTDEzLjc2IDEybC03Ljg4IDcuODhMOCAyMmwxMC0xMEw4IDJ6Ii8+Cjwvc3ZnPgo=);
   --jp-icon-link: url(data:image/svg+xml;base64,PHN2ZyB2aWV3Qm94PSIwIDAgMjQgMjQiIHdpZHRoPSIxNiIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KICA8ZyBjbGFzcz0ianAtaWNvbjMiIGZpbGw9IiM2MTYxNjEiPgogICAgPHBhdGggZD0iTTMuOSAxMmMwLTEuNzEgMS4zOS0zLjEgMy4xLTMuMWg0VjdIN2MtMi43NiAwLTUgMi4yNC01IDVzMi4yNCA1IDUgNWg0di0xLjlIN2MtMS43MSAwLTMuMS0xLjM5LTMuMS0zLjF6TTggMTNoOHYtMkg4djJ6bTktNmgtNHYxLjloNGMxLjcxIDAgMy4xIDEuMzkgMy4xIDMuMXMtMS4zOSAzLjEtMy4xIDMuMWgtNFYxN2g0YzIuNzYgMCA1LTIuMjQgNS01cy0yLjI0LTUtNS01eiIvPgogIDwvZz4KPC9zdmc+Cg==);
   --jp-icon-list: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgdmlld0JveD0iMCAwIDI0IDI0Ij4KICAgIDxwYXRoIGNsYXNzPSJqcC1pY29uMiBqcC1pY29uLXNlbGVjdGFibGUiIGZpbGw9IiM2MTYxNjEiIGQ9Ik0xOSA1djE0SDVWNWgxNG0xLjEtMkgzLjljLS41IDAtLjkuNC0uOS45djE2LjJjMCAuNC40LjkuOS45aDE2LjJjLjQgMCAuOS0uNS45LS45VjMuOWMwLS41LS41LS45LS45LS45ek0xMSA3aDZ2MmgtNlY3em0wIDRoNnYyaC02di0yem0wIDRoNnYyaC02ek03IDdoMnYySDd6bTAgNGgydjJIN3ptMCA0aDJ2Mkg3eiIvPgo8L3N2Zz4=);
   --jp-icon-listings-info: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA1MC45NzggNTAuOTc4IiBzdHlsZT0iZW5hYmxlLWJhY2tncm91bmQ6bmV3IDAgMCA1MC45NzggNTAuOTc4OyIgeG1sOnNwYWNlPSJwcmVzZXJ2ZSI+Cgk8Zz4KCQk8cGF0aCBzdHlsZT0iZmlsbDojMDEwMDAyOyIgZD0iTTQzLjUyLDcuNDU4QzM4LjcxMSwyLjY0OCwzMi4zMDcsMCwyNS40ODksMEMxOC42NywwLDEyLjI2NiwyLjY0OCw3LjQ1OCw3LjQ1OAoJCQljLTkuOTQzLDkuOTQxLTkuOTQzLDI2LjExOSwwLDM2LjA2MmM0LjgwOSw0LjgwOSwxMS4yMTIsNy40NTYsMTguMDMxLDcuNDU4YzAsMCwwLjAwMSwwLDAuMDAyLDAKCQkJYzYuODE2LDAsMTMuMjIxLTIuNjQ4LDE4LjAyOS03LjQ1OGM0LjgwOS00LjgwOSw3LjQ1Ny0xMS4yMTIsNy40NTctMTguMDNDNTAuOTc3LDE4LjY3LDQ4LjMyOCwxMi4yNjYsNDMuNTIsNy40NTh6CgkJCSBNNDIuMTA2LDQyLjEwNWMtNC40MzIsNC40MzEtMTAuMzMyLDYuODcyLTE2LjYxNSw2Ljg3MmgtMC4wMDJjLTYuMjg1LTAuMDAxLTEyLjE4Ny0yLjQ0MS0xNi42MTctNi44NzIKCQkJYy05LjE2Mi05LjE2My05LjE2Mi0yNC4wNzEsMC0zMy4yMzNDMTMuMzAzLDQuNDQsMTkuMjA0LDIsMjUuNDg5LDJjNi4yODQsMCwxMi4xODYsMi40NCwxNi42MTcsNi44NzIKCQkJYzQuNDMxLDQuNDMxLDYuODcxLDEwLjMzMiw2Ljg3MSwxNi42MTdDNDguOTc3LDMxLjc3Miw0Ni41MzYsMzcuNjc1LDQyLjEwNiw0Mi4xMDV6Ii8+CgkJPHBhdGggc3R5bGU9ImZpbGw6IzAxMDAwMjsiIGQ9Ik0yMy41NzgsMzIuMjE4Yy0wLjAyMy0xLjczNCwwLjE0My0zLjA1OSwwLjQ5Ni0zLjk3MmMwLjM1My0wLjkxMywxLjExLTEuOTk3LDIuMjcyLTMuMjUzCgkJCWMwLjQ2OC0wLjUzNiwwLjkyMy0xLjA2MiwxLjM2Ny0xLjU3NWMwLjYyNi0wLjc1MywxLjEwNC0xLjQ3OCwxLjQzNi0yLjE3NWMwLjMzMS0wLjcwNywwLjQ5NS0xLjU0MSwwLjQ5NS0yLjUKCQkJYzAtMS4wOTYtMC4yNi0yLjA4OC0wLjc3OS0yLjk3OWMtMC41NjUtMC44NzktMS41MDEtMS4zMzYtMi44MDYtMS4zNjljLTEuODAyLDAuMDU3LTIuOTg1LDAuNjY3LTMuNTUsMS44MzIKCQkJYy0wLjMwMSwwLjUzNS0wLjUwMywxLjE0MS0wLjYwNywxLjgxNGMtMC4xMzksMC43MDctMC4yMDcsMS40MzItMC4yMDcsMi4xNzRoLTIuOTM3Yy0wLjA5MS0yLjIwOCwwLjQwNy00LjExNCwxLjQ5My01LjcxOQoJCQljMS4wNjItMS42NCwyLjg1NS0yLjQ4MSw1LjM3OC0yLjUyN2MyLjE2LDAuMDIzLDMuODc0LDAuNjA4LDUuMTQxLDEuNzU4YzEuMjc4LDEuMTYsMS45MjksMi43NjQsMS45NSw0LjgxMQoJCQljMCwxLjE0Mi0wLjEzNywyLjExMS0wLjQxLDIuOTExYy0wLjMwOSwwLjg0NS0wLjczMSwxLjU5My0xLjI2OCwyLjI0M2MtMC40OTIsMC42NS0xLjA2OCwxLjMxOC0xLjczLDIuMDAyCgkJCWMtMC42NSwwLjY5Ny0xLjMxMywxLjQ3OS0xLjk4NywyLjM0NmMtMC4yMzksMC4zNzctMC40MjksMC43NzctMC41NjUsMS4xOTljLTAuMTYsMC45NTktMC4yMTcsMS45NTEtMC4xNzEsMi45NzkKCQkJQzI2LjU4OSwzMi4yMTgsMjMuNTc4LDMyLjIxOCwyMy41NzgsMzIuMjE4eiBNMjMuNTc4LDM4LjIydi0zLjQ4NGgzLjA3NnYzLjQ4NEgyMy41Nzh6Ii8+Cgk8L2c+Cjwvc3ZnPgo=);
   --jp-icon-markdown: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgdmlld0JveD0iMCAwIDIyIDIyIj4KICA8cGF0aCBjbGFzcz0ianAtaWNvbi1jb250cmFzdDAganAtaWNvbi1zZWxlY3RhYmxlIiBmaWxsPSIjN0IxRkEyIiBkPSJNNSAxNC45aDEybC02LjEgNnptOS40LTYuOGMwLTEuMy0uMS0yLjktLjEtNC41LS40IDEuNC0uOSAyLjktMS4zIDQuM2wtMS4zIDQuM2gtMkw4LjUgNy45Yy0uNC0xLjMtLjctMi45LTEtNC4zLS4xIDEuNi0uMSAzLjItLjIgNC42TDcgMTIuNEg0LjhsLjctMTFoMy4zTDEwIDVjLjQgMS4yLjcgMi43IDEgMy45LjMtMS4yLjctMi42IDEtMy45bDEuMi0zLjdoMy4zbC42IDExaC0yLjRsLS4zLTQuMnoiLz4KPC9zdmc+Cg==);
+  --jp-icon-move-down: url(data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTQiIGhlaWdodD0iMTQiIHZpZXdCb3g9IjAgMCAxNCAxNCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggY2xhc3M9ImpwLWljb24zIiBkPSJNMTIuNDcxIDcuNTI4OTlDMTIuNzYzMiA3LjIzNjg0IDEyLjc2MzIgNi43NjMxNiAxMi40NzEgNi40NzEwMVY2LjQ3MTAxQzEyLjE3OSA2LjE3OTA1IDExLjcwNTcgNi4xNzg4NCAxMS40MTM1IDYuNDcwNTRMNy43NSAxMC4xMjc1VjEuNzVDNy43NSAxLjMzNTc5IDcuNDE0MjEgMSA3IDFWMUM2LjU4NTc5IDEgNi4yNSAxLjMzNTc5IDYuMjUgMS43NVYxMC4xMjc1TDIuNTk3MjYgNi40NjgyMkMyLjMwMzM4IDYuMTczODEgMS44MjY0MSA2LjE3MzU5IDEuNTMyMjYgNi40Njc3NFY2LjQ2Nzc0QzEuMjM4MyA2Ljc2MTcgMS4yMzgzIDcuMjM4MyAxLjUzMjI2IDcuNTMyMjZMNi4yOTI4OSAxMi4yOTI5QzYuNjgzNDIgMTIuNjgzNCA3LjMxNjU4IDEyLjY4MzQgNy43MDcxMSAxMi4yOTI5TDEyLjQ3MSA3LjUyODk5WiIgZmlsbD0iIzYxNjE2MSIvPgo8L3N2Zz4K);
+  --jp-icon-move-up: url(data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTQiIGhlaWdodD0iMTQiIHZpZXdCb3g9IjAgMCAxNCAxNCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggY2xhc3M9ImpwLWljb24zIiBkPSJNMS41Mjg5OSA2LjQ3MTAxQzEuMjM2ODQgNi43NjMxNiAxLjIzNjg0IDcuMjM2ODQgMS41Mjg5OSA3LjUyODk5VjcuNTI4OTlDMS44MjA5NSA3LjgyMDk1IDIuMjk0MjYgNy44MjExNiAyLjU4NjQ5IDcuNTI5NDZMNi4yNSAzLjg3MjVWMTIuMjVDNi4yNSAxMi42NjQyIDYuNTg1NzkgMTMgNyAxM1YxM0M3LjQxNDIxIDEzIDcuNzUgMTIuNjY0MiA3Ljc1IDEyLjI1VjMuODcyNUwxMS40MDI3IDcuNTMxNzhDMTEuNjk2NiA3LjgyNjE5IDEyLjE3MzYgNy44MjY0MSAxMi40Njc3IDcuNTMyMjZWNy41MzIyNkMxMi43NjE3IDcuMjM4MyAxMi43NjE3IDYuNzYxNyAxMi40Njc3IDYuNDY3NzRMNy43MDcxMSAxLjcwNzExQzcuMzE2NTggMS4zMTY1OCA2LjY4MzQyIDEuMzE2NTggNi4yOTI4OSAxLjcwNzExTDEuNTI4OTkgNi40NzEwMVoiIGZpbGw9IiM2MTYxNjEiLz4KPC9zdmc+Cg==);
   --jp-icon-new-folder: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgdmlld0JveD0iMCAwIDI0IDI0Ij4KICA8ZyBjbGFzcz0ianAtaWNvbjMiIGZpbGw9IiM2MTYxNjEiPgogICAgPHBhdGggZD0iTTIwIDZoLThsLTItMkg0Yy0xLjExIDAtMS45OS44OS0xLjk5IDJMMiAxOGMwIDEuMTEuODkgMiAyIDJoMTZjMS4xMSAwIDItLjg5IDItMlY4YzAtMS4xMS0uODktMi0yLTJ6bS0xIDhoLTN2M2gtMnYtM2gtM3YtMmgzVjloMnYzaDN2MnoiLz4KICA8L2c+Cjwvc3ZnPgo=);
   --jp-icon-not-trusted: url(data:image/svg+xml;base64,PHN2ZyBmaWxsPSJub25lIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgdmlld0JveD0iMCAwIDI1IDI1Ij4KICAgIDxwYXRoIGNsYXNzPSJqcC1pY29uMiIgc3Ryb2tlPSIjMzMzMzMzIiBzdHJva2Utd2lkdGg9IjIiIHRyYW5zZm9ybT0idHJhbnNsYXRlKDMgMykiIGQ9Ik0xLjg2MDk0IDExLjQ0MDlDMC44MjY0NDggOC43NzAyNyAwLjg2Mzc3OSA2LjA1NzY0IDEuMjQ5MDcgNC4xOTkzMkMyLjQ4MjA2IDMuOTMzNDcgNC4wODA2OCAzLjQwMzQ3IDUuNjAxMDIgMi44NDQ5QzcuMjM1NDkgMi4yNDQ0IDguODU2NjYgMS41ODE1IDkuOTg3NiAxLjA5NTM5QzExLjA1OTcgMS41ODM0MSAxMi42MDk0IDIuMjQ0NCAxNC4yMTggMi44NDMzOUMxNS43NTAzIDMuNDEzOTQgMTcuMzk5NSAzLjk1MjU4IDE4Ljc1MzkgNC4yMTM4NUMxOS4xMzY0IDYuMDcxNzcgMTkuMTcwOSA4Ljc3NzIyIDE4LjEzOSAxMS40NDA5QzE3LjAzMDMgMTQuMzAzMiAxNC42NjY4IDE3LjE4NDQgOS45OTk5OSAxOC45MzU0QzUuMzMzMTkgMTcuMTg0NCAyLjk2OTY4IDE0LjMwMzIgMS44NjA5NCAxMS40NDA5WiIvPgogICAgPHBhdGggY2xhc3M9ImpwLWljb24yIiBzdHJva2U9IiMzMzMzMzMiIHN0cm9rZS13aWR0aD0iMiIgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoOS4zMTU5MiA5LjMyMDMxKSIgZD0iTTcuMzY4NDIgMEwwIDcuMzY0NzkiLz4KICAgIDxwYXRoIGNsYXNzPSJqcC1pY29uMiIgc3Ryb2tlPSIjMzMzMzMzIiBzdHJva2Utd2lkdGg9IjIiIHRyYW5zZm9ybT0idHJhbnNsYXRlKDkuMzE1OTIgMTYuNjgzNikgc2NhbGUoMSAtMSkiIGQ9Ik03LjM2ODQyIDBMMCA3LjM2NDc5Ii8+Cjwvc3ZnPgo=);
-  --jp-icon-notebook: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgdmlld0JveD0iMCAwIDIyIDIyIj4KICA8ZyBjbGFzcz0ianAtaWNvbi13YXJuMCBqcC1pY29uLXNlbGVjdGFibGUiIGZpbGw9IiNFRjZDMDAiPgogICAgPHBhdGggZD0iTTE4LjcgMy4zdjE1LjRIMy4zVjMuM2gxNS40bTEuNS0xLjVIMS44djE4LjNoMTguM2wuMS0xOC4zeiIvPgogICAgPHBhdGggZD0iTTE2LjUgMTYuNWwtNS40LTQuMy01LjYgNC4zdi0xMWgxMXoiLz4KICA8L2c+Cjwvc3ZnPgo=);
+  --jp-icon-notebook: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgdmlld0JveD0iMCAwIDIyIDIyIj4KICA8ZyBjbGFzcz0ianAtbm90ZWJvb2staWNvbi1jb2xvciBqcC1pY29uLXNlbGVjdGFibGUiIGZpbGw9IiNFRjZDMDAiPgogICAgPHBhdGggZD0iTTE4LjcgMy4zdjE1LjRIMy4zVjMuM2gxNS40bTEuNS0xLjVIMS44djE4LjNoMTguM2wuMS0xOC4zeiIvPgogICAgPHBhdGggZD0iTTE2LjUgMTYuNWwtNS40LTQuMy01LjYgNC4zdi0xMWgxMXoiLz4KICA8L2c+Cjwvc3ZnPgo=);
   --jp-icon-numbering: url(data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjIiIGhlaWdodD0iMjIiIHZpZXdCb3g9IjAgMCAyOCAyOCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KCTxnIGNsYXNzPSJqcC1pY29uMyIgZmlsbD0iIzYxNjE2MSI+CgkJPHBhdGggZD0iTTQgMTlINlYxOS41SDVWMjAuNUg2VjIxSDRWMjJIN1YxOEg0VjE5Wk01IDEwSDZWNkg0VjdINVYxMFpNNCAxM0g1LjhMNCAxNS4xVjE2SDdWMTVINS4yTDcgMTIuOVYxMkg0VjEzWk05IDdWOUgyM1Y3SDlaTTkgMjFIMjNWMTlIOVYyMVpNOSAxNUgyM1YxM0g5VjE1WiIvPgoJPC9nPgo8L3N2Zz4K);
   --jp-icon-offline-bolt: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCIgd2lkdGg9IjE2Ij4KICA8ZyBjbGFzcz0ianAtaWNvbjMiIGZpbGw9IiM2MTYxNjEiPgogICAgPHBhdGggZD0iTTEyIDIuMDJjLTUuNTEgMC05Ljk4IDQuNDctOS45OCA5Ljk4czQuNDcgOS45OCA5Ljk4IDkuOTggOS45OC00LjQ3IDkuOTgtOS45OFMxNy41MSAyLjAyIDEyIDIuMDJ6TTExLjQ4IDIwdi02LjI2SDhMMTMgNHY2LjI2aDMuMzVMMTEuNDggMjB6Ii8+CiAgPC9nPgo8L3N2Zz4K);
   --jp-icon-palette: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgdmlld0JveD0iMCAwIDI0IDI0Ij4KICA8ZyBjbGFzcz0ianAtaWNvbjMiIGZpbGw9IiM2MTYxNjEiPgogICAgPHBhdGggZD0iTTE4IDEzVjIwSDRWNkg5LjAyQzkuMDcgNS4yOSA5LjI0IDQuNjIgOS41IDRINEMyLjkgNCAyIDQuOSAyIDZWMjBDMiAyMS4xIDIuOSAyMiA0IDIySDE4QzE5LjEgMjIgMjAgMjEuMSAyMCAyMFYxNUwxOCAxM1pNMTkuMyA4Ljg5QzE5Ljc0IDguMTkgMjAgNy4zOCAyMCA2LjVDMjAgNC4wMSAxNy45OSAyIDE1LjUgMkMxMy4wMSAyIDExIDQuMDEgMTEgNi41QzExIDguOTkgMTMuMDEgMTEgMTUuNDkgMTFDMTYuMzcgMTEgMTcuMTkgMTAuNzQgMTcuODggMTAuM0wyMSAxMy40MkwyMi40MiAxMkwxOS4zIDguODlaTTE1LjUgOUMxNC4xMiA5IDEzIDcuODggMTMgNi41QzEzIDUuMTIgMTQuMTIgNCAxNS41IDRDMTYuODggNCAxOCA1LjEyIDE4IDYuNUMxOCA3Ljg4IDE2Ljg4IDkgMTUuNSA5WiIvPgogICAgPHBhdGggZmlsbC1ydWxlPSJldmVub2RkIiBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGQ9Ik00IDZIOS4wMTg5NEM5LjAwNjM5IDYuMTY1MDIgOSA2LjMzMTc2IDkgNi41QzkgOC44MTU3NyAxMC4yMTEgMTAuODQ4NyAxMi4wMzQzIDEySDlWMTRIMTZWMTIuOTgxMUMxNi41NzAzIDEyLjkzNzcgMTcuMTIgMTIuODIwNyAxNy42Mzk2IDEyLjYzOTZMMTggMTNWMjBINFY2Wk04IDhINlYxMEg4VjhaTTYgMTJIOFYxNEg2VjEyWk04IDE2SDZWMThIOFYxNlpNOSAxNkgxNlYxOEg5VjE2WiIvPgogIDwvZz4KPC9zdmc+Cg==);
   --jp-icon-paste: url(data:image/svg+xml;base64,PHN2ZyBoZWlnaHQ9IjI0IiB2aWV3Qm94PSIwIDAgMjQgMjQiIHdpZHRoPSIyNCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KICAgIDxnIGNsYXNzPSJqcC1pY29uMyIgZmlsbD0iIzYxNjE2MSI+CiAgICAgICAgPHBhdGggZD0iTTE5IDJoLTQuMThDMTQuNC44NCAxMy4zIDAgMTIgMGMtMS4zIDAtMi40Ljg0LTIuODIgMkg1Yy0xLjEgMC0yIC45LTIgMnYxNmMwIDEuMS45IDIgMiAyaDE0YzEuMSAwIDItLjkgMi0yVjRjMC0xLjEtLjktMi0yLTJ6bS03IDBjLjU1IDAgMSAuNDUgMSAxcy0uNDUgMS0xIDEtMS0uNDUtMS0xIC40NS0xIDEtMXptNyAxOEg1VjRoMnYzaDEwVjRoMnYxNnoiLz4KICAgIDwvZz4KPC9zdmc+Cg==);
   --jp-icon-pdf: url(data:image/svg+xml;base64,PHN2ZwogICB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyMiAyMiIgd2lkdGg9IjE2Ij4KICAgIDxwYXRoIHRyYW5zZm9ybT0icm90YXRlKDQ1KSIgY2xhc3M9ImpwLWljb24tc2VsZWN0YWJsZSIgZmlsbD0iI0ZGMkEyQSIKICAgICAgIGQ9Im0gMjIuMzQ0MzY5LC0zLjAxNjM2NDIgaCA1LjYzODYwNCB2IDEuNTc5MjQzMyBoIC0zLjU0OTIyNyB2IDEuNTA4NjkyOTkgaCAzLjMzNzU3NiBWIDEuNjUwODE1NCBoIC0zLjMzNzU3NiB2IDMuNDM1MjYxMyBoIC0yLjA4OTM3NyB6IG0gLTcuMTM2NDQ0LDEuNTc5MjQzMyB2IDQuOTQzOTU0MyBoIDAuNzQ4OTIgcSAxLjI4MDc2MSwwIDEuOTUzNzAzLC0wLjYzNDk1MzUgMC42NzgzNjksLTAuNjM0OTUzNSAwLjY3ODM2OSwtMS44NDUxNjQxIDAsLTEuMjA0NzgzNTUgLTAuNjcyOTQyLC0xLjgzNDMxMDExIC0wLjY3Mjk0MiwtMC42Mjk1MjY1OSAtMS45NTkxMywtMC42Mjk1MjY1OSB6IG0gLTIuMDg5Mzc3LC0xLjU3OTI0MzMgaCAyLjIwMzM0MyBxIDEuODQ1MTY0LDAgMi43NDYwMzksMC4yNjU5MjA3IDAuOTA2MzAxLDAuMjYwNDkzNyAxLjU1MjEwOCwwLjg5MDAyMDMgMC41Njk4MywwLjU0ODEyMjMgMC44NDY2MDUsMS4yNjQ0ODAwNiAwLjI3Njc3NCwwLjcxNjM1NzgxIDAuMjc2Nzc0LDEuNjIyNjU4OTQgMCwwLjkxNzE1NTEgLTAuMjc2Nzc0LDEuNjM4OTM5OSAtMC4yNzY3NzUsMC43MTYzNTc4IC0wLjg0NjYwNSwxLjI2NDQ4IC0wLjY1MTIzNCwwLjYyOTUyNjYgLTEuNTYyOTYyLDAuODk1NDQ3MyAtMC45MTE3MjgsMC4yNjA0OTM3IC0yLjczNTE4NSwwLjI2MDQ5MzcgaCAtMi4yMDMzNDMgeiBtIC04LjE0NTg1NjUsMCBoIDMuNDY3ODIzIHEgMS41NDY2ODE2LDAgMi4zNzE1Nzg1LDAuNjg5MjIzIDAuODMwMzI0LDAuNjgzNzk2MSAwLjgzMDMyNCwxLjk1MzcwMzE0IDAsMS4yNzUzMzM5NyAtMC44MzAzMjQsMS45NjQ1NTcwNiBRIDkuOTg3MTk2MSwyLjI3NDkxNSA4LjQ0MDUxNDUsMi4yNzQ5MTUgSCA3LjA2MjA2ODQgViA1LjA4NjA3NjcgSCA0Ljk3MjY5MTUgWiBtIDIuMDg5Mzc2OSwxLjUxNDExOTkgdiAyLjI2MzAzOTQzIGggMS4xNTU5NDEgcSAwLjYwNzgxODgsMCAwLjkzODg2MjksLTAuMjkzMDU1NDcgMC4zMzEwNDQxLC0wLjI5ODQ4MjQxIDAuMzMxMDQ0MSwtMC44NDExNzc3MiAwLC0wLjU0MjY5NTMxIC0wLjMzMTA0NDEsLTAuODM1NzUwNzQgLTAuMzMxMDQ0MSwtMC4yOTMwNTU1IC0wLjkzODg2MjksLTAuMjkzMDU1NSB6IgovPgo8L3N2Zz4K);
-  --jp-icon-python: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgdmlld0JveD0iMCAwIDIyIDIyIj4KICA8ZyBjbGFzcz0ianAtaWNvbi1icmFuZDAganAtaWNvbi1zZWxlY3RhYmxlIiBmaWxsPSIjMEQ0N0ExIj4KICAgIDxwYXRoIGQ9Ik0xMS4xIDYuOVY1LjhINi45YzAtLjUgMC0xLjMuMi0xLjYuNC0uNy44LTEuMSAxLjctMS40IDEuNy0uMyAyLjUtLjMgMy45LS4xIDEgLjEgMS45LjkgMS45IDEuOXY0LjJjMCAuNS0uOSAxLjYtMiAxLjZIOC44Yy0xLjUgMC0yLjQgMS40LTIuNCAyLjh2Mi4ySDQuN0MzLjUgMTUuMSAzIDE0IDMgMTMuMVY5Yy0uMS0xIC42LTIgMS44LTIgMS41LS4xIDYuMy0uMSA2LjMtLjF6Ii8+CiAgICA8cGF0aCBkPSJNMTAuOSAxNS4xdjEuMWg0LjJjMCAuNSAwIDEuMy0uMiAxLjYtLjQuNy0uOCAxLjEtMS43IDEuNC0xLjcuMy0yLjUuMy0zLjkuMS0xLS4xLTEuOS0uOS0xLjktMS45di00LjJjMC0uNS45LTEuNiAyLTEuNmgzLjhjMS41IDAgMi40LTEuNCAyLjQtMi44VjYuNmgxLjdDMTguNSA2LjkgMTkgOCAxOSA4LjlWMTNjMCAxLS43IDIuMS0xLjkgMi4xaC02LjJ6Ii8+CiAgPC9nPgo8L3N2Zz4K);
+  --jp-icon-python: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgdmlld0JveD0iLTEwIC0xMCAxMzEuMTYxMzYxNjk0MzM1OTQgMTMyLjM4ODk5OTkzODk2NDg0Ij4KICA8cGF0aCBjbGFzcz0ianAtaWNvbi1zZWxlY3RhYmxlIiBmaWxsPSIjMzA2OTk4IiBkPSJNIDU0LjkxODc4NSw5LjE5Mjc0MjFlLTQgQyA1MC4zMzUxMzIsMC4wMjIyMTcyNyA0NS45NTc4NDYsMC40MTMxMzY5NyA0Mi4xMDYyODUsMS4wOTQ2NjkzIDMwLjc2MDA2OSwzLjA5OTE3MzEgMjguNzAwMDM2LDcuMjk0NzcxNCAyOC43MDAwMzUsMTUuMDMyMTY5IHYgMTAuMjE4NzUgaCAyNi44MTI1IHYgMy40MDYyNSBoIC0yNi44MTI1IC0xMC4wNjI1IGMgLTcuNzkyNDU5LDAgLTE0LjYxNTc1ODgsNC42ODM3MTcgLTE2Ljc0OTk5OTgsMTMuNTkzNzUgLTIuNDYxODE5OTgsMTAuMjEyOTY2IC0yLjU3MTAxNTA4LDE2LjU4NjAyMyAwLDI3LjI1IDEuOTA1OTI4Myw3LjkzNzg1MiA2LjQ1NzU0MzIsMTMuNTkzNzQ4IDE0LjI0OTk5OTgsMTMuNTkzNzUgaCA5LjIxODc1IHYgLTEyLjI1IGMgMCwtOC44NDk5MDIgNy42NTcxNDQsLTE2LjY1NjI0OCAxNi43NSwtMTYuNjU2MjUgaCAyNi43ODEyNSBjIDcuNDU0OTUxLDAgMTMuNDA2MjUzLC02LjEzODE2NCAxMy40MDYyNSwtMTMuNjI1IHYgLTI1LjUzMTI1IGMgMCwtNy4yNjYzMzg2IC02LjEyOTk4LC0xMi43MjQ3NzcxIC0xMy40MDYyNSwtMTMuOTM3NDk5NyBDIDY0LjI4MTU0OCwwLjMyNzk0Mzk3IDU5LjUwMjQzOCwtMC4wMjAzNzkwMyA1NC45MTg3ODUsOS4xOTI3NDIxZS00IFogbSAtMTQuNSw4LjIxODc1MDEyNTc5IGMgMi43Njk1NDcsMCA1LjAzMTI1LDIuMjk4NjQ1NiA1LjAzMTI1LDUuMTI0OTk5NiAtMmUtNiwyLjgxNjMzNiAtMi4yNjE3MDMsNS4wOTM3NSAtNS4wMzEyNSw1LjA5Mzc1IC0yLjc3OTQ3NiwtMWUtNiAtNS4wMzEyNSwtMi4yNzc0MTUgLTUuMDMxMjUsLTUuMDkzNzUgLTEwZS03LC0yLjgyNjM1MyAyLjI1MTc3NCwtNS4xMjQ5OTk2IDUuMDMxMjUsLTUuMTI0OTk5NiB6Ii8+CiAgPHBhdGggY2xhc3M9ImpwLWljb24tc2VsZWN0YWJsZSIgZmlsbD0iI2ZmZDQzYiIgZD0ibSA4NS42Mzc1MzUsMjguNjU3MTY5IHYgMTEuOTA2MjUgYyAwLDkuMjMwNzU1IC03LjgyNTg5NSwxNi45OTk5OTkgLTE2Ljc1LDE3IGggLTI2Ljc4MTI1IGMgLTcuMzM1ODMzLDAgLTEzLjQwNjI0OSw2LjI3ODQ4MyAtMTMuNDA2MjUsMTMuNjI1IHYgMjUuNTMxMjQ3IGMgMCw3LjI2NjM0NCA2LjMxODU4OCwxMS41NDAzMjQgMTMuNDA2MjUsMTMuNjI1MDA0IDguNDg3MzMxLDIuNDk1NjEgMTYuNjI2MjM3LDIuOTQ2NjMgMjYuNzgxMjUsMCA2Ljc1MDE1NSwtMS45NTQzOSAxMy40MDYyNTMsLTUuODg3NjEgMTMuNDA2MjUsLTEzLjYyNTAwNCBWIDg2LjUwMDkxOSBoIC0yNi43ODEyNSB2IC0zLjQwNjI1IGggMjYuNzgxMjUgMTMuNDA2MjU0IGMgNy43OTI0NjEsMCAxMC42OTYyNTEsLTUuNDM1NDA4IDEzLjQwNjI0MSwtMTMuNTkzNzUgMi43OTkzMywtOC4zOTg4ODYgMi42ODAyMiwtMTYuNDc1Nzc2IDAsLTI3LjI1IC0xLjkyNTc4LC03Ljc1NzQ0MSAtNS42MDM4NywtMTMuNTkzNzUgLTEzLjQwNjI0MSwtMTMuNTkzNzUgeiBtIC0xNS4wNjI1LDY0LjY1NjI1IGMgMi43Nzk0NzgsM2UtNiA1LjAzMTI1LDIuMjc3NDE3IDUuMDMxMjUsNS4wOTM3NDcgLTJlLTYsMi44MjYzNTQgLTIuMjUxNzc1LDUuMTI1MDA0IC01LjAzMTI1LDUuMTI1MDA0IC0yLjc2OTU1LDAgLTUuMDMxMjUsLTIuMjk4NjUgLTUuMDMxMjUsLTUuMTI1MDA0IDJlLTYsLTIuODE2MzMgMi4yNjE2OTcsLTUuMDkzNzQ3IDUuMDMxMjUsLTUuMDkzNzQ3IHoiLz4KPC9zdmc+Cg==);
   --jp-icon-r-kernel: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgdmlld0JveD0iMCAwIDIyIDIyIj4KICA8cGF0aCBjbGFzcz0ianAtaWNvbi1jb250cmFzdDMganAtaWNvbi1zZWxlY3RhYmxlIiBmaWxsPSIjMjE5NkYzIiBkPSJNNC40IDIuNWMxLjItLjEgMi45LS4zIDQuOS0uMyAyLjUgMCA0LjEuNCA1LjIgMS4zIDEgLjcgMS41IDEuOSAxLjUgMy41IDAgMi0xLjQgMy41LTIuOSA0LjEgMS4yLjQgMS43IDEuNiAyLjIgMyAuNiAxLjkgMSAzLjkgMS4zIDQuNmgtMy44Yy0uMy0uNC0uOC0xLjctMS4yLTMuN3MtMS4yLTIuNi0yLjYtMi42aC0uOXY2LjRINC40VjIuNXptMy43IDYuOWgxLjRjMS45IDAgMi45LS45IDIuOS0yLjNzLTEtMi4zLTIuOC0yLjNjLS43IDAtMS4zIDAtMS42LjJ2NC41aC4xdi0uMXoiLz4KPC9zdmc+Cg==);
   --jp-icon-react: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgdmlld0JveD0iMTUwIDE1MCA1NDEuOSAyOTUuMyI+CiAgPGcgY2xhc3M9ImpwLWljb24tYnJhbmQyIGpwLWljb24tc2VsZWN0YWJsZSIgZmlsbD0iIzYxREFGQiI+CiAgICA8cGF0aCBkPSJNNjY2LjMgMjk2LjVjMC0zMi41LTQwLjctNjMuMy0xMDMuMS04Mi40IDE0LjQtNjMuNiA4LTExNC4yLTIwLjItMTMwLjQtNi41LTMuOC0xNC4xLTUuNi0yMi40LTUuNnYyMi4zYzQuNiAwIDguMy45IDExLjQgMi42IDEzLjYgNy44IDE5LjUgMzcuNSAxNC45IDc1LjctMS4xIDkuNC0yLjkgMTkuMy01LjEgMjkuNC0xOS42LTQuOC00MS04LjUtNjMuNS0xMC45LTEzLjUtMTguNS0yNy41LTM1LjMtNDEuNi01MCAzMi42LTMwLjMgNjMuMi00Ni45IDg0LTQ2LjlWNzhjLTI3LjUgMC02My41IDE5LjYtOTkuOSA1My42LTM2LjQtMzMuOC03Mi40LTUzLjItOTkuOS01My4ydjIyLjNjMjAuNyAwIDUxLjQgMTYuNSA4NCA0Ni42LTE0IDE0LjctMjggMzEuNC00MS4zIDQ5LjktMjIuNiAyLjQtNDQgNi4xLTYzLjYgMTEtMi4zLTEwLTQtMTkuNy01LjItMjktNC43LTM4LjIgMS4xLTY3LjkgMTQuNi03NS44IDMtMS44IDYuOS0yLjYgMTEuNS0yLjZWNzguNWMtOC40IDAtMTYgMS44LTIyLjYgNS42LTI4LjEgMTYuMi0zNC40IDY2LjctMTkuOSAxMzAuMS02Mi4yIDE5LjItMTAyLjcgNDkuOS0xMDIuNyA4Mi4zIDAgMzIuNSA0MC43IDYzLjMgMTAzLjEgODIuNC0xNC40IDYzLjYtOCAxMTQuMiAyMC4yIDEzMC40IDYuNSAzLjggMTQuMSA1LjYgMjIuNSA1LjYgMjcuNSAwIDYzLjUtMTkuNiA5OS45LTUzLjYgMzYuNCAzMy44IDcyLjQgNTMuMiA5OS45IDUzLjIgOC40IDAgMTYtMS44IDIyLjYtNS42IDI4LjEtMTYuMiAzNC40LTY2LjcgMTkuOS0xMzAuMSA2Mi0xOS4xIDEwMi41LTQ5LjkgMTAyLjUtODIuM3ptLTEzMC4yLTY2LjdjLTMuNyAxMi45LTguMyAyNi4yLTEzLjUgMzkuNS00LjEtOC04LjQtMTYtMTMuMS0yNC00LjYtOC05LjUtMTUuOC0xNC40LTIzLjQgMTQuMiAyLjEgMjcuOSA0LjcgNDEgNy45em0tNDUuOCAxMDYuNWMtNy44IDEzLjUtMTUuOCAyNi4zLTI0LjEgMzguMi0xNC45IDEuMy0zMCAyLTQ1LjIgMi0xNS4xIDAtMzAuMi0uNy00NS0xLjktOC4zLTExLjktMTYuNC0yNC42LTI0LjItMzgtNy42LTEzLjEtMTQuNS0yNi40LTIwLjgtMzkuOCA2LjItMTMuNCAxMy4yLTI2LjggMjAuNy0zOS45IDcuOC0xMy41IDE1LjgtMjYuMyAyNC4xLTM4LjIgMTQuOS0xLjMgMzAtMiA0NS4yLTIgMTUuMSAwIDMwLjIuNyA0NSAxLjkgOC4zIDExLjkgMTYuNCAyNC42IDI0LjIgMzggNy42IDEzLjEgMTQuNSAyNi40IDIwLjggMzkuOC02LjMgMTMuNC0xMy4yIDI2LjgtMjAuNyAzOS45em0zMi4zLTEzYzUuNCAxMy40IDEwIDI2LjggMTMuOCAzOS44LTEzLjEgMy4yLTI2LjkgNS45LTQxLjIgOCA0LjktNy43IDkuOC0xNS42IDE0LjQtMjMuNyA0LjYtOCA4LjktMTYuMSAxMy0yNC4xek00MjEuMiA0MzBjLTkuMy05LjYtMTguNi0yMC4zLTI3LjgtMzIgOSAuNCAxOC4yLjcgMjcuNS43IDkuNCAwIDE4LjctLjIgMjcuOC0uNy05IDExLjctMTguMyAyMi40LTI3LjUgMzJ6bS03NC40LTU4LjljLTE0LjItMi4xLTI3LjktNC43LTQxLTcuOSAzLjctMTIuOSA4LjMtMjYuMiAxMy41LTM5LjUgNC4xIDggOC40IDE2IDEzLjEgMjQgNC43IDggOS41IDE1LjggMTQuNCAyMy40ek00MjAuNyAxNjNjOS4zIDkuNiAxOC42IDIwLjMgMjcuOCAzMi05LS40LTE4LjItLjctMjcuNS0uNy05LjQgMC0xOC43LjItMjcuOC43IDktMTEuNyAxOC4zLTIyLjQgMjcuNS0zMnptLTc0IDU4LjljLTQuOSA3LjctOS44IDE1LjYtMTQuNCAyMy43LTQuNiA4LTguOSAxNi0xMyAyNC01LjQtMTMuNC0xMC0yNi44LTEzLjgtMzkuOCAxMy4xLTMuMSAyNi45LTUuOCA0MS4yLTcuOXptLTkwLjUgMTI1LjJjLTM1LjQtMTUuMS01OC4zLTM0LjktNTguMy01MC42IDAtMTUuNyAyMi45LTM1LjYgNTguMy01MC42IDguNi0zLjcgMTgtNyAyNy43LTEwLjEgNS43IDE5LjYgMTMuMiA0MCAyMi41IDYwLjktOS4yIDIwLjgtMTYuNiA0MS4xLTIyLjIgNjAuNi05LjktMy4xLTE5LjMtNi41LTI4LTEwLjJ6TTMxMCA0OTBjLTEzLjYtNy44LTE5LjUtMzcuNS0xNC45LTc1LjcgMS4xLTkuNCAyLjktMTkuMyA1LjEtMjkuNCAxOS42IDQuOCA0MSA4LjUgNjMuNSAxMC45IDEzLjUgMTguNSAyNy41IDM1LjMgNDEuNiA1MC0zMi42IDMwLjMtNjMuMiA0Ni45LTg0IDQ2LjktNC41LS4xLTguMy0xLTExLjMtMi43em0yMzcuMi03Ni4yYzQuNyAzOC4yLTEuMSA2Ny45LTE0LjYgNzUuOC0zIDEuOC02LjkgMi42LTExLjUgMi42LTIwLjcgMC01MS40LTE2LjUtODQtNDYuNiAxNC0xNC43IDI4LTMxLjQgNDEuMy00OS45IDIyLjYtMi40IDQ0LTYuMSA2My42LTExIDIuMyAxMC4xIDQuMSAxOS44IDUuMiAyOS4xem0zOC41LTY2LjdjLTguNiAzLjctMTggNy0yNy43IDEwLjEtNS43LTE5LjYtMTMuMi00MC0yMi41LTYwLjkgOS4yLTIwLjggMTYuNi00MS4xIDIyLjItNjAuNiA5LjkgMy4xIDE5LjMgNi41IDI4LjEgMTAuMiAzNS40IDE1LjEgNTguMyAzNC45IDU4LjMgNTAuNi0uMSAxNS43LTIzIDM1LjYtNTguNCA1MC42ek0zMjAuOCA3OC40eiIvPgogICAgPGNpcmNsZSBjeD0iNDIwLjkiIGN5PSIyOTYuNSIgcj0iNDUuNyIvPgogIDwvZz4KPC9zdmc+Cg==);
   --jp-icon-redo: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGhlaWdodD0iMjQiIHZpZXdCb3g9IjAgMCAyNCAyNCIgd2lkdGg9IjE2Ij4KICA8ZyBjbGFzcz0ianAtaWNvbjMiIGZpbGw9IiM2MTYxNjEiPgogICAgICA8cGF0aCBkPSJNMCAwaDI0djI0SDB6IiBmaWxsPSJub25lIi8+PHBhdGggZD0iTTE4LjQgMTAuNkMxNi41NSA4Ljk5IDE0LjE1IDggMTEuNSA4Yy00LjY1IDAtOC41OCAzLjAzLTkuOTYgNy4yMkwzLjkgMTZjMS4wNS0zLjE5IDQuMDUtNS41IDcuNi01LjUgMS45NSAwIDMuNzMuNzIgNS4xMiAxLjg4TDEzIDE2aDlWN2wtMy42IDMuNnoiLz4KICA8L2c+Cjwvc3ZnPgo=);
@@ -9429,25 +9427,40 @@ span.bp3-popover-target{
   --jp-icon-save: url(data:image/svg+xml;base64,PHN2ZyBoZWlnaHQ9IjI0IiB2aWV3Qm94PSIwIDAgMjQgMjQiIHdpZHRoPSIyNCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KICAgIDxnIGNsYXNzPSJqcC1pY29uMyIgZmlsbD0iIzYxNjE2MSI+CiAgICAgICAgPHBhdGggZD0iTTE3IDNINWMtMS4xMSAwLTIgLjktMiAydjE0YzAgMS4xLjg5IDIgMiAyaDE0YzEuMSAwIDItLjkgMi0yVjdsLTQtNHptLTUgMTZjLTEuNjYgMC0zLTEuMzQtMy0zczEuMzQtMyAzLTMgMyAxLjM0IDMgMy0xLjM0IDMtMyAzem0zLTEwSDVWNWgxMHY0eiIvPgogICAgPC9nPgo8L3N2Zz4K);
   --jp-icon-search: url(data:image/svg+xml;base64,PHN2ZyB2aWV3Qm94PSIwIDAgMTggMTgiIHdpZHRoPSIxNiIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KICA8ZyBjbGFzcz0ianAtaWNvbjMiIGZpbGw9IiM2MTYxNjEiPgogICAgPHBhdGggZD0iTTEyLjEsMTAuOWgtMC43bC0wLjItMC4yYzAuOC0wLjksMS4zLTIuMiwxLjMtMy41YzAtMy0yLjQtNS40LTUuNC01LjRTMS44LDQuMiwxLjgsNy4xczIuNCw1LjQsNS40LDUuNCBjMS4zLDAsMi41LTAuNSwzLjUtMS4zbDAuMiwwLjJ2MC43bDQuMSw0LjFsMS4yLTEuMkwxMi4xLDEwLjl6IE03LjEsMTAuOWMtMi4xLDAtMy43LTEuNy0zLjctMy43czEuNy0zLjcsMy43LTMuN3MzLjcsMS43LDMuNywzLjcgUzkuMiwxMC45LDcuMSwxMC45eiIvPgogIDwvZz4KPC9zdmc+Cg==);
   --jp-icon-settings: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgdmlld0JveD0iMCAwIDI0IDI0Ij4KICA8cGF0aCBjbGFzcz0ianAtaWNvbjMganAtaWNvbi1zZWxlY3RhYmxlIiBmaWxsPSIjNjE2MTYxIiBkPSJNMTkuNDMgMTIuOThjLjA0LS4zMi4wNy0uNjQuMDctLjk4cy0uMDMtLjY2LS4wNy0uOThsMi4xMS0xLjY1Yy4xOS0uMTUuMjQtLjQyLjEyLS42NGwtMi0zLjQ2Yy0uMTItLjIyLS4zOS0uMy0uNjEtLjIybC0yLjQ5IDFjLS41Mi0uNC0xLjA4LS43My0xLjY5LS45OGwtLjM4LTIuNjVBLjQ4OC40ODggMCAwMDE0IDJoLTRjLS4yNSAwLS40Ni4xOC0uNDkuNDJsLS4zOCAyLjY1Yy0uNjEuMjUtMS4xNy41OS0xLjY5Ljk4bC0yLjQ5LTFjLS4yMy0uMDktLjQ5IDAtLjYxLjIybC0yIDMuNDZjLS4xMy4yMi0uMDcuNDkuMTIuNjRsMi4xMSAxLjY1Yy0uMDQuMzItLjA3LjY1LS4wNy45OHMuMDMuNjYuMDcuOThsLTIuMTEgMS42NWMtLjE5LjE1LS4yNC40Mi0uMTIuNjRsMiAzLjQ2Yy4xMi4yMi4zOS4zLjYxLjIybDIuNDktMWMuNTIuNCAxLjA4LjczIDEuNjkuOThsLjM4IDIuNjVjLjAzLjI0LjI0LjQyLjQ5LjQyaDRjLjI1IDAgLjQ2LS4xOC40OS0uNDJsLjM4LTIuNjVjLjYxLS4yNSAxLjE3LS41OSAxLjY5LS45OGwyLjQ5IDFjLjIzLjA5LjQ5IDAgLjYxLS4yMmwyLTMuNDZjLjEyLS4yMi4wNy0uNDktLjEyLS42NGwtMi4xMS0xLjY1ek0xMiAxNS41Yy0xLjkzIDAtMy41LTEuNTctMy41LTMuNXMxLjU3LTMuNSAzLjUtMy41IDMuNSAxLjU3IDMuNSAzLjUtMS41NyAzLjUtMy41IDMuNXoiLz4KPC9zdmc+Cg==);
+  --jp-icon-share: url(data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTYiIHZpZXdCb3g9IjAgMCAyNCAyNCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KICA8ZyBjbGFzcz0ianAtaWNvbjMiIGZpbGw9IiM2MTYxNjEiPgogICAgPHBhdGggZD0iTSAxOCAyIEMgMTYuMzU0OTkgMiAxNSAzLjM1NDk5MDQgMTUgNSBDIDE1IDUuMTkwOTUyOSAxNS4wMjE3OTEgNS4zNzcxMjI0IDE1LjA1NjY0MSA1LjU1ODU5MzggTCA3LjkyMTg3NSA5LjcyMDcwMzEgQyA3LjM5ODUzOTkgOS4yNzc4NTM5IDYuNzMyMDc3MSA5IDYgOSBDIDQuMzU0OTkwNCA5IDMgMTAuMzU0OTkgMyAxMiBDIDMgMTMuNjQ1MDEgNC4zNTQ5OTA0IDE1IDYgMTUgQyA2LjczMjA3NzEgMTUgNy4zOTg1Mzk5IDE0LjcyMjE0NiA3LjkyMTg3NSAxNC4yNzkyOTcgTCAxNS4wNTY2NDEgMTguNDM5NDUzIEMgMTUuMDIxNTU1IDE4LjYyMTUxNCAxNSAxOC44MDgzODYgMTUgMTkgQyAxNSAyMC42NDUwMSAxNi4zNTQ5OSAyMiAxOCAyMiBDIDE5LjY0NTAxIDIyIDIxIDIwLjY0NTAxIDIxIDE5IEMgMjEgMTcuMzU0OTkgMTkuNjQ1MDEgMTYgMTggMTYgQyAxNy4yNjc0OCAxNiAxNi42MDE1OTMgMTYuMjc5MzI4IDE2LjA3ODEyNSAxNi43MjI2NTYgTCA4Ljk0MzM1OTQgMTIuNTU4NTk0IEMgOC45NzgyMDk1IDEyLjM3NzEyMiA5IDEyLjE5MDk1MyA5IDEyIEMgOSAxMS44MDkwNDcgOC45NzgyMDk1IDExLjYyMjg3OCA4Ljk0MzM1OTQgMTEuNDQxNDA2IEwgMTYuMDc4MTI1IDcuMjc5Mjk2OSBDIDE2LjYwMTQ2IDcuNzIyMTQ2MSAxNy4yNjc5MjMgOCAxOCA4IEMgMTkuNjQ1MDEgOCAyMSA2LjY0NTAwOTYgMjEgNSBDIDIxIDMuMzU0OTkwNCAxOS42NDUwMSAyIDE4IDIgeiBNIDE4IDQgQyAxOC41NjQxMjkgNCAxOSA0LjQzNTg3MDYgMTkgNSBDIDE5IDUuNTY0MTI5NCAxOC41NjQxMjkgNiAxOCA2IEMgMTcuNDM1ODcxIDYgMTcgNS41NjQxMjk0IDE3IDUgQyAxNyA0LjQzNTg3MDYgMTcuNDM1ODcxIDQgMTggNCB6IE0gNiAxMSBDIDYuNTY0MTI5NCAxMSA3IDExLjQzNTg3MSA3IDEyIEMgNyAxMi41NjQxMjkgNi41NjQxMjk0IDEzIDYgMTMgQyA1LjQzNTg3MDYgMTMgNSAxMi41NjQxMjkgNSAxMiBDIDUgMTEuNDM1ODcxIDUuNDM1ODcwNiAxMSA2IDExIHogTSAxOCAxOCBDIDE4LjU2NDEyOSAxOCAxOSAxOC40MzU4NzEgMTkgMTkgQyAxOSAxOS41NjQxMjkgMTguNTY0MTI5IDIwIDE4IDIwIEMgMTcuNDM1ODcxIDIwIDE3IDE5LjU2NDEyOSAxNyAxOSBDIDE3IDE4LjQzNTg3MSAxNy40MzU4NzEgMTggMTggMTggeiIvPgogIDwvZz4KPC9zdmc+Cg==);
   --jp-icon-spreadsheet: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgdmlld0JveD0iMCAwIDIyIDIyIj4KICA8cGF0aCBjbGFzcz0ianAtaWNvbi1jb250cmFzdDEganAtaWNvbi1zZWxlY3RhYmxlIiBmaWxsPSIjNENBRjUwIiBkPSJNMi4yIDIuMnYxNy42aDE3LjZWMi4ySDIuMnptMTUuNCA3LjdoLTUuNVY0LjRoNS41djUuNXpNOS45IDQuNHY1LjVINC40VjQuNGg1LjV6bS01LjUgNy43aDUuNXY1LjVINC40di01LjV6bTcuNyA1LjV2LTUuNWg1LjV2NS41aC01LjV6Ii8+Cjwvc3ZnPgo=);
   --jp-icon-stop: url(data:image/svg+xml;base64,PHN2ZyBoZWlnaHQ9IjI0IiB2aWV3Qm94PSIwIDAgMjQgMjQiIHdpZHRoPSIyNCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KICAgIDxnIGNsYXNzPSJqcC1pY29uMyIgZmlsbD0iIzYxNjE2MSI+CiAgICAgICAgPHBhdGggZD0iTTAgMGgyNHYyNEgweiIgZmlsbD0ibm9uZSIvPgogICAgICAgIDxwYXRoIGQ9Ik02IDZoMTJ2MTJINnoiLz4KICAgIDwvZz4KPC9zdmc+Cg==);
   --jp-icon-tab: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgdmlld0JveD0iMCAwIDI0IDI0Ij4KICA8ZyBjbGFzcz0ianAtaWNvbjMiIGZpbGw9IiM2MTYxNjEiPgogICAgPHBhdGggZD0iTTIxIDNIM2MtMS4xIDAtMiAuOS0yIDJ2MTRjMCAxLjEuOSAyIDIgMmgxOGMxLjEgMCAyLS45IDItMlY1YzAtMS4xLS45LTItMi0yem0wIDE2SDNWNWgxMHY0aDh2MTB6Ii8+CiAgPC9nPgo8L3N2Zz4K);
   --jp-icon-table-rows: url(data:image/svg+xml;base64,PHN2ZyBoZWlnaHQ9IjI0IiB2aWV3Qm94PSIwIDAgMjQgMjQiIHdpZHRoPSIyNCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KICAgIDxnIGNsYXNzPSJqcC1pY29uMyIgZmlsbD0iIzYxNjE2MSI+CiAgICAgICAgPHBhdGggZD0iTTAgMGgyNHYyNEgweiIgZmlsbD0ibm9uZSIvPgogICAgICAgIDxwYXRoIGQ9Ik0yMSw4SDNWNGgxOFY4eiBNMjEsMTBIM3Y0aDE4VjEweiBNMjEsMTZIM3Y0aDE4VjE2eiIvPgogICAgPC9nPgo8L3N2Zz4=);
   --jp-icon-tag: url(data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjgiIGhlaWdodD0iMjgiIHZpZXdCb3g9IjAgMCA0MyAyOCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KCTxnIGNsYXNzPSJqcC1pY29uMyIgZmlsbD0iIzYxNjE2MSI+CgkJPHBhdGggZD0iTTI4LjgzMzIgMTIuMzM0TDMyLjk5OTggMTYuNTAwN0wzNy4xNjY1IDEyLjMzNEgyOC44MzMyWiIvPgoJCTxwYXRoIGQ9Ik0xNi4yMDk1IDIxLjYxMDRDMTUuNjg3MyAyMi4xMjk5IDE0Ljg0NDMgMjIuMTI5OSAxNC4zMjQ4IDIxLjYxMDRMNi45ODI5IDE0LjcyNDVDNi41NzI0IDE0LjMzOTQgNi4wODMxMyAxMy42MDk4IDYuMDQ3ODYgMTMuMDQ4MkM1Ljk1MzQ3IDExLjUyODggNi4wMjAwMiA4LjYxOTQ0IDYuMDY2MjEgNy4wNzY5NUM2LjA4MjgxIDYuNTE0NzcgNi41NTU0OCA2LjA0MzQ3IDcuMTE4MDQgNi4wMzA1NUM5LjA4ODYzIDUuOTg0NzMgMTMuMjYzOCA1LjkzNTc5IDEzLjY1MTggNi4zMjQyNUwyMS43MzY5IDEzLjYzOUMyMi4yNTYgMTQuMTU4NSAyMS43ODUxIDE1LjQ3MjQgMjEuMjYyIDE1Ljk5NDZMMTYuMjA5NSAyMS42MTA0Wk05Ljc3NTg1IDguMjY1QzkuMzM1NTEgNy44MjU2NiA4LjYyMzUxIDcuODI1NjYgOC4xODI4IDguMjY1QzcuNzQzNDYgOC43MDU3MSA3Ljc0MzQ2IDkuNDE3MzMgOC4xODI4IDkuODU2NjdDOC42MjM4MiAxMC4yOTY0IDkuMzM1ODIgMTAuMjk2NCA5Ljc3NTg1IDkuODU2NjdDMTAuMjE1NiA5LjQxNzMzIDEwLjIxNTYgOC43MDUzMyA5Ljc3NTg1IDguMjY1WiIvPgoJPC9nPgo8L3N2Zz4K);
-  --jp-icon-terminal: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgdmlld0JveD0iMCAwIDI0IDI0IiA+CiAgICA8cmVjdCBjbGFzcz0ianAtaWNvbjIganAtaWNvbi1zZWxlY3RhYmxlIiB3aWR0aD0iMjAiIGhlaWdodD0iMjAiIHRyYW5zZm9ybT0idHJhbnNsYXRlKDIgMikiIGZpbGw9IiMzMzMzMzMiLz4KICAgIDxwYXRoIGNsYXNzPSJqcC1pY29uLWFjY2VudDIganAtaWNvbi1zZWxlY3RhYmxlLWludmVyc2UiIGQ9Ik01LjA1NjY0IDguNzYxNzJDNS4wNTY2NCA4LjU5NzY2IDUuMDMxMjUgOC40NTMxMiA0Ljk4MDQ3IDguMzI4MTJDNC45MzM1OSA4LjE5OTIyIDQuODU1NDcgOC4wODIwMyA0Ljc0NjA5IDcuOTc2NTZDNC42NDA2MiA3Ljg3MTA5IDQuNSA3Ljc3NTM5IDQuMzI0MjIgNy42ODk0NUM0LjE1MjM0IDcuNTk5NjEgMy45NDMzNiA3LjUxMTcyIDMuNjk3MjcgNy40MjU3OEMzLjMwMjczIDcuMjg1MTYgMi45NDMzNiA3LjEzNjcyIDIuNjE5MTQgNi45ODA0N0MyLjI5NDkyIDYuODI0MjIgMi4wMTc1OCA2LjY0MjU4IDEuNzg3MTEgNi40MzU1NUMxLjU2MDU1IDYuMjI4NTIgMS4zODQ3NyA1Ljk4ODI4IDEuMjU5NzcgNS43MTQ4NEMxLjEzNDc3IDUuNDM3NSAxLjA3MjI3IDUuMTA5MzggMS4wNzIyNyA0LjczMDQ3QzEuMDcyMjcgNC4zOTg0NCAxLjEyODkxIDQuMDk1NyAxLjI0MjE5IDMuODIyMjdDMS4zNTU0NyAzLjU0NDkyIDEuNTE1NjIgMy4zMDQ2OSAxLjcyMjY2IDMuMTAxNTZDMS45Mjk2OSAyLjg5ODQ0IDIuMTc5NjkgMi43MzQzNyAyLjQ3MjY2IDIuNjA5MzhDMi43NjU2MiAyLjQ4NDM4IDMuMDkxOCAyLjQwNDMgMy40NTExNyAyLjM2OTE0VjEuMTA5MzhINC4zODg2N1YyLjM4MDg2QzQuNzQwMjMgMi40Mjc3MyA1LjA1NjY0IDIuNTIzNDQgNS4zMzc4OSAyLjY2Nzk3QzUuNjE5MTQgMi44MTI1IDUuODU3NDIgMy4wMDE5NSA2LjA1MjczIDMuMjM2MzNDNi4yNTE5NSAzLjQ2NjggNi40MDQzIDMuNzQwMjMgNi41MDk3NyA0LjA1NjY0QzYuNjE5MTQgNC4zNjkxNCA2LjY3MzgzIDQuNzIwNyA2LjY3MzgzIDUuMTExMzNINS4wNDQ5MkM1LjA0NDkyIDQuNjM4NjcgNC45Mzc1IDQuMjgxMjUgNC43MjI2NiA0LjAzOTA2QzQuNTA3ODEgMy43OTI5NyA0LjIxNjggMy42Njk5MiAzLjg0OTYxIDMuNjY5OTJDMy42NTAzOSAzLjY2OTkyIDMuNDc2NTYgMy42OTcyNyAzLjMyODEyIDMuNzUxOTVDMy4xODM1OSAzLjgwMjczIDMuMDY0NDUgMy44NzY5NSAyLjk3MDcgMy45NzQ2MUMyLjg3Njk1IDQuMDY4MzYgMi44MDY2NCA0LjE3OTY5IDIuNzU5NzcgNC4zMDg1OUMyLjcxNjggNC40Mzc1IDIuNjk1MzEgNC41NzgxMiAyLjY5NTMxIDQuNzMwNDdDMi42OTUzMSA0Ljg4MjgxIDIuNzE2OCA1LjAxOTUzIDIuNzU5NzcgNS4xNDA2MkMyLjgwNjY0IDUuMjU3ODEgMi44ODI4MSA1LjM2NzE5IDIuOTg4MjggNS40Njg3NUMzLjA5NzY2IDUuNTcwMzEgMy4yNDAyMyA1LjY2Nzk3IDMuNDE2MDIgNS43NjE3MkMzLjU5MTggNS44NTE1NiAzLjgxMDU1IDUuOTQzMzYgNC4wNzIyNyA2LjAzNzExQzQuNDY2OCA2LjE4NTU1IDQuODI0MjIgNi4zMzk4NCA1LjE0NDUzIDYuNUM1LjQ2NDg0IDYuNjU2MjUgNS43MzgyOCA2LjgzOTg0IDUuOTY0ODQgNy4wNTA3OEM2LjE5NTMxIDcuMjU3ODEgNi4zNzEwOSA3LjUgNi40OTIxOSA3Ljc3NzM0QzYuNjE3MTkgOC4wNTA3OCA2LjY3OTY5IDguMzc1IDYuNjc5NjkgOC43NUM2LjY3OTY5IDkuMDkzNzUgNi42MjMwNSA5LjQwNDMgNi41MDk3NyA5LjY4MTY0QzYuMzk2NDggOS45NTUwOCA2LjIzNDM4IDEwLjE5MTQgNi4wMjM0NCAxMC4zOTA2QzUuODEyNSAxMC41ODk4IDUuNTU4NTkgMTAuNzUgNS4yNjE3MiAxMC44NzExQzQuOTY0ODQgMTAuOTg4MyA0LjYzMjgxIDExLjA2NDUgNC4yNjU2MiAxMS4wOTk2VjEyLjI0OEgzLjMzMzk4VjExLjA5OTZDMy4wMDE5NSAxMS4wNjg0IDIuNjc5NjkgMTAuOTk2MSAyLjM2NzE5IDEwLjg4MjhDMi4wNTQ2OSAxMC43NjU2IDEuNzc3MzQgMTAuNTk3NyAxLjUzNTE2IDEwLjM3ODlDMS4yOTY4OCAxMC4xNjAyIDEuMTA1NDcgOS44ODQ3NyAwLjk2MDkzOCA5LjU1MjczQzAuODE2NDA2IDkuMjE2OCAwLjc0NDE0MSA4LjgxNDQ1IDAuNzQ0MTQxIDguMzQ1N0gyLjM3ODkxQzIuMzc4OTEgOC42MjY5NSAyLjQxOTkyIDguODYzMjggMi41MDE5NSA5LjA1NDY5QzIuNTgzOTggOS4yNDIxOSAyLjY4OTQ1IDkuMzkyNTggMi44MTgzNiA5LjUwNTg2QzIuOTUxMTcgOS42MTUyMyAzLjEwMTU2IDkuNjkzMzYgMy4yNjk1MyA5Ljc0MDIzQzMuNDM3NSA5Ljc4NzExIDMuNjA5MzggOS44MTA1NSAzLjc4NTE2IDkuODEwNTVDNC4yMDMxMiA5LjgxMDU1IDQuNTE5NTMgOS43MTI4OSA0LjczNDM4IDkuNTE3NThDNC45NDkyMiA5LjMyMjI3IDUuMDU2NjQgOS4wNzAzMSA1LjA1NjY0IDguNzYxNzJaTTEzLjQxOCAxMi4yNzE1SDguMDc0MjJWMTFIMTMuNDE4VjEyLjI3MTVaIiB0cmFuc2Zvcm09InRyYW5zbGF0ZSgzLjk1MjY0IDYpIiBmaWxsPSJ3aGl0ZSIvPgo8L3N2Zz4K);
-  --jp-icon-text-editor: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgdmlld0JveD0iMCAwIDI0IDI0Ij4KICA8cGF0aCBjbGFzcz0ianAtaWNvbjMganAtaWNvbi1zZWxlY3RhYmxlIiBmaWxsPSIjNjE2MTYxIiBkPSJNMTUgMTVIM3YyaDEydi0yem0wLThIM3YyaDEyVjd6TTMgMTNoMTh2LTJIM3Yyem0wIDhoMTh2LTJIM3Yyek0zIDN2MmgxOFYzSDN6Ii8+Cjwvc3ZnPgo=);
+  --jp-icon-terminal: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgdmlld0JveD0iMCAwIDI0IDI0IiA+CiAgICA8cmVjdCBjbGFzcz0ianAtdGVybWluYWwtaWNvbi1iYWNrZ3JvdW5kLWNvbG9yIGpwLWljb24tc2VsZWN0YWJsZSIgd2lkdGg9IjIwIiBoZWlnaHQ9IjIwIiB0cmFuc2Zvcm09InRyYW5zbGF0ZSgyIDIpIiBmaWxsPSIjMzMzMzMzIi8+CiAgICA8cGF0aCBjbGFzcz0ianAtdGVybWluYWwtaWNvbi1jb2xvciBqcC1pY29uLXNlbGVjdGFibGUtaW52ZXJzZSIgZD0iTTUuMDU2NjQgOC43NjE3MkM1LjA1NjY0IDguNTk3NjYgNS4wMzEyNSA4LjQ1MzEyIDQuOTgwNDcgOC4zMjgxMkM0LjkzMzU5IDguMTk5MjIgNC44NTU0NyA4LjA4MjAzIDQuNzQ2MDkgNy45NzY1NkM0LjY0MDYyIDcuODcxMDkgNC41IDcuNzc1MzkgNC4zMjQyMiA3LjY4OTQ1QzQuMTUyMzQgNy41OTk2MSAzLjk0MzM2IDcuNTExNzIgMy42OTcyNyA3LjQyNTc4QzMuMzAyNzMgNy4yODUxNiAyLjk0MzM2IDcuMTM2NzIgMi42MTkxNCA2Ljk4MDQ3QzIuMjk0OTIgNi44MjQyMiAyLjAxNzU4IDYuNjQyNTggMS43ODcxMSA2LjQzNTU1QzEuNTYwNTUgNi4yMjg1MiAxLjM4NDc3IDUuOTg4MjggMS4yNTk3NyA1LjcxNDg0QzEuMTM0NzcgNS40Mzc1IDEuMDcyMjcgNS4xMDkzOCAxLjA3MjI3IDQuNzMwNDdDMS4wNzIyNyA0LjM5ODQ0IDEuMTI4OTEgNC4wOTU3IDEuMjQyMTkgMy44MjIyN0MxLjM1NTQ3IDMuNTQ0OTIgMS41MTU2MiAzLjMwNDY5IDEuNzIyNjYgMy4xMDE1NkMxLjkyOTY5IDIuODk4NDQgMi4xNzk2OSAyLjczNDM3IDIuNDcyNjYgMi42MDkzOEMyLjc2NTYyIDIuNDg0MzggMy4wOTE4IDIuNDA0MyAzLjQ1MTE3IDIuMzY5MTRWMS4xMDkzOEg0LjM4ODY3VjIuMzgwODZDNC43NDAyMyAyLjQyNzczIDUuMDU2NjQgMi41MjM0NCA1LjMzNzg5IDIuNjY3OTdDNS42MTkxNCAyLjgxMjUgNS44NTc0MiAzLjAwMTk1IDYuMDUyNzMgMy4yMzYzM0M2LjI1MTk1IDMuNDY2OCA2LjQwNDMgMy43NDAyMyA2LjUwOTc3IDQuMDU2NjRDNi42MTkxNCA0LjM2OTE0IDYuNjczODMgNC43MjA3IDYuNjczODMgNS4xMTEzM0g1LjA0NDkyQzUuMDQ0OTIgNC42Mzg2NyA0LjkzNzUgNC4yODEyNSA0LjcyMjY2IDQuMDM5MDZDNC41MDc4MSAzLjc5Mjk3IDQuMjE2OCAzLjY2OTkyIDMuODQ5NjEgMy42Njk5MkMzLjY1MDM5IDMuNjY5OTIgMy40NzY1NiAzLjY5NzI3IDMuMzI4MTIgMy43NTE5NUMzLjE4MzU5IDMuODAyNzMgMy4wNjQ0NSAzLjg3Njk1IDIuOTcwNyAzLjk3NDYxQzIuODc2OTUgNC4wNjgzNiAyLjgwNjY0IDQuMTc5NjkgMi43NTk3NyA0LjMwODU5QzIuNzE2OCA0LjQzNzUgMi42OTUzMSA0LjU3ODEyIDIuNjk1MzEgNC43MzA0N0MyLjY5NTMxIDQuODgyODEgMi43MTY4IDUuMDE5NTMgMi43NTk3NyA1LjE0MDYyQzIuODA2NjQgNS4yNTc4MSAyLjg4MjgxIDUuMzY3MTkgMi45ODgyOCA1LjQ2ODc1QzMuMDk3NjYgNS41NzAzMSAzLjI0MDIzIDUuNjY3OTcgMy40MTYwMiA1Ljc2MTcyQzMuNTkxOCA1Ljg1MTU2IDMuODEwNTUgNS45NDMzNiA0LjA3MjI3IDYuMDM3MTFDNC40NjY4IDYuMTg1NTUgNC44MjQyMiA2LjMzOTg0IDUuMTQ0NTMgNi41QzUuNDY0ODQgNi42NTYyNSA1LjczODI4IDYuODM5ODQgNS45NjQ4NCA3LjA1MDc4QzYuMTk1MzEgNy4yNTc4MSA2LjM3MTA5IDcuNSA2LjQ5MjE5IDcuNzc3MzRDNi42MTcxOSA4LjA1MDc4IDYuNjc5NjkgOC4zNzUgNi42Nzk2OSA4Ljc1QzYuNjc5NjkgOS4wOTM3NSA2LjYyMzA1IDkuNDA0MyA2LjUwOTc3IDkuNjgxNjRDNi4zOTY0OCA5Ljk1NTA4IDYuMjM0MzggMTAuMTkxNCA2LjAyMzQ0IDEwLjM5MDZDNS44MTI1IDEwLjU4OTggNS41NTg1OSAxMC43NSA1LjI2MTcyIDEwLjg3MTFDNC45NjQ4NCAxMC45ODgzIDQuNjMyODEgMTEuMDY0NSA0LjI2NTYyIDExLjA5OTZWMTIuMjQ4SDMuMzMzOThWMTEuMDk5NkMzLjAwMTk1IDExLjA2ODQgMi42Nzk2OSAxMC45OTYxIDIuMzY3MTkgMTAuODgyOEMyLjA1NDY5IDEwLjc2NTYgMS43NzczNCAxMC41OTc3IDEuNTM1MTYgMTAuMzc4OUMxLjI5Njg4IDEwLjE2MDIgMS4xMDU0NyA5Ljg4NDc3IDAuOTYwOTM4IDkuNTUyNzNDMC44MTY0MDYgOS4yMTY4IDAuNzQ0MTQxIDguODE0NDUgMC43NDQxNDEgOC4zNDU3SDIuMzc4OTFDMi4zNzg5MSA4LjYyNjk1IDIuNDE5OTIgOC44NjMyOCAyLjUwMTk1IDkuMDU0NjlDMi41ODM5OCA5LjI0MjE5IDIuNjg5NDUgOS4zOTI1OCAyLjgxODM2IDkuNTA1ODZDMi45NTExNyA5LjYxNTIzIDMuMTAxNTYgOS42OTMzNiAzLjI2OTUzIDkuNzQwMjNDMy40Mzc1IDkuNzg3MTEgMy42MDkzOCA5LjgxMDU1IDMuNzg1MTYgOS44MTA1NUM0LjIwMzEyIDkuODEwNTUgNC41MTk1MyA5LjcxMjg5IDQuNzM0MzggOS41MTc1OEM0Ljk0OTIyIDkuMzIyMjcgNS4wNTY2NCA5LjA3MDMxIDUuMDU2NjQgOC43NjE3MlpNMTMuNDE4IDEyLjI3MTVIOC4wNzQyMlYxMUgxMy40MThWMTIuMjcxNVoiIHRyYW5zZm9ybT0idHJhbnNsYXRlKDMuOTUyNjQgNikiIGZpbGw9IndoaXRlIi8+Cjwvc3ZnPgo=);
+  --jp-icon-text-editor: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgdmlld0JveD0iMCAwIDI0IDI0Ij4KICA8cGF0aCBjbGFzcz0ianAtdGV4dC1lZGl0b3ItaWNvbi1jb2xvciBqcC1pY29uLXNlbGVjdGFibGUiIGZpbGw9IiM2MTYxNjEiIGQ9Ik0xNSAxNUgzdjJoMTJ2LTJ6bTAtOEgzdjJoMTJWN3pNMyAxM2gxOHYtMkgzdjJ6bTAgOGgxOHYtMkgzdjJ6TTMgM3YyaDE4VjNIM3oiLz4KPC9zdmc+Cg==);
   --jp-icon-toc: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0Ij4KICA8ZyBjbGFzcz0ianAtaWNvbjMganAtaWNvbi1zZWxlY3RhYmxlIiBmaWxsPSIjNjE2MTYxIj4KICAgIDxwYXRoIGQ9Ik03LDVIMjFWN0g3VjVNNywxM1YxMUgyMVYxM0g3TTQsNC41QTEuNSwxLjUgMCAwLDEgNS41LDZBMS41LDEuNSAwIDAsMSA0LDcuNUExLjUsMS41IDAgMCwxIDIuNSw2QTEuNSwxLjUgMCAwLDEgNCw0LjVNNCwxMC41QTEuNSwxLjUgMCAwLDEgNS41LDEyQTEuNSwxLjUgMCAwLDEgNCwxMy41QTEuNSwxLjUgMCAwLDEgMi41LDEyQTEuNSwxLjUgMCAwLDEgNCwxMC41TTcsMTlWMTdIMjFWMTlIN000LDE2LjVBMS41LDEuNSAwIDAsMSA1LjUsMThBMS41LDEuNSAwIDAsMSA0LDE5LjVBMS41LDEuNSAwIDAsMSAyLjUsMThBMS41LDEuNSAwIDAsMSA0LDE2LjVaIiAvPgogIDwvZz4KPC9zdmc+Cg==);
   --jp-icon-tree-view: url(data:image/svg+xml;base64,PHN2ZyBoZWlnaHQ9IjI0IiB2aWV3Qm94PSIwIDAgMjQgMjQiIHdpZHRoPSIyNCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KICAgIDxnIGNsYXNzPSJqcC1pY29uMyIgZmlsbD0iIzYxNjE2MSI+CiAgICAgICAgPHBhdGggZD0iTTAgMGgyNHYyNEgweiIgZmlsbD0ibm9uZSIvPgogICAgICAgIDxwYXRoIGQ9Ik0yMiAxMVYzaC03djNIOVYzSDJ2OGg3VjhoMnYxMGg0djNoN3YtOGgtN3YzaC0yVjhoMnYzeiIvPgogICAgPC9nPgo8L3N2Zz4=);
   --jp-icon-trusted: url(data:image/svg+xml;base64,PHN2ZyBmaWxsPSJub25lIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgdmlld0JveD0iMCAwIDI0IDI1Ij4KICAgIDxwYXRoIGNsYXNzPSJqcC1pY29uMiIgc3Ryb2tlPSIjMzMzMzMzIiBzdHJva2Utd2lkdGg9IjIiIHRyYW5zZm9ybT0idHJhbnNsYXRlKDIgMykiIGQ9Ik0xLjg2MDk0IDExLjQ0MDlDMC44MjY0NDggOC43NzAyNyAwLjg2Mzc3OSA2LjA1NzY0IDEuMjQ5MDcgNC4xOTkzMkMyLjQ4MjA2IDMuOTMzNDcgNC4wODA2OCAzLjQwMzQ3IDUuNjAxMDIgMi44NDQ5QzcuMjM1NDkgMi4yNDQ0IDguODU2NjYgMS41ODE1IDkuOTg3NiAxLjA5NTM5QzExLjA1OTcgMS41ODM0MSAxMi42MDk0IDIuMjQ0NCAxNC4yMTggMi44NDMzOUMxNS43NTAzIDMuNDEzOTQgMTcuMzk5NSAzLjk1MjU4IDE4Ljc1MzkgNC4yMTM4NUMxOS4xMzY0IDYuMDcxNzcgMTkuMTcwOSA4Ljc3NzIyIDE4LjEzOSAxMS40NDA5QzE3LjAzMDMgMTQuMzAzMiAxNC42NjY4IDE3LjE4NDQgOS45OTk5OSAxOC45MzU0QzUuMzMzMiAxNy4xODQ0IDIuOTY5NjggMTQuMzAzMiAxLjg2MDk0IDExLjQ0MDlaIi8+CiAgICA8cGF0aCBjbGFzcz0ianAtaWNvbjIiIGZpbGw9IiMzMzMzMzMiIHN0cm9rZT0iIzMzMzMzMyIgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoOCA5Ljg2NzE5KSIgZD0iTTIuODYwMTUgNC44NjUzNUwwLjcyNjU0OSAyLjk5OTU5TDAgMy42MzA0NUwyLjg2MDE1IDYuMTMxNTdMOCAwLjYzMDg3Mkw3LjI3ODU3IDBMMi44NjAxNSA0Ljg2NTM1WiIvPgo8L3N2Zz4K);
   --jp-icon-undo: url(data:image/svg+xml;base64,PHN2ZyB2aWV3Qm94PSIwIDAgMjQgMjQiIHdpZHRoPSIxNiIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KICA8ZyBjbGFzcz0ianAtaWNvbjMiIGZpbGw9IiM2MTYxNjEiPgogICAgPHBhdGggZD0iTTEyLjUgOGMtMi42NSAwLTUuMDUuOTktNi45IDIuNkwyIDd2OWg5bC0zLjYyLTMuNjJjMS4zOS0xLjE2IDMuMTYtMS44OCA1LjEyLTEuODggMy41NCAwIDYuNTUgMi4zMSA3LjYgNS41bDIuMzctLjc4QzIxLjA4IDExLjAzIDE3LjE1IDggMTIuNSA4eiIvPgogIDwvZz4KPC9zdmc+Cg==);
+  --jp-icon-user: url(data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTYiIHZpZXdCb3g9IjAgMCAyNCAyNCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KICA8ZyBjbGFzcz0ianAtaWNvbjMiIGZpbGw9IiM2MTYxNjEiPgogICAgPHBhdGggZD0iTTE2IDdhNCA0IDAgMTEtOCAwIDQgNCAwIDAxOCAwek0xMiAxNGE3IDcgMCAwMC03IDdoMTRhNyA3IDAgMDAtNy03eiIvPgogIDwvZz4KPC9zdmc+);
+  --jp-icon-users: url(data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjQiIGhlaWdodD0iMjQiIHZlcnNpb249IjEuMSIgdmlld0JveD0iMCAwIDM2IDI0IiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPgogPGcgY2xhc3M9ImpwLWljb24zIiB0cmFuc2Zvcm09Im1hdHJpeCgxLjczMjcgMCAwIDEuNzMyNyAtMy42MjgyIC4wOTk1NzcpIiBmaWxsPSIjNjE2MTYxIj4KICA8cGF0aCB0cmFuc2Zvcm09Im1hdHJpeCgxLjUsMCwwLDEuNSwwLC02KSIgZD0ibTEyLjE4NiA3LjUwOThjLTEuMDUzNSAwLTEuOTc1NyAwLjU2NjUtMi40Nzg1IDEuNDEwMiAwLjc1MDYxIDAuMzEyNzcgMS4zOTc0IDAuODI2NDggMS44NzMgMS40NzI3aDMuNDg2M2MwLTEuNTkyLTEuMjg4OS0yLjg4MjgtMi44ODA5LTIuODgyOHoiLz4KICA8cGF0aCBkPSJtMjAuNDY1IDIuMzg5NWEyLjE4ODUgMi4xODg1IDAgMCAxLTIuMTg4NCAyLjE4ODUgMi4xODg1IDIuMTg4NSAwIDAgMS0yLjE4ODUtMi4xODg1IDIuMTg4NSAyLjE4ODUgMCAwIDEgMi4xODg1LTIuMTg4NSAyLjE4ODUgMi4xODg1IDAgMCAxIDIuMTg4NCAyLjE4ODV6Ii8+CiAgPHBhdGggdHJhbnNmb3JtPSJtYXRyaXgoMS41LDAsMCwxLjUsMCwtNikiIGQ9Im0zLjU4OTggOC40MjE5Yy0xLjExMjYgMC0yLjAxMzcgMC45MDExMS0yLjAxMzcgMi4wMTM3aDIuODE0NWMwLjI2Nzk3LTAuMzczMDkgMC41OTA3LTAuNzA0MzUgMC45NTg5OC0wLjk3ODUyLTAuMzQ0MzMtMC42MTY4OC0xLjAwMzEtMS4wMzUyLTEuNzU5OC0xLjAzNTJ6Ii8+CiAgPHBhdGggZD0ibTYuOTE1NCA0LjYyM2ExLjUyOTQgMS41Mjk0IDAgMCAxLTEuNTI5NCAxLjUyOTQgMS41Mjk0IDEuNTI5NCAwIDAgMS0xLjUyOTQtMS41Mjk0IDEuNTI5NCAxLjUyOTQgMCAwIDEgMS41Mjk0LTEuNTI5NCAxLjUyOTQgMS41Mjk0IDAgMCAxIDEuNTI5NCAxLjUyOTR6Ii8+CiAgPHBhdGggZD0ibTYuMTM1IDEzLjUzNWMwLTMuMjM5MiAyLjYyNTktNS44NjUgNS44NjUtNS44NjUgMy4yMzkyIDAgNS44NjUgMi42MjU5IDUuODY1IDUuODY1eiIvPgogIDxjaXJjbGUgY3g9IjEyIiBjeT0iMy43Njg1IiByPSIyLjk2ODUiLz4KIDwvZz4KPC9zdmc+Cg==);
   --jp-icon-vega: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgdmlld0JveD0iMCAwIDIyIDIyIj4KICA8ZyBjbGFzcz0ianAtaWNvbjEganAtaWNvbi1zZWxlY3RhYmxlIiBmaWxsPSIjMjEyMTIxIj4KICAgIDxwYXRoIGQ9Ik0xMC42IDUuNGwyLjItMy4ySDIuMnY3LjNsNC02LjZ6Ii8+CiAgICA8cGF0aCBkPSJNMTUuOCAyLjJsLTQuNCA2LjZMNyA2LjNsLTQuOCA4djUuNWgxNy42VjIuMmgtNHptLTcgMTUuNEg1LjV2LTQuNGgzLjN2NC40em00LjQgMEg5LjhWOS44aDMuNHY3Ljh6bTQuNCAwaC0zLjRWNi41aDMuNHYxMS4xeiIvPgogIDwvZz4KPC9zdmc+Cg==);
   --jp-icon-yaml: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgdmlld0JveD0iMCAwIDIyIDIyIj4KICA8ZyBjbGFzcz0ianAtaWNvbi1jb250cmFzdDIganAtaWNvbi1zZWxlY3RhYmxlIiBmaWxsPSIjRDgxQjYwIj4KICAgIDxwYXRoIGQ9Ik03LjIgMTguNnYtNS40TDMgNS42aDMuM2wxLjQgMy4xYy4zLjkuNiAxLjYgMSAyLjUuMy0uOC42LTEuNiAxLTIuNWwxLjQtMy4xaDMuNGwtNC40IDcuNnY1LjVsLTIuOS0uMXoiLz4KICAgIDxjaXJjbGUgY2xhc3M9InN0MCIgY3g9IjE3LjYiIGN5PSIxNi41IiByPSIyLjEiLz4KICAgIDxjaXJjbGUgY2xhc3M9InN0MCIgY3g9IjE3LjYiIGN5PSIxMSIgcj0iMi4xIi8+CiAgPC9nPgo8L3N2Zz4K);
 }
 
 /* Icon CSS class declarations */
 
+.jp-AddAboveIcon {
+  background-image: var(--jp-icon-add-above);
+}
+.jp-AddBelowIcon {
+  background-image: var(--jp-icon-add-below);
+}
 .jp-AddIcon {
   background-image: var(--jp-icon-add);
+}
+.jp-BellIcon {
+  background-image: var(--jp-icon-bell);
+}
+.jp-BugDotIcon {
+  background-image: var(--jp-icon-bug-dot);
 }
 .jp-BugIcon {
   background-image: var(--jp-icon-bug);
@@ -9509,8 +9522,14 @@ span.bp3-popover-target{
 .jp-CutIcon {
   background-image: var(--jp-icon-cut);
 }
+.jp-DeleteIcon {
+  background-image: var(--jp-icon-delete);
+}
 .jp-DownloadIcon {
   background-image: var(--jp-icon-download);
+}
+.jp-DuplicateIcon {
+  background-image: var(--jp-icon-duplicate);
 }
 .jp-EditIcon {
   background-image: var(--jp-icon-edit);
@@ -9533,8 +9552,14 @@ span.bp3-popover-target{
 .jp-FilterListIcon {
   background-image: var(--jp-icon-filter-list);
 }
+.jp-FolderFavoriteIcon {
+  background-image: var(--jp-icon-folder-favorite);
+}
 .jp-FolderIcon {
   background-image: var(--jp-icon-folder);
+}
+.jp-HomeIcon {
+  background-image: var(--jp-icon-home);
 }
 .jp-Html5Icon {
   background-image: var(--jp-icon-html5);
@@ -9566,6 +9591,9 @@ span.bp3-popover-target{
 .jp-KeyboardIcon {
   background-image: var(--jp-icon-keyboard);
 }
+.jp-LaunchIcon {
+  background-image: var(--jp-icon-launch);
+}
 .jp-LauncherIcon {
   background-image: var(--jp-icon-launcher);
 }
@@ -9583,6 +9611,12 @@ span.bp3-popover-target{
 }
 .jp-MarkdownIcon {
   background-image: var(--jp-icon-markdown);
+}
+.jp-MoveDownIcon {
+  background-image: var(--jp-icon-move-down);
+}
+.jp-MoveUpIcon {
+  background-image: var(--jp-icon-move-up);
 }
 .jp-NewFolderIcon {
   background-image: var(--jp-icon-new-folder);
@@ -9641,6 +9675,9 @@ span.bp3-popover-target{
 .jp-SettingsIcon {
   background-image: var(--jp-icon-settings);
 }
+.jp-ShareIcon {
+  background-image: var(--jp-icon-share);
+}
 .jp-SpreadsheetIcon {
   background-image: var(--jp-icon-spreadsheet);
 }
@@ -9673,6 +9710,12 @@ span.bp3-popover-target{
 }
 .jp-UndoIcon {
   background-image: var(--jp-icon-undo);
+}
+.jp-UserIcon {
+  background-image: var(--jp-icon-user);
+}
+.jp-UsersIcon {
+  background-image: var(--jp-icon-users);
 }
 .jp-VegaIcon {
   background-image: var(--jp-icon-vega);
@@ -9725,6 +9768,36 @@ span.bp3-popover-target{
   background-size: 20px;
   min-width: 20px;
   min-height: 20px;
+}
+
+/*-----------------------------------------------------------------------------
+| Copyright (c) Jupyter Development Team.
+| Distributed under the terms of the Modified BSD License.
+|----------------------------------------------------------------------------*/
+
+.lm-TabBar .lm-TabBar-addButton {
+  align-items: center;
+  display: flex;
+  padding: 4px;
+  padding-bottom: 5px;
+  margin-right: 1px;
+  background-color: var(--jp-layout-color2);
+}
+
+.lm-TabBar .lm-TabBar-addButton:hover {
+  background-color: var(--jp-layout-color1);
+}
+
+.lm-DockPanel-tabBar .lm-TabBar-tab {
+  width: var(--jp-private-horizontal-tab-width);
+}
+
+.lm-DockPanel-tabBar .lm-TabBar-content {
+  flex: unset;
+}
+
+.lm-DockPanel-tabBar[data-orientation='horizontal'] {
+  flex: 1 1 auto;
 }
 
 /*-----------------------------------------------------------------------------
@@ -9893,15 +9966,40 @@ span.bp3-popover-target{
   stroke: var(--jp-icon-contrast-color3);
 }
 
-/* CSS for icons in selected items in the settings editor */
-#setting-editor .jp-PluginList .jp-mod-selected .jp-icon-selectable[fill] {
-  fill: #fff;
+.jp-jupyter-icon-color[fill] {
+  fill: var(--jp-jupyter-icon-color, var(--jp-warn-color0));
 }
-#setting-editor
-  .jp-PluginList
-  .jp-mod-selected
-  .jp-icon-selectable-inverse[fill] {
-  fill: var(--jp-brand-color1);
+
+.jp-notebook-icon-color[fill] {
+  fill: var(--jp-notebook-icon-color, var(--jp-warn-color0));
+}
+
+.jp-json-icon-color[fill] {
+  fill: var(--jp-json-icon-color, var(--jp-warn-color1));
+}
+
+.jp-console-icon-color[fill] {
+  fill: var(--jp-console-icon-color, white);
+}
+
+.jp-console-icon-background-color[fill] {
+  fill: var(--jp-console-icon-background-color, var(--jp-brand-color1));
+}
+
+.jp-terminal-icon-color[fill] {
+  fill: var(--jp-terminal-icon-color, var(--jp-layout-color2));
+}
+
+.jp-terminal-icon-background-color[fill] {
+  fill: var(--jp-terminal-icon-background-color, var(--jp-inverse-layout2));
+}
+
+.jp-text-editor-icon-color[fill] {
+  fill: var(--jp-text-editor-icon-color, var(--jp-inverse-layout3));
+}
+
+.jp-inspector-icon-color[fill] {
+  fill: var(--jp-inspector-icon-color, var(--jp-inverse-layout3));
 }
 
 /* CSS for icons in selected filebrowser listing items */
@@ -10084,7 +10182,7 @@ span.bp3-popover-target{
 | Distributed under the terms of the Modified BSD License.
 |----------------------------------------------------------------------------*/
 
-.jp-icon-hoverShow:not(:hover) svg {
+.jp-icon-hoverShow:not(:hover) .jp-icon-hoverShow-content {
   display: none !important;
 }
 
@@ -10268,7 +10366,7 @@ span.bp3-popover-target{
 
 .jp-switch-track {
   cursor: pointer;
-  background-color: var(--jp-border-color1);
+  background-color: var(--jp-switch-color, var(--jp-border-color1));
   -webkit-transition: 0.4s;
   transition: 0.4s;
   border-radius: 34px;
@@ -10291,7 +10389,7 @@ span.bp3-popover-target{
 }
 
 .jp-switch[aria-checked='true'] .jp-switch-track {
-  background-color: var(--jp-warn-color0);
+  background-color: var(--jp-switch-true-position-color, var(--jp-warn-color0));
 }
 
 .jp-switch[aria-checked='true'] .jp-switch-track::before {
@@ -10741,8 +10839,7 @@ select {
   margin-left: auto;
   margin-right: auto;
   background: var(--jp-layout-color1);
-  padding: 24px;
-  padding-bottom: 12px;
+  padding: 24px 24px 12px 24px;
   min-width: 300px;
   min-height: 150px;
   max-width: 1000px;
@@ -10758,6 +10855,10 @@ select {
   resize: both;
 }
 
+.jp-Dialog-content.jp-Dialog-content-small {
+  max-width: 500px;
+}
+
 .jp-Dialog-button {
   overflow: visible;
 }
@@ -10770,6 +10871,25 @@ button.jp-Dialog-button:focus {
 
 button.jp-Dialog-button:focus::-moz-focus-inner {
   border: 0;
+}
+
+button.jp-Dialog-button.jp-mod-styled.jp-mod-accept:focus,
+button.jp-Dialog-button.jp-mod-styled.jp-mod-warn:focus,
+button.jp-Dialog-button.jp-mod-styled.jp-mod-reject:focus {
+  outline-offset: 4px;
+  -moz-outline-radius: 0px;
+}
+
+button.jp-Dialog-button.jp-mod-styled.jp-mod-accept:focus {
+  outline: 1px solid var(--md-blue-700);
+}
+
+button.jp-Dialog-button.jp-mod-styled.jp-mod-warn:focus {
+  outline: 1px solid var(--md-red-600);
+}
+
+button.jp-Dialog-button.jp-mod-styled.jp-mod-reject:focus {
+  outline: 1px solid var(--md-grey-700);
 }
 
 button.jp-Dialog-close-button {
@@ -10802,10 +10922,24 @@ button.jp-Dialog-close-button {
   display: flex;
   flex-direction: row;
   justify-content: flex-end;
+  align-items: center;
   flex: 0 0 auto;
   margin-left: -12px;
   margin-right: -12px;
   padding: 12px;
+}
+
+.jp-Dialog-checkbox {
+  padding-right: 5px;
+}
+
+.jp-Dialog-checkbox > input:focus-visible {
+  outline: 1px solid var(--jp-input-active-border-color);
+  outline-offset: 1px;
+}
+
+.jp-Dialog-spacer {
+  flex: 1 1 auto;
 }
 
 .jp-Dialog-title {
@@ -10897,6 +11031,26 @@ body.lm-mod-override-cursor .jp-IFrame:before {
 
 .jp-MainAreaWidget > :focus {
   outline: none;
+}
+
+.jp-MainAreaWidget .jp-MainAreaWidget-error {
+  padding: 6px;
+}
+
+.jp-MainAreaWidget .jp-MainAreaWidget-error > pre {
+  width: auto;
+  padding: 10px;
+  background: var(--jp-error-color3);
+  border: var(--jp-border-width) solid var(--jp-error-color1);
+  border-radius: var(--jp-border-radius);
+  color: var(--jp-ui-font-color1);
+  font-size: var(--jp-ui-font-size1);
+  white-space: pre-wrap;
+  word-wrap: break-word;
+}
+
+.jp-MainAreaWidget {
+  contain: strict;
 }
 
 /**
@@ -11382,8 +11536,8 @@ select.jp-mod-styled {
   background: var(--jp-toolbar-background);
   min-height: var(--jp-toolbar-micro-height);
   padding: 2px;
-  z-index: 1;
-  overflow-x: auto;
+  z-index: 8;
+  overflow-x: hidden;
 }
 
 /* Toolbar items */
@@ -11491,8 +11645,8 @@ button.jp-ToolbarButtonComponent .jp-ToolbarButtonComponent-label {
 | The full license is in the file LICENSE, distributed with this software.
 |----------------------------------------------------------------------------*/
 
-
-/* <DEPRECATED> */ body.p-mod-override-cursor *, /* </DEPRECATED> */
+/* <DEPRECATED> */
+body.p-mod-override-cursor *, /* </DEPRECATED> */
 body.lm-mod-override-cursor * {
   cursor: inherit !important;
 }
@@ -11550,6 +11704,80 @@ body.lm-mod-override-cursor * {
 .jp-Editor.jp-mod-dropTarget {
   border: var(--jp-border-width) solid var(--jp-input-active-border-color);
   box-shadow: var(--jp-input-box-shadow);
+}
+
+/*-----------------------------------------------------------------------------
+| Copyright (c) Jupyter Development Team.
+| Distributed under the terms of the Modified BSD License.
+|----------------------------------------------------------------------------*/
+
+/*-----------------------------------------------------------------------------
+| Variables
+|----------------------------------------------------------------------------*/
+
+/*-----------------------------------------------------------------------------
+
+/*-----------------------------------------------------------------------------
+| Styles
+|----------------------------------------------------------------------------*/
+
+.jp-Statusbar-ProgressCircle svg {
+  display: block;
+  margin: 0 auto;
+  width: 16px;
+  height: 24px;
+  align-self: normal;
+}
+.jp-Statusbar-ProgressCircle path {
+  fill: var(--jp-inverse-layout-color3);
+}
+
+.jp-Statusbar-ProgressBar-progress-bar {
+  height: 10px;
+  width: 100px;
+  border: solid 0.25px var(--jp-brand-color2);
+  border-radius: 3px;
+  overflow: hidden;
+  align-self: center;
+}
+.jp-Statusbar-ProgressBar-progress-bar > div {
+  background-color: var(--jp-brand-color2);
+  background-image: linear-gradient(
+    -45deg,
+    rgba(255, 255, 255, 0.2) 25%,
+    transparent 25%,
+    transparent 50%,
+    rgba(255, 255, 255, 0.2) 50%,
+    rgba(255, 255, 255, 0.2) 75%,
+    transparent 75%,
+    transparent
+  );
+  background-size: 40px 40px;
+  float: left;
+  width: 0%;
+  height: 100%;
+  font-size: 12px;
+  line-height: 14px;
+  color: #ffffff;
+  text-align: center;
+  animation: jp-Statusbar-ExecutionTime-progress-bar 2s linear infinite;
+}
+
+.jp-Statusbar-ProgressBar-progress-bar p {
+  color: var(--jp-ui-font-color1);
+  font-family: var(--jp-ui-font-family);
+  font-size: var(--jp-ui-font-size1);
+  line-height: 10px;
+  width: 100px;
+}
+
+@keyframes jp-Statusbar-ExecutionTime-progress-bar {
+  0% {
+    background-position: 0 0;
+  }
+  100% {
+    background-position: 40px 40px;
+  }
 }
 
 /* BASICS */
@@ -11976,6 +12204,10 @@ span.CodeMirror-selectedtext { background: none; }
   padding: 0 var(--jp-code-padding);
 }
 
+.CodeMirror.cm-fat-cursor .cm-overlay.cm-searching {
+  opacity: 0.5;
+}
+
 .jp-CodeMirrorEditor[data-type='inline'] .CodeMirror-dialog {
   background-color: var(--jp-layout-color0);
   color: var(--jp-content-font-color1);
@@ -12044,6 +12276,12 @@ span.CodeMirror-selectedtext { background: none; }
     --jp-search-unselected-match-background-color
   ) !important;
   color: var(--jp-search-unselected-match-color) !important;
+}
+
+.cm-trailingspace {
+  background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAgAAAAFCAYAAAB4ka1VAAAAsElEQVQIHQGlAFr/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA7+r3zKmT0/+pk9P/7+r3zAAAAAAAAAAABAAAAAAAAAAA6OPzM+/q9wAAAAAA6OPzMwAAAAAAAAAAAgAAAAAAAAAAGR8NiRQaCgAZIA0AGR8NiQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQyoYJ/SY80UAAAAASUVORK5CYII=);
+  background-position: center left;
+  background-repeat: repeat-x;
 }
 
 .CodeMirror-focused .CodeMirror-selected {
@@ -12219,7 +12457,10 @@ span.CodeMirror-selectedtext { background: none; }
   opacity: 0;
 }
 
-.jp-CodeMirrorEditor .remote-caret:hover > div {
+/* Use `div[style]` as more specific selector on 3.4.x to reduce the impact of
+ * Chromium style invalidation strategy on performance when many divs are present.
+ */
+.jp-CodeMirrorEditor .remote-caret:hover > div[style] {
   opacity: 1;
   transition-delay: 0s;
 }
@@ -12606,7 +12847,7 @@ span.CodeMirror-selectedtext { background: none; }
   border-spacing: 0;
   border: none;
   color: var(--jp-ui-font-color1);
-  font-size: 12px;
+  font-size: var(--jp-ui-font-size1);
   table-layout: fixed;
   margin-left: auto;
   margin-right: auto;
@@ -12795,7 +13036,7 @@ h6:hover .jp-InternalAnchorLink {
   border-radius: 3px;
   box-shadow: inset 0 -1px 0 rgba(0, 0, 0, 0.25);
   display: inline-block;
-  font-size: 0.8em;
+  font-size: var(--jp-ui-font-size0);
   line-height: 1em;
   padding: 0.2em 0.5em;
 }
@@ -12850,8 +13091,10 @@ h6:hover .jp-InternalAnchorLink {
 .jp-FileBrowser-toolbar.jp-Toolbar {
   border-bottom: none;
   height: auto;
-  margin: var(--jp-toolbar-header-margin);
+  margin: 8px 12px 0px 12px;
+  padding: 0px;
   box-shadow: none;
+  justify-content: flex-start;
 }
 
 .jp-BreadCrumbs {
@@ -12883,43 +13126,33 @@ h6:hover .jp-InternalAnchorLink {
 | Buttons
 |----------------------------------------------------------------------------*/
 
-.jp-FileBrowser-toolbar.jp-Toolbar {
-  padding: 0px;
-  margin: 8px 12px 0px 12px;
-}
-
-.jp-FileBrowser-toolbar.jp-Toolbar {
-  justify-content: flex-start;
-}
-
-.jp-FileBrowser-toolbar.jp-Toolbar .jp-Toolbar-item {
+.jp-FileBrowser-toolbar > .jp-Toolbar-item {
   flex: 0 0 auto;
   padding-left: 0px;
   padding-right: 2px;
 }
 
-.jp-FileBrowser-toolbar.jp-Toolbar .jp-ToolbarButtonComponent {
+.jp-FileBrowser-toolbar > .jp-Toolbar-item .jp-ToolbarButtonComponent {
   width: 40px;
 }
 
-.jp-FileBrowser-toolbar.jp-Toolbar
-  .jp-Toolbar-item:first-child
-  .jp-ToolbarButtonComponent {
+.jp-FileBrowser-toolbar
+  .jp-ToolbarButtonComponent[data-command='filebrowser:create-main-launcher'] {
   width: 72px;
   background: var(--jp-brand-color1);
 }
 
-.jp-FileBrowser-toolbar.jp-Toolbar
-  .jp-Toolbar-item:first-child
-  .jp-ToolbarButtonComponent:focus-visible {
-  background-color: var(--jp-brand-color0);
+.jp-FileBrowser-toolbar
+  .jp-ToolbarButtonComponent[data-command='filebrowser:create-main-launcher']:hover,
+.jp-FileBrowser-toolbar
+  .jp-ToolbarButtonComponent[data-command='filebrowser:create-main-launcher']:focus-visible {
+  background-color: var(--jp-brand-color0) !important;
 }
 
-.jp-FileBrowser-toolbar.jp-Toolbar
-  .jp-Toolbar-item:first-child
-  .jp-ToolbarButtonComponent
+.jp-FileBrowser-toolbar
+  .jp-ToolbarButtonComponent[data-command='filebrowser:create-main-launcher']
   .jp-icon3 {
-  fill: white;
+  fill: var(--jp-layout-color1);
 }
 
 /*-----------------------------------------------------------------------------
@@ -12956,7 +13189,8 @@ h6:hover .jp-InternalAnchorLink {
 }
 
 .jp-DirListing:focus-visible {
-  border: 1px solid var(--jp-brand-color1);
+  outline: 1px solid var(--jp-brand-color1);
+  outline-offset: -2px;
 }
 
 .jp-DirListing-header {
@@ -13087,6 +13321,8 @@ h6:hover .jp-InternalAnchorLink {
   flex: 1 0 64px;
   outline: none;
   border: none;
+  color: var(--jp-ui-font-color1);
+  background-color: var(--jp-layout-color1);
 }
 
 .jp-DirListing-item.jp-mod-running .jp-DirListing-itemIcon:before {
@@ -13113,15 +13349,6 @@ h6:hover .jp-InternalAnchorLink {
   border-radius: 0px;
   color: var(--jp-ui-font-color1);
   transform: translateX(-40%) translateY(-58%);
-}
-
-.jp-DirListing-deadSpace {
-  flex: 1 1 auto;
-  margin: 0;
-  padding: 0;
-  list-style-type: none;
-  overflow: auto;
-  background-color: var(--jp-layout-color1);
 }
 
 .jp-Document {
@@ -13283,12 +13510,24 @@ body.lm-mod-override-cursor .jp-OutputArea-output.jp-mod-isolated:before {
   margin: 0;
 }
 
+.jp-TrimmedOutputs a {
+  margin: 10px;
+  text-decoration: none;
+  cursor: pointer;
+}
+
 /* Hide the gutter in case of
  *  - nested output areas (e.g. in the case of output widgets)
  *  - mirrored output areas
  */
 .jp-OutputArea .jp-OutputArea .jp-OutputArea-prompt {
   display: none;
+}
+
+/* Hide empty lines in the output area, for instance due to cleared widgets */
+.jp-OutputArea-prompt:empty {
+  padding: 0;
+  border: 0;
 }
 
 /*-----------------------------------------------------------------------------
@@ -13313,12 +13552,6 @@ body.lm-mod-override-cursor .jp-OutputArea-output.jp-mod-isolated:before {
 | The Stdin output
 |----------------------------------------------------------------------------*/
 
-.jp-OutputArea-stdin {
-  line-height: var(--jp-code-line-height);
-  padding-top: var(--jp-code-padding);
-  display: flex;
-}
-
 .jp-Stdin-prompt {
   color: var(--jp-content-font-color0);
   padding-right: var(--jp-code-padding);
@@ -13341,8 +13574,16 @@ body.lm-mod-override-cursor .jp-OutputArea-output.jp-mod-isolated:before {
   flex: 0 0 70%;
 }
 
+.jp-Stdin-input::placeholder {
+  opacity: 0;
+}
+
 .jp-Stdin-input:focus {
   box-shadow: none;
+}
+
+.jp-Stdin-input:focus::placeholder {
+  opacity: 1;
 }
 
 /*-----------------------------------------------------------------------------
@@ -13581,9 +13822,26 @@ body[data-format='mobile'] .jp-InputPrompt {
 
 .jp-CodeCell.jp-mod-outputsScrolled .jp-Cell-outputArea {
   overflow-y: auto;
-  max-height: 200px;
-  box-shadow: inset 0 0 6px 2px rgba(0, 0, 0, 0.3);
+  max-height: 24em;
   margin-left: var(--jp-private-cell-scrolling-output-offset);
+}
+
+.jp-CodeCell.jp-mod-outputsScrolled .jp-Cell-outputArea::after {
+  content: ' ';
+  box-shadow: inset 0 0 6px 2px rgb(0 0 0 / 30%);
+  width: 100%;
+  height: 100%;
+  position: sticky;
+  bottom: 0;
+  top: 0;
+  margin-top: -50%;
+  float: left;
+  display: block;
+  pointer-events: none;
+}
+
+.jp-CodeCell.jp-mod-outputsScrolled .jp-OutputArea-child {
+  padding-top: 6px;
 }
 
 .jp-CodeCell.jp-mod-outputsScrolled .jp-OutputArea-prompt {
@@ -13613,6 +13871,79 @@ body[data-format='mobile'] .jp-InputPrompt {
   overflow: auto;
 }
 
+/* collapseHeadingButton (show always if hiddenCellsButton is _not_ shown) */
+.jp-collapseHeadingButton {
+  display: none;
+  min-height: var(--jp-cell-collapser-min-height);
+  font-size: var(--jp-code-font-size);
+  position: absolute;
+  right: 0;
+  top: 0;
+  bottom: 0;
+  background-color: transparent;
+  background-size: 25px;
+  background-repeat: no-repeat;
+  background-position-x: center;
+  background-position-y: top;
+  background-image: var(--jp-icon-caret-down);
+  border: none;
+  cursor: pointer;
+}
+
+.jp-collapseHeadingButton:hover {
+  background-color: var(--jp-layout-color2);
+}
+
+.jp-collapseHeadingButton.jp-mod-collapsed {
+  background-image: var(--jp-icon-caret-right);
+}
+
+:is(.jp-MarkdownCell:hover, .jp-mod-active) .jp-collapseHeadingButton {
+  display: flex;
+}
+
+/*
+ set the container font size to match that of content
+ so that the nested collapse buttons have the right size
+*/
+.jp-MarkdownCell .jp-InputPrompt {
+  font-size: var(--jp-content-font-size1);
+}
+
+/*
+  Align collapseHeadingButton with cell top header
+  The font sizes are identical to the ones in packages/rendermime/style/base.css
+*/
+.jp-mod-rendered .jp-collapseHeadingButton[data-heading-level='1'] {
+  font-size: var(--jp-content-font-size5);
+  background-position-y: calc(0.3 * var(--jp-content-font-size5));
+}
+
+.jp-mod-rendered .jp-collapseHeadingButton[data-heading-level='2'] {
+  font-size: var(--jp-content-font-size4);
+  background-position-y: calc(0.3 * var(--jp-content-font-size4));
+}
+
+.jp-mod-rendered .jp-collapseHeadingButton[data-heading-level='3'] {
+  font-size: var(--jp-content-font-size3);
+  background-position-y: calc(0.3 * var(--jp-content-font-size3));
+}
+
+.jp-mod-rendered .jp-collapseHeadingButton[data-heading-level='4'] {
+  font-size: var(--jp-content-font-size2);
+  background-position-y: calc(0.3 * var(--jp-content-font-size2));
+}
+
+.jp-mod-rendered .jp-collapseHeadingButton[data-heading-level='5'] {
+  font-size: var(--jp-content-font-size1);
+  background-position-y: top;
+}
+
+.jp-mod-rendered .jp-collapseHeadingButton[data-heading-level='6'] {
+  font-size: var(--jp-content-font-size0);
+  background-position-y: top;
+}
+
 .jp-showHiddenCellsButton {
   margin-left: calc(var(--jp-cell-prompt-width) + 2 * var(--jp-code-padding));
   margin-top: var(--jp-code-padding);
@@ -13623,19 +13954,6 @@ body[data-format='mobile'] .jp-InputPrompt {
 
 .jp-showHiddenCellsButton:hover {
   background-color: var(--jp-border-color2) !important;
-}
-
-.jp-collapseHeadingButton {
-  display: none;
-}
-
-.jp-MarkdownCell:hover .jp-collapseHeadingButton {
-  display: flex;
-  min-height: var(--jp-cell-collapser-min-height);
-  position: absolute;
-  right: 0;
-  top: 0;
-  bottom: 0;
 }
 
 /*-----------------------------------------------------------------------------
@@ -13652,6 +13970,10 @@ body[data-format='mobile'] .jp-InputPrompt {
 | Variables
 |----------------------------------------------------------------------------*/
 
+:root {
+  --jp-notebook-toolbar-padding: 2px 5px 2px 2px;
+}
+
 /*-----------------------------------------------------------------------------
 
 /*-----------------------------------------------------------------------------
@@ -13659,7 +13981,7 @@ body[data-format='mobile'] .jp-InputPrompt {
 |----------------------------------------------------------------------------*/
 
 .jp-NotebookPanel-toolbar {
-  padding: 2px;
+  padding: var(--jp-notebook-toolbar-padding);
 }
 
 .jp-Toolbar-item.jp-Notebook-toolbarCellType .jp-select-wrapper.jp-mod-focused {
@@ -13677,6 +13999,93 @@ body[data-format='mobile'] .jp-InputPrompt {
 
 .jp-Notebook-toolbarCellTypeDropdown span {
   top: 5px !important;
+}
+
+.jp-Toolbar-responsive-popup {
+  position: absolute;
+  height: fit-content;
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  border-bottom: var(--jp-border-width) solid var(--jp-toolbar-border-color);
+  box-shadow: var(--jp-toolbar-box-shadow);
+  background: var(--jp-toolbar-background);
+  min-height: var(--jp-toolbar-micro-height);
+  padding: var(--jp-notebook-toolbar-padding);
+  z-index: 1;
+  right: 0px;
+  top: 0px;
+}
+
+.jp-Toolbar > .jp-Toolbar-responsive-opener {
+  margin-left: auto;
+}
+
+/*-----------------------------------------------------------------------------
+| Copyright (c) Jupyter Development Team.
+| Distributed under the terms of the Modified BSD License.
+|----------------------------------------------------------------------------*/
+
+/*-----------------------------------------------------------------------------
+| Variables
+|----------------------------------------------------------------------------*/
+
+/*-----------------------------------------------------------------------------
+
+/*-----------------------------------------------------------------------------
+| Styles
+|----------------------------------------------------------------------------*/
+
+.jp-Notebook-ExecutionIndicator {
+  position: relative;
+  display: inline-block;
+  height: 100%;
+  z-index: 9997;
+}
+
+.jp-Notebook-ExecutionIndicator-tooltip {
+  visibility: hidden;
+  height: auto;
+  width: max-content;
+  width: -moz-max-content;
+  background-color: var(--jp-layout-color2);
+  color: var(--jp-ui-font-color1);
+  text-align: justify;
+  border-radius: 6px;
+  padding: 0 5px;
+  position: fixed;
+  display: table;
+}
+
+.jp-Notebook-ExecutionIndicator-tooltip.up {
+  transform: translateX(-50%) translateY(-100%) translateY(-32px);
+}
+
+.jp-Notebook-ExecutionIndicator-tooltip.down {
+  transform: translateX(calc(-100% + 16px)) translateY(5px);
+}
+
+.jp-Notebook-ExecutionIndicator-tooltip.hidden {
+  display: none;
+}
+
+.jp-Notebook-ExecutionIndicator:hover .jp-Notebook-ExecutionIndicator-tooltip {
+  visibility: visible;
+}
+
+.jp-Notebook-ExecutionIndicator span {
+  font-size: var(--jp-ui-font-size1);
+  font-family: var(--jp-ui-font-family);
+  color: var(--jp-ui-font-color1);
+  line-height: 24px;
+  display: block;
+}
+
+.jp-Notebook-ExecutionIndicator-progress-bar {
+  display: flex;
+  justify-content: center;
+  height: 100%;
 }
 
 /*-----------------------------------------------------------------------------
@@ -13728,10 +14137,6 @@ body[data-format='mobile'] .jp-InputPrompt {
 
 .jp-MainAreaWidget-ContainStrict .jp-Notebook * {
   contain: strict;
-}
-
-.jp-Notebook-render * {
-  contain: none !important;
 }
 
 .jp-Notebook .jp-Cell {
@@ -13974,6 +14379,86 @@ body[data-format='mobile'] .jp-InputPrompt {
 }
 
 /*-----------------------------------------------------------------------------
+| Side-by-side Mode (.jp-mod-sideBySide)
+|----------------------------------------------------------------------------*/
+:root {
+  --jp-side-by-side-output-size: 1fr;
+  --jp-side-by-side-resized-cell: var(--jp-side-by-side-output-size);
+}
+
+.jp-mod-sideBySide.jp-Notebook .jp-Notebook-cell {
+  margin-top: 3em;
+  margin-bottom: 3em;
+  margin-left: 5%;
+  margin-right: 5%;
+}
+
+.jp-mod-sideBySide.jp-Notebook .jp-CodeCell {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) min-content minmax(
+      0,
+      var(--jp-side-by-side-output-size)
+    );
+  grid-template-rows: auto minmax(0, 1fr) auto;
+  grid-template-areas:
+    'header header header'
+    'input handle output'
+    'footer footer footer';
+}
+
+.jp-mod-sideBySide.jp-Notebook .jp-CodeCell.jp-mod-resizedCell {
+  grid-template-columns: minmax(0, 1fr) min-content minmax(
+      0,
+      var(--jp-side-by-side-resized-cell)
+    );
+}
+
+.jp-mod-sideBySide.jp-Notebook .jp-CodeCell .jp-CellHeader {
+  grid-area: header;
+}
+
+.jp-mod-sideBySide.jp-Notebook .jp-CodeCell .jp-Cell-inputWrapper {
+  grid-area: input;
+}
+
+.jp-mod-sideBySide.jp-Notebook .jp-CodeCell .jp-Cell-outputWrapper {
+  /* overwrite the default margin (no vertical separation needed in side by side move */
+  margin-top: 0;
+  grid-area: output;
+}
+
+.jp-mod-sideBySide.jp-Notebook .jp-CodeCell .jp-CellFooter {
+  grid-area: footer;
+}
+
+.jp-mod-sideBySide.jp-Notebook .jp-CodeCell .jp-CellResizeHandle {
+  grid-area: handle;
+  user-select: none;
+  display: block;
+  height: 100%;
+  cursor: ew-resize;
+  padding: 0 var(--jp-cell-padding);
+}
+
+.jp-mod-sideBySide.jp-Notebook .jp-CodeCell .jp-CellResizeHandle::after {
+  content: '';
+  display: block;
+  background: var(--jp-border-color2);
+  height: 100%;
+  width: 5px;
+}
+
+.jp-mod-sideBySide.jp-Notebook
+  .jp-CodeCell.jp-mod-resizedCell
+  .jp-CellResizeHandle::after {
+  background: var(--jp-border-color0);
+}
+
+.jp-CellResizeHandle {
+  display: none;
+}
+
+/*-----------------------------------------------------------------------------
 | Placeholder
 |----------------------------------------------------------------------------*/
 
@@ -14152,6 +14637,7 @@ all of MD as it is not optimized for dense, information rich UIs.
   --jp-border-color1: var(--md-grey-400);
   --jp-border-color2: var(--md-grey-300);
   --jp-border-color3: var(--md-grey-200);
+  --jp-inverse-border-color: var(--md-grey-600);
   --jp-border-radius: 2px;
 
   /* UI Fonts
@@ -14388,7 +14874,7 @@ all of MD as it is not optimized for dense, information rich UIs.
   --jp-input-active-background: var(--jp-layout-color1);
   --jp-input-hover-background: var(--jp-layout-color1);
   --jp-input-background: var(--md-grey-100);
-  --jp-input-border-color: var(--jp-border-color1);
+  --jp-input-border-color: var(--jp-inverse-border-color);
   --jp-input-active-border-color: var(--jp-brand-color1);
   --jp-input-active-box-shadow-color: rgba(19, 124, 189, 0.3);
 
@@ -14425,6 +14911,20 @@ all of MD as it is not optimized for dense, information rich UIs.
   --jp-mirror-editor-error-color: #f00;
   --jp-mirror-editor-hr-color: #999;
 
+  /*
+    RTC user specific colors.
+    These colors are used for the cursor, username in the editor,
+    and the icon of the user.
+  */
+
+  --jp-collaborator-color1: #ffad8e;
+  --jp-collaborator-color2: #dac83d;
+  --jp-collaborator-color3: #72dd76;
+  --jp-collaborator-color4: #00e4d0;
+  --jp-collaborator-color5: #45d4ff;
+  --jp-collaborator-color6: #e2b1ff;
+  --jp-collaborator-color7: #ff9de6;
+
   /* Vega extension styles */
 
   --jp-vega-background: white;
@@ -14450,6 +14950,19 @@ all of MD as it is not optimized for dense, information rich UIs.
   --jp-icon-contrast-color1: var(--md-green-600);
   --jp-icon-contrast-color2: var(--md-pink-600);
   --jp-icon-contrast-color3: var(--md-blue-600);
+
+  /* File or activity icons and switch semantic variables */
+  --jp-jupyter-icon-color: #f37626;
+  --jp-notebook-icon-color: #f37626;
+  --jp-json-icon-color: var(--md-orange-700);
+  --jp-console-icon-background-color: var(--md-blue-700);
+  --jp-console-icon-color: white;
+  --jp-terminal-icon-background-color: var(--md-grey-800);
+  --jp-terminal-icon-color: var(--md-grey-200);
+  --jp-text-editor-icon-color: var(--md-grey-700);
+  --jp-inspector-icon-color: var(--md-grey-700);
+  --jp-switch-color: var(--md-grey-400);
+  --jp-switch-true-position-color: var(--md-orange-900);
 }
 </style>
 
@@ -14464,10 +14977,6 @@ a.anchor-link {
   display: none;
 }
 
-.highlight  {
-  margin: 0.4em;
-}
-
 /* Input area styling */
 .jp-InputArea {
   overflow: hidden;
@@ -14477,9 +14986,26 @@ a.anchor-link {
   overflow: hidden;
 }
 
-.CodeMirror pre {
+.CodeMirror.cm-s-jupyter .highlight pre {
+/* weird, but --jp-code-padding defined to be 5px but 4px horizontal padding is hardcoded for pre.CodeMirror-line */
+  padding: var(--jp-code-padding) 4px;
   margin: 0;
-  padding: 0;
+
+  font-family: inherit;
+  font-size: inherit;
+  line-height: inherit;
+  color: inherit;
+
+}
+
+.jp-OutputArea-output pre {
+  line-height: inherit;
+  font-family: inherit;
+}
+
+.jp-RenderedText pre {
+  color: var(--jp-content-font-color1);
+  font-size: var(--jp-code-font-size);
 }
 
 /* Using table instead of flexbox so that we can use break-inside property */
@@ -14523,6 +15049,10 @@ body[data-format='mobile'] .jp-OutputArea-child .jp-OutputArea-output {
 /* Hiding the collapser by default */
 .jp-Collapser {
   display: none;
+}
+
+@page {
+    margin: 0.5in; /* Margin for each printed piece of paper */
 }
 
 @media print {
@@ -14572,17 +15102,17 @@ body[data-format='mobile'] .jp-OutputArea-child .jp-OutputArea-output {
     </script>
     <!-- End of mathjax configuration --></head>
 <body class="jp-Notebook" data-jp-theme-light="true" data-jp-theme-name="JupyterLab Light">
-<div class="jp-Cell jp-CodeCell jp-Notebook-cell jp-mod-noOutputs  ">
+<div  class="jp-Cell jp-CodeCell jp-Notebook-cell jp-mod-noOutputs  ">
 <div class="jp-Cell-inputWrapper">
 <div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
 </div>
 <div class="jp-InputArea jp-Cell-inputArea">
-<div class="jp-InputPrompt jp-InputArea-prompt">In&nbsp;[1]:</div>
+<div class="jp-InputPrompt jp-InputArea-prompt">In&nbsp;[13]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
      <div class="CodeMirror cm-s-jupyter">
 <div class=" highlight hl-ipython3"><pre><span></span><span class="n">__author__</span> <span class="o">=</span> <span class="s1">&#39;Carl Stubens &lt;carl.stubens@noirlab.edu&gt;&#39;</span>
-<span class="n">__edited__</span> <span class="o">=</span> <span class="s1">&#39;Gautham Narayan, Chien-Hsiu Lee &lt;chien-hsiu.lee@noirlab.edu&gt;&#39;</span>
-<span class="n">__version__</span> <span class="o">=</span> <span class="s1">&#39;20211130&#39;</span> <span class="c1"># yyyymmdd</span>
+<span class="n">__edited__</span> <span class="o">=</span> <span class="s1">&#39;Gautham Narayan, Chien-Hsiu Lee &lt;chien-hsiu.lee@noirlab.edu&gt;, ANTARES Team &lt;antares@noirlab.edu&gt;&#39;</span>
+<span class="n">__version__</span> <span class="o">=</span> <span class="s1">&#39;20230425&#39;</span> <span class="c1"># yyyymmdd</span>
 <span class="n">__datasets__</span> <span class="o">=</span> <span class="p">[</span><span class="s1">&#39;&#39;</span><span class="p">]</span>
 <span class="n">__keywords__</span> <span class="o">=</span> <span class="p">[</span><span class="s1">&#39;ANTARES&#39;</span><span class="p">,</span> <span class="s1">&#39;transient&#39;</span><span class="p">]</span>
 </pre></div>
@@ -14593,7 +15123,7 @@ body[data-format='mobile'] .jp-OutputArea-child .jp-OutputArea-output {
 </div>
 
 </div>
-<div class="jp-Cell jp-MarkdownCell jp-Notebook-cell">
+<div  class="jp-Cell jp-MarkdownCell jp-Notebook-cell">
 <div class="jp-Cell-inputWrapper">
 <div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
 </div>
@@ -14604,7 +15134,7 @@ body[data-format='mobile'] .jp-OutputArea-child .jp-OutputArea-output {
 <h2 id="Summary">Summary<a class="anchor-link" href="#Summary">&#182;</a></h2><p>This Notebook demonstrates how to write filters for <a href="http://antares.noirlab.edu">ANTARES</a> and test them against a sample of real data from <a href="http://ztf.caltech.edu/">ZTF</a>.</p>
 <p>This Notebook is intended to be used in Astro Data Lab's Jupyter environment. There, you will have access to ANTARES data. If you're not running in Data Lab, <a href="https://datalab.noirlab.edu">sign up for DataLab</a>, then <a href="https://datalab.noirlab.edu/devbooks">log in to the notebook server</a>.</p>
 <p>For new Data Lab accounts, this notebook will be automatically included in your <code>notebooks/</code> directory. Otherwise, you can save this <code>.ipynb</code> notebook file locally, and then upload it to your Data Lab Jupyter notebook server (use the 'Upload' button in the upper right corner).</p>
-<p>In Data Lab, you MUST use the Kernel version "Python 3 (ANTARES 0.4)".</p>
+<p>In Data Lab, you MUST use the Kernel version &quot;Python 3 (ANTARES)&quot;.</p>
 <h2 id="Goals">Goals<a class="anchor-link" href="#Goals">&#182;</a></h2><p>To demonstrate:</p>
 <ol>
 <li>How to write filters using the ANTARES filter API.</li>
@@ -14612,13 +15142,11 @@ body[data-format='mobile'] .jp-OutputArea-child .jp-OutputArea-output {
 </ol>
 <h2 id="Table-of-Contents">Table of Contents<a class="anchor-link" href="#Table-of-Contents">&#182;</a></h2><ul>
 <li><a href="#background">0. Background information on ANTARES</a></li>
-<li><a href="#connect">1. Connect to ANTARES database</a></li>
-<li><a href="#write">2. Write a Filter</a><ul>
-<li><a href="#write-one">2.1 Hellow World</a></li>
+<li><a href="#connect">1. Initalize the dev kit</a></li>
+<li><a href="#write">2. Write a Filter</a></li>
+<li><a href="#write-one">2.1 Hello World</a></li>
 <li><a href="#write-two">2.2 Example of a real Filter</a></li>
 <li><a href="#write-three">2.3 Structure of a Filter</a></li>
-</ul>
-</li>
 <li><a href="#test">3. Test a Filter</a></li>
 <li><a href="#data">4. Upload and use Data File</a></li>
 <li><a href="#submit">5. Submit Filter to ANTARES</a></li>
@@ -14626,7 +15154,7 @@ body[data-format='mobile'] .jp-OutputArea-child .jp-OutputArea-output {
 <p><a class="anchor" id="background"></a></p>
 <h2 id="0.-Background-information-on-ANTARES">0. Background information on ANTARES<a class="anchor-link" href="#0.-Background-information-on-ANTARES">&#182;</a></h2><p>ANTARES receives alerts from surveys in real-time and sends them through a processing pipeline. The pipeline contains the following stages:</p>
 <ol>
-<li>Associate the Alert with the nearest point of known past measurements within a 1" radius. We call this a Locus.</li>
+<li>Associate the Alert with the nearest point of known past measurements within a 1&quot; radius. We call this a Locus.</li>
 <li>Discard Alerts with a high probability of being false detections.</li>
 <li>Discard Alerts with poor image quality.</li>
 <li>Look up associated objects in our catalogs.</li>
@@ -14639,7 +15167,7 @@ body[data-format='mobile'] .jp-OutputArea-child .jp-OutputArea-output {
 </div>
 </div>
 </div>
-</div><div class="jp-Cell jp-CodeCell jp-Notebook-cell   ">
+</div><div  class="jp-Cell jp-CodeCell jp-Notebook-cell   ">
 <div class="jp-Cell-inputWrapper">
 <div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
 </div>
@@ -14664,9 +15192,7 @@ body[data-format='mobile'] .jp-OutputArea-child .jp-OutputArea-output {
 
 
 <div class="jp-OutputArea jp-Cell-outputArea">
-
 <div class="jp-OutputArea-child">
-
     
     <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
 
@@ -14678,32 +15204,40 @@ body[data-format='mobile'] .jp-OutputArea-child .jp-OutputArea-output {
        / \  | \ | |_   _|/ \  |  _ \| ____/ ___|
       / _ \ |  \| | | | / _ \ | |_| |  _| \___ \\
      / ___ \| |\  | | |/ ___ \|  _ /| |___ ___| |
-    /_/   \_\_| \_| |_/_/   \_\_| \_\_____|____/   v2.1.5
+    /_/   \_\_| \_| |_/_/   \_\_| \_\_____|____/   v2.4.1
     
-2022-08-10 13:13:54,643 - WARNING MainThread settings.py:setup_prometheus:106 - Prometheus failed to start with [Errno 98] Address already in use
-Testing loading a random Locus with `dk.get_locus()`...
-2022-08-10 13:13:58,620 - INFO MainThread settings.py:cassandra_session_factory:67 - Establishing connection to Cassandra
-2022-08-10 13:13:59,956 - INFO MainThread settings.py:cassandra_session_factory:67 - Establishing connection to Cassandra
-2022-08-10 13:14:01,180 - INFO MainThread settings.py:cassandra_session_factory:67 - Establishing connection to Cassandra
-2022-08-10 13:14:05,327 - WARNING MainThread cassandra.py:list_by_location:1169 - Catalog object not found (catalog_id=19, object_id=548958647)
-
-ANTARES v2.1.5 DevKit is ready!
-Website: http://antares.noirlab.edu
-Documentation: http://noao.gitlab.io/antares/filter-documentation/
-
 </pre>
 </div>
 </div>
-
 <div class="jp-OutputArea-child">
-
     
     <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
 
 
 <div class="jp-RenderedText jp-OutputArea-output" data-mime-type="application/vnd.jupyter.stderr">
-<pre>/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:397: RuntimeWarning: invalid value encountered in log10
-  result = getattr(ufunc, method)(*inputs, **kwargs)
+<pre>Jaeger tracer already initialized, skipping
+</pre>
+</div>
+</div>
+<div class="jp-OutputArea-child">
+    
+    <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
+
+
+<div class="jp-RenderedText jp-OutputArea-output" data-mime-type="text/plain">
+<pre>2023-04-25 14:22:09,019 - WARNING MainThread settings.py:setup_prometheus:124 - Prometheus failed to start with [Errno 98] Address already in use
+Testing loading a random Locus with `dk.get_locus()`...
+2023-04-25 14:22:11,595 - INFO MainThread settings.py:cassandra_session_factory:84 - Establishing connection to Cassandra
+2023-04-25 14:22:12,826 - INFO MainThread settings.py:cassandra_session_factory:88 - Connection to Cassandra established
+2023-04-25 14:22:12,827 - INFO MainThread settings.py:cassandra_session_factory:84 - Establishing connection to Cassandra
+2023-04-25 14:22:14,039 - INFO MainThread settings.py:cassandra_session_factory:88 - Connection to Cassandra established
+2023-04-25 14:22:14,040 - INFO MainThread settings.py:cassandra_session_factory:84 - Establishing connection to Cassandra
+2023-04-25 14:22:15,203 - INFO MainThread settings.py:cassandra_session_factory:88 - Connection to Cassandra established
+
+ANTARES v2.4.1 DevKit is ready!
+Website: http://antares.noirlab.edu
+Documentation: https://nsf-noirlab.gitlab.io/csdc/antares/antares/
+
 </pre>
 </div>
 </div>
@@ -14713,7 +15247,7 @@ Documentation: http://noao.gitlab.io/antares/filter-documentation/
 </div>
 
 </div>
-<div class="jp-Cell jp-MarkdownCell jp-Notebook-cell">
+<div  class="jp-Cell jp-MarkdownCell jp-Notebook-cell">
 <div class="jp-Cell-inputWrapper">
 <div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
 </div>
@@ -14726,7 +15260,7 @@ Documentation: http://noao.gitlab.io/antares/filter-documentation/
 </div>
 </div>
 </div>
-</div><div class="jp-Cell jp-CodeCell jp-Notebook-cell jp-mod-noOutputs  ">
+</div><div  class="jp-Cell jp-CodeCell jp-Notebook-cell jp-mod-noOutputs  ">
 <div class="jp-Cell-inputWrapper">
 <div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
 </div>
@@ -14753,7 +15287,7 @@ Documentation: http://noao.gitlab.io/antares/filter-documentation/
 </div>
 
 </div>
-<div class="jp-Cell jp-MarkdownCell jp-Notebook-cell">
+<div  class="jp-Cell jp-MarkdownCell jp-Notebook-cell">
 <div class="jp-Cell-inputWrapper">
 <div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
 </div>
@@ -14764,7 +15298,7 @@ Documentation: http://noao.gitlab.io/antares/filter-documentation/
 </div>
 </div>
 </div>
-</div><div class="jp-Cell jp-CodeCell jp-Notebook-cell   ">
+</div><div  class="jp-Cell jp-CodeCell jp-Notebook-cell   ">
 <div class="jp-Cell-inputWrapper">
 <div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
 </div>
@@ -14793,29 +15327,25 @@ Documentation: http://noao.gitlab.io/antares/filter-documentation/
 
 
 <div class="jp-OutputArea jp-Cell-outputArea">
-
 <div class="jp-OutputArea-child">
-
     
     <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
 
 
 <div class="jp-RenderedText jp-OutputArea-output" data-mime-type="text/plain">
-<pre>2022-08-10 13:14:09,061 - WARNING MainThread cassandra.py:list_by_location:1169 - Catalog object not found (catalog_id=19, object_id=548958647)
-Hello Locus ANT2018h5lrq
-{&#39;locus_id&#39;: &#39;ANT2018h5lrq&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2018h5lrq&#34;), &#39;t&#39;: 0.00020771899999871835, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}
+<pre>2023-04-25 14:22:33,115 - WARNING MainThread cassandra.py:list_by_location:1167 - Catalog object not found (catalog_id=19, object_id=634809564)
+Hello Locus ANT2020bbrei
+{&#39;locus_id&#39;: &#39;ANT2020bbrei&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2020bbrei&#34;), &#39;t&#39;: 9.559899999977972e-05, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}
 </pre>
 </div>
 </div>
-
 <div class="jp-OutputArea-child">
-
     
     <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
 
 
 <div class="jp-RenderedText jp-OutputArea-output" data-mime-type="application/vnd.jupyter.stderr">
-<pre>/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:397: RuntimeWarning: invalid value encountered in log10
+<pre>/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:396: RuntimeWarning: invalid value encountered in log10
   result = getattr(ufunc, method)(*inputs, **kwargs)
 </pre>
 </div>
@@ -14826,7 +15356,7 @@ Hello Locus ANT2018h5lrq
 </div>
 
 </div>
-<div class="jp-Cell jp-MarkdownCell jp-Notebook-cell">
+<div  class="jp-Cell jp-MarkdownCell jp-Notebook-cell">
 <div class="jp-Cell-inputWrapper">
 <div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
 </div>
@@ -14838,7 +15368,7 @@ Hello Locus ANT2018h5lrq
 </div>
 </div>
 </div>
-</div><div class="jp-Cell jp-CodeCell jp-Notebook-cell jp-mod-noOutputs  ">
+</div><div  class="jp-Cell jp-CodeCell jp-Notebook-cell jp-mod-noOutputs  ">
 <div class="jp-Cell-inputWrapper">
 <div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
 </div>
@@ -14898,7 +15428,7 @@ Hello Locus ANT2018h5lrq
 </div>
 
 </div>
-<div class="jp-Cell jp-MarkdownCell jp-Notebook-cell">
+<div  class="jp-Cell jp-MarkdownCell jp-Notebook-cell">
 <div class="jp-Cell-inputWrapper">
 <div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
 </div>
@@ -14906,12 +15436,12 @@ Hello Locus ANT2018h5lrq
 </div><div class="jp-RenderedHTMLCommon jp-RenderedMarkdown jp-MarkdownOutput " data-mime-type="text/markdown">
 <p><a class="anchor" id="write-three"></a></p>
 <h3 id="2.3-Structure-of-a-Filter">2.3 Structure of a Filter<a class="anchor-link" href="#2.3-Structure-of-a-Filter">&#182;</a></h3><p>The filter <code>MyFilter</code> below does nothing of scientific interest, but it demonstrates the most basic use of the filter API.</p>
-<p>The Filter API consists of the Locus Object, which is passed to the Filter as the single parameter. The <code>MyFilter</code> shows examples of how to use the Locus data. For detailed information on the Locus Object, please visit ANTARES documentation at <a href="https://noao.gitlab.io/antares/filter-documentation/devkit/locus.html">https://noao.gitlab.io/antares/filter-documentation/devkit/locus.html</a></p>
+<p>The Filter API consists of the Locus Object, which is passed to the Filter as the single parameter. The <code>MyFilter</code> shows examples of how to use the Locus data. For detailed information on the Locus Object, please visit ANTARES documentation at <a href="https://nsf-noirlab.gitlab.io/csdc/antares/antares/devkit/locus.html">https://nsf-noirlab.gitlab.io/csdc/antares/antares/devkit/locus.html</a></p>
 
 </div>
 </div>
 </div>
-</div><div class="jp-Cell jp-CodeCell jp-Notebook-cell jp-mod-noOutputs  ">
+</div><div  class="jp-Cell jp-CodeCell jp-Notebook-cell jp-mod-noOutputs  ">
 <div class="jp-Cell-inputWrapper">
 <div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
 </div>
@@ -14932,7 +15462,7 @@ Hello Locus ANT2018h5lrq
     <span class="c1"># List of Locus properties which the Filter depends on.</span>
     <span class="c1"># If an incoming Alert&#39;s Locus does not have all properties listed here,</span>
     <span class="c1"># then the Filter will not run on it.</span>
-    <span class="n">INPUT_LOCUS_PROPERTIES</span> <span class="o">=</span> <span class="p">[</span>
+    <span class="n">REQUIRED_LOCUS_PROPERTIES</span> <span class="o">=</span> <span class="p">[</span>
         <span class="c1"># eg:</span>
         <span class="s1">&#39;ztf_object_id&#39;</span><span class="p">,</span>
         <span class="c1"># etc.</span>
@@ -14943,7 +15473,7 @@ Hello Locus ANT2018h5lrq
     <span class="c1"># List of Alert properties which the Filter depends on.</span>
     <span class="c1"># If an incoming Alert does not have all properties listed here, then</span>
     <span class="c1"># the Filter will not run on it.</span>
-    <span class="n">INPUT_ALERT_PROPERTIES</span> <span class="o">=</span> <span class="p">[</span>
+    <span class="n">REQUIRED_ALERT_PROPERTIES</span> <span class="o">=</span> <span class="p">[</span>
         <span class="c1"># eg:</span>
         <span class="s1">&#39;passband&#39;</span><span class="p">,</span>
         <span class="s1">&#39;mag&#39;</span><span class="p">,</span>
@@ -14956,7 +15486,7 @@ Hello Locus ANT2018h5lrq
     <span class="c1"># List of Tag names which the Filter depends on.</span>
     <span class="c1"># If an incoming Alert&#39;s Locus does not have all Tags listed here, then</span>
     <span class="c1"># the Filter will not run on it.</span>
-    <span class="n">INPUT_TAGS</span> <span class="o">=</span> <span class="p">[</span>
+    <span class="n">REQUIRED_TAGS</span> <span class="o">=</span> <span class="p">[</span>
         <span class="c1"># eg:</span>
         <span class="s1">&#39;high_snr&#39;</span><span class="p">,</span>
         <span class="c1"># etc.</span>
@@ -15057,7 +15587,7 @@ Hello Locus ANT2018h5lrq
 </div>
 
 </div>
-<div class="jp-Cell jp-MarkdownCell jp-Notebook-cell">
+<div  class="jp-Cell jp-MarkdownCell jp-Notebook-cell">
 <div class="jp-Cell-inputWrapper">
 <div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
 </div>
@@ -15069,7 +15599,7 @@ Hello Locus ANT2018h5lrq
 </div>
 </div>
 </div>
-</div><div class="jp-Cell jp-CodeCell jp-Notebook-cell jp-mod-noOutputs  ">
+</div><div  class="jp-Cell jp-CodeCell jp-Notebook-cell jp-mod-noOutputs  ">
 <div class="jp-Cell-inputWrapper">
 <div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
 </div>
@@ -15096,7 +15626,7 @@ Hello Locus ANT2018h5lrq
 </div>
 
 </div>
-<div class="jp-Cell jp-MarkdownCell jp-Notebook-cell">
+<div  class="jp-Cell jp-MarkdownCell jp-Notebook-cell">
 <div class="jp-Cell-inputWrapper">
 <div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
 </div>
@@ -15107,7 +15637,7 @@ Hello Locus ANT2018h5lrq
 </div>
 </div>
 </div>
-</div><div class="jp-Cell jp-CodeCell jp-Notebook-cell   ">
+</div><div  class="jp-Cell jp-CodeCell jp-Notebook-cell   ">
 <div class="jp-Cell-inputWrapper">
 <div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
 </div>
@@ -15141,43 +15671,37 @@ Hello Locus ANT2018h5lrq
 
 
 <div class="jp-OutputArea jp-Cell-outputArea">
-
 <div class="jp-OutputArea-child">
-
     
     <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
 
 
 <div class="jp-RenderedText jp-OutputArea-output" data-mime-type="text/plain">
-<pre>2022-08-10 13:14:24,790 - WARNING MainThread cassandra.py:list_by_location:1169 - Catalog object not found (catalog_id=19, object_id=548958647)
+<pre>2023-04-25 14:23:15,922 - WARNING MainThread cassandra.py:list_by_location:1167 - Catalog object not found (catalog_id=19, object_id=634809564)
 </pre>
 </div>
 </div>
-
 <div class="jp-OutputArea-child">
-
     
     <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
 
 
 <div class="jp-RenderedText jp-OutputArea-output" data-mime-type="application/vnd.jupyter.stderr">
-<pre>/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:397: RuntimeWarning: invalid value encountered in log10
+<pre>/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:396: RuntimeWarning: invalid value encountered in log10
   result = getattr(ufunc, method)(*inputs, **kwargs)
 </pre>
 </div>
 </div>
-
 <div class="jp-OutputArea-child">
-
     
     <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
 
 
 <div class="jp-RenderedText jp-OutputArea-output" data-mime-type="text/plain">
-<pre>Hello Locus ANT2018h5lrq
-{&#39;locus_id&#39;: &#39;ANT2018h5lrq&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2018h5lrq&#34;), &#39;t&#39;: 0.00010604399999891712, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}
+<pre>Hello Locus ANT2020bbrei
+{&#39;locus_id&#39;: &#39;ANT2020bbrei&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2020bbrei&#34;), &#39;t&#39;: 9.513700000063352e-05, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}
 Hello Locus ANT2020hcm7s
-{&#39;locus_id&#39;: &#39;ANT2020hcm7s&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2020hcm7s&#34;), &#39;t&#39;: 0.00010958000000016455, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}
+{&#39;locus_id&#39;: &#39;ANT2020hcm7s&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2020hcm7s&#34;), &#39;t&#39;: 9.552200000051414e-05, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}
 </pre>
 </div>
 </div>
@@ -15187,7 +15711,7 @@ Hello Locus ANT2020hcm7s
 </div>
 
 </div>
-<div class="jp-Cell jp-MarkdownCell jp-Notebook-cell">
+<div  class="jp-Cell jp-MarkdownCell jp-Notebook-cell">
 <div class="jp-Cell-inputWrapper">
 <div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
 </div>
@@ -15198,12 +15722,12 @@ Hello Locus ANT2020hcm7s
 </div>
 </div>
 </div>
-</div><div class="jp-Cell jp-CodeCell jp-Notebook-cell   ">
+</div><div  class="jp-Cell jp-CodeCell jp-Notebook-cell   ">
 <div class="jp-Cell-inputWrapper">
 <div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
 </div>
 <div class="jp-InputArea jp-Cell-inputArea">
-<div class="jp-InputPrompt jp-InputArea-prompt">In&nbsp;[9]:</div>
+<div class="jp-InputPrompt jp-InputArea-prompt">In&nbsp;[10]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
      <div class="CodeMirror cm-s-jupyter">
 <div class=" highlight hl-ipython3"><pre><span></span><span class="c1"># Execute HelloWorld filter on 100 random locii</span>
@@ -15224,265 +15748,159 @@ Hello Locus ANT2020hcm7s
 
 
 <div class="jp-OutputArea jp-Cell-outputArea">
-
 <div class="jp-OutputArea-child">
-
     
     <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
 
 
 <div class="jp-RenderedText jp-OutputArea-output" data-mime-type="text/plain">
-<pre>2022-08-10 13:14:53,649 - WARNING MainThread cassandra.py:list_by_location:1169 - Catalog object not found (catalog_id=19, object_id=548958647)
+<pre>2023-04-25 14:28:47,805 - WARNING MainThread cassandra.py:list_by_location:1167 - Catalog object not found (catalog_id=19, object_id=634809564)
 </pre>
 </div>
 </div>
-
 <div class="jp-OutputArea-child">
-
     
     <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
 
 
 <div class="jp-RenderedText jp-OutputArea-output" data-mime-type="application/vnd.jupyter.stderr">
-<pre>/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:397: RuntimeWarning: invalid value encountered in log10
+<pre>/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:396: RuntimeWarning: invalid value encountered in log10
   result = getattr(ufunc, method)(*inputs, **kwargs)
 </pre>
 </div>
 </div>
-
 <div class="jp-OutputArea-child">
-
     
     <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
 
 
 <div class="jp-RenderedText jp-OutputArea-output" data-mime-type="text/plain">
-<pre>Hello Locus ANT2018h5lrq
-Hello Locus ANT202284zos5406d9j
-2022-08-10 13:14:55,817 - WARNING MainThread cassandra.py:list_by_location:1169 - Catalog object not found (catalog_id=19, object_id=472988617)
-Hello Locus ANT20202uum4
-2022-08-10 13:14:56,674 - WARNING MainThread cassandra.py:list_by_location:1169 - Catalog object not found (catalog_id=19, object_id=592386369)
-Hello Locus ANT2022sz5ssrdu1dhv
-Hello Locus ANT2022wcnvfar1iaxa
-2022-08-10 13:14:59,157 - WARNING MainThread cassandra.py:list_by_location:1169 - Catalog object not found (catalog_id=19, object_id=492387242)
+<pre>Hello Locus ANT2020bbrei
+2023-04-25 14:28:50,643 - WARNING MainThread cassandra.py:list_by_location:1167 - Catalog object not found (catalog_id=19, object_id=698523106)
 </pre>
 </div>
 </div>
-
 <div class="jp-OutputArea-child">
-
     
     <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
 
 
 <div class="jp-RenderedText jp-OutputArea-output" data-mime-type="application/vnd.jupyter.stderr">
-<pre>/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:397: RuntimeWarning: invalid value encountered in log10
+<pre>/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:396: RuntimeWarning: invalid value encountered in log10
   result = getattr(ufunc, method)(*inputs, **kwargs)
 </pre>
 </div>
 </div>
-
 <div class="jp-OutputArea-child">
-
     
     <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
 
 
 <div class="jp-RenderedText jp-OutputArea-output" data-mime-type="text/plain">
-<pre>Hello Locus ANT2018hc6cm
-2022-08-10 13:15:01,003 - WARNING MainThread cassandra.py:list_by_location:1169 - Catalog object not found (catalog_id=19, object_id=554583015)
+<pre>Hello Locus ANT2020jojuc
+2023-04-25 14:28:52,917 - WARNING MainThread cassandra.py:list_by_location:1167 - Catalog object not found (catalog_id=19, object_id=607041990)
 </pre>
 </div>
 </div>
-
 <div class="jp-OutputArea-child">
-
     
     <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
 
 
 <div class="jp-RenderedText jp-OutputArea-output" data-mime-type="application/vnd.jupyter.stderr">
-<pre>/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:397: RuntimeWarning: invalid value encountered in log10
+<pre>/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:396: RuntimeWarning: invalid value encountered in log10
   result = getattr(ufunc, method)(*inputs, **kwargs)
 </pre>
 </div>
 </div>
-
 <div class="jp-OutputArea-child">
-
     
     <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
 
 
 <div class="jp-RenderedText jp-OutputArea-output" data-mime-type="text/plain">
-<pre>Hello Locus ANT2019nbtus
-2022-08-10 13:15:02,619 - WARNING MainThread cassandra.py:list_by_location:1169 - Catalog object not found (catalog_id=19, object_id=471662039)
+<pre>Hello Locus ANT2018ba7as
+2023-04-25 14:28:55,286 - WARNING MainThread cassandra.py:list_by_location:1167 - Catalog object not found (catalog_id=19, object_id=662848338)
+Hello Locus ANT2020a4nco
+Hello Locus ANT2023t92jq14b9zrc
+2023-04-25 14:28:58,366 - WARNING MainThread cassandra.py:list_by_location:1167 - Catalog object not found (catalog_id=19, object_id=597997077)
+Hello Locus ANT2020a4w3e
+2023-04-25 14:29:00,376 - WARNING MainThread cassandra.py:list_by_location:1167 - Catalog object not found (catalog_id=19, object_id=654300737)
 </pre>
 </div>
 </div>
-
 <div class="jp-OutputArea-child">
-
     
     <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
 
 
 <div class="jp-RenderedText jp-OutputArea-output" data-mime-type="application/vnd.jupyter.stderr">
-<pre>/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:397: RuntimeWarning: invalid value encountered in log10
+<pre>/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:396: RuntimeWarning: invalid value encountered in log10
   result = getattr(ufunc, method)(*inputs, **kwargs)
 </pre>
 </div>
 </div>
-
 <div class="jp-OutputArea-child">
-
     
     <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
 
 
 <div class="jp-RenderedText jp-OutputArea-output" data-mime-type="text/plain">
-<pre>Hello Locus ANT20217n3te
-2022-08-10 13:15:03,944 - WARNING MainThread cassandra.py:list_by_location:1169 - Catalog object not found (catalog_id=19, object_id=511257660)
+<pre>Hello Locus ANT2018iqoq
+2023-04-25 14:29:02,783 - WARNING MainThread cassandra.py:list_by_location:1167 - Catalog object not found (catalog_id=19, object_id=618970098)
+Hello Locus ANT2020a7khs
+Hello Locus ANT2023ztpvwxlwgyn7
+2023-04-25 14:29:06,092 - WARNING MainThread cassandra.py:list_by_location:1167 - Catalog object not found (catalog_id=19, object_id=683662522)
+Hello Locus ANT2020cnps4
+2023-04-25 14:29:09,104 - WARNING MainThread cassandra.py:list_by_location:1167 - Catalog object not found (catalog_id=19, object_id=658715695)
 </pre>
 </div>
 </div>
-
 <div class="jp-OutputArea-child">
-
     
     <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
 
 
 <div class="jp-RenderedText jp-OutputArea-output" data-mime-type="application/vnd.jupyter.stderr">
-<pre>/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:397: RuntimeWarning: invalid value encountered in log10
+<pre>/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:396: RuntimeWarning: invalid value encountered in log10
   result = getattr(ufunc, method)(*inputs, **kwargs)
 </pre>
 </div>
 </div>
-
 <div class="jp-OutputArea-child">
-
     
     <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
 
 
 <div class="jp-RenderedText jp-OutputArea-output" data-mime-type="text/plain">
-<pre>Hello Locus ANT2019awmuk
-Hello Locus ANT202201gghmzf3kzz
-2022-08-10 13:15:06,188 - WARNING MainThread cassandra.py:list_by_location:1169 - Catalog object not found (catalog_id=19, object_id=568623508)
+<pre>Hello Locus ANT20195tat2
+2023-04-25 14:29:11,879 - WARNING MainThread cassandra.py:list_by_location:1167 - Catalog object not found (catalog_id=19, object_id=611329812)
 </pre>
 </div>
 </div>
-
 <div class="jp-OutputArea-child">
-
     
     <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
 
 
 <div class="jp-RenderedText jp-OutputArea-output" data-mime-type="application/vnd.jupyter.stderr">
-<pre>/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:397: RuntimeWarning: invalid value encountered in log10
+<pre>/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:396: RuntimeWarning: invalid value encountered in log10
   result = getattr(ufunc, method)(*inputs, **kwargs)
 </pre>
 </div>
 </div>
-
 <div class="jp-OutputArea-child">
-
     
     <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
 
 
 <div class="jp-RenderedText jp-OutputArea-output" data-mime-type="text/plain">
-<pre>Hello Locus ANT20206tdje
-2022-08-10 13:15:08,734 - WARNING MainThread cassandra.py:list_by_location:1169 - Catalog object not found (catalog_id=19, object_id=468850192)
+<pre>Hello Locus ANT2018b4w6k
+2023-04-25 14:29:15,663 - WARNING MainThread cassandra.py:list_by_location:1167 - Catalog object not found (catalog_id=19, object_id=668679822)
 </pre>
 </div>
 </div>
-
 <div class="jp-OutputArea-child">
-
-    
-    <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
-
-
-<div class="jp-RenderedText jp-OutputArea-output" data-mime-type="application/vnd.jupyter.stderr">
-<pre>/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:397: RuntimeWarning: invalid value encountered in log10
-  result = getattr(ufunc, method)(*inputs, **kwargs)
-</pre>
-</div>
-</div>
-
-<div class="jp-OutputArea-child">
-
-    
-    <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
-
-
-<div class="jp-RenderedText jp-OutputArea-output" data-mime-type="text/plain">
-<pre>Hello Locus ANT2020qgnjo
-2022-08-10 13:15:10,953 - WARNING MainThread cassandra.py:list_by_location:1169 - Catalog object not found (catalog_id=19, object_id=572048708)
-Hello Locus ANT202045kqm
-2022-08-10 13:15:12,239 - WARNING MainThread cassandra.py:list_by_location:1169 - Catalog object not found (catalog_id=19, object_id=589266727)
-Hello Locus ANT2022om7a6nuh4lrx
-2022-08-10 13:15:14,911 - WARNING MainThread cassandra.py:list_by_location:1169 - Catalog object not found (catalog_id=19, object_id=592793524)
-</pre>
-</div>
-</div>
-
-<div class="jp-OutputArea-child">
-
-    
-    <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
-
-
-<div class="jp-RenderedText jp-OutputArea-output" data-mime-type="application/vnd.jupyter.stderr">
-<pre>/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:397: RuntimeWarning: invalid value encountered in log10
-  result = getattr(ufunc, method)(*inputs, **kwargs)
-</pre>
-</div>
-</div>
-
-<div class="jp-OutputArea-child">
-
-    
-    <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
-
-
-<div class="jp-RenderedText jp-OutputArea-output" data-mime-type="text/plain">
-<pre>Hello Locus ANT2018hayaa
-2022-08-10 13:15:16,994 - WARNING MainThread cassandra.py:list_by_location:1169 - Catalog object not found (catalog_id=19, object_id=468403334)
-</pre>
-</div>
-</div>
-
-<div class="jp-OutputArea-child">
-
-    
-    <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
-
-
-<div class="jp-RenderedText jp-OutputArea-output" data-mime-type="application/vnd.jupyter.stderr">
-<pre>/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:397: RuntimeWarning: invalid value encountered in log10
-  result = getattr(ufunc, method)(*inputs, **kwargs)
-</pre>
-</div>
-</div>
-
-<div class="jp-OutputArea-child">
-
-    
-    <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
-
-
-<div class="jp-RenderedText jp-OutputArea-output" data-mime-type="text/plain">
-<pre>Hello Locus ANT2020aehmxqq
-</pre>
-</div>
-</div>
-
-<div class="jp-OutputArea-child">
-
     
     <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
 
@@ -15492,950 +15910,940 @@ Hello Locus ANT2022om7a6nuh4lrx
 </pre>
 </div>
 </div>
-
 <div class="jp-OutputArea-child">
-
     
     <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
 
 
 <div class="jp-RenderedText jp-OutputArea-output" data-mime-type="text/plain">
-<pre>Hello Locus ANT2022pryenjmb8vwm
-2022-08-10 13:15:19,545 - WARNING MainThread cassandra.py:list_by_location:1169 - Catalog object not found (catalog_id=19, object_id=544105239)
-Hello Locus ANT2020aengcka
-2022-08-10 13:15:21,144 - WARNING MainThread cassandra.py:list_by_location:1169 - Catalog object not found (catalog_id=19, object_id=515803367)
+<pre>Hello Locus ANT2020a4sh2
+2023-04-25 14:29:17,178 - WARNING MainThread cassandra.py:list_by_location:1167 - Catalog object not found (catalog_id=19, object_id=699321404)
+Hello Locus ANT2023splnbnda0wyl
+Hello Locus ANT20231jsy3o1bb4eo
+2023-04-25 14:29:19,923 - WARNING MainThread cassandra.py:list_by_location:1167 - Catalog object not found (catalog_id=19, object_id=691628475)
 </pre>
 </div>
 </div>
-
 <div class="jp-OutputArea-child">
-
     
     <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
 
 
 <div class="jp-RenderedText jp-OutputArea-output" data-mime-type="application/vnd.jupyter.stderr">
-<pre>/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:397: RuntimeWarning: invalid value encountered in log10
+<pre>/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:396: RuntimeWarning: invalid value encountered in log10
   result = getattr(ufunc, method)(*inputs, **kwargs)
 </pre>
 </div>
 </div>
-
 <div class="jp-OutputArea-child">
-
     
     <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
 
 
 <div class="jp-RenderedText jp-OutputArea-output" data-mime-type="text/plain">
-<pre>Hello Locus ANT2020z2wla
-Hello Locus ANT20227os4qm7bi5mf
-2022-08-10 13:15:23,546 - WARNING MainThread cassandra.py:list_by_location:1169 - Catalog object not found (catalog_id=19, object_id=504401148)
-Hello Locus ANT2020sbt2e
-2022-08-10 13:15:25,339 - WARNING MainThread cassandra.py:list_by_location:1169 - Catalog object not found (catalog_id=19, object_id=538687544)
-Hello Locus ANT20202uuky
-2022-08-10 13:15:27,861 - WARNING MainThread cassandra.py:list_by_location:1169 - Catalog object not found (catalog_id=19, object_id=591979701)
+<pre>Hello Locus ANT2020a4ype
+2023-04-25 14:29:21,672 - WARNING MainThread cassandra.py:list_by_location:1167 - Catalog object not found (catalog_id=19, object_id=664965152)
 </pre>
 </div>
 </div>
-
 <div class="jp-OutputArea-child">
-
     
     <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
 
 
 <div class="jp-RenderedText jp-OutputArea-output" data-mime-type="application/vnd.jupyter.stderr">
-<pre>/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:397: RuntimeWarning: invalid value encountered in log10
+<pre>/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:396: RuntimeWarning: invalid value encountered in log10
   result = getattr(ufunc, method)(*inputs, **kwargs)
 </pre>
 </div>
 </div>
-
 <div class="jp-OutputArea-child">
-
     
     <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
 
 
 <div class="jp-RenderedText jp-OutputArea-output" data-mime-type="text/plain">
-<pre>Hello Locus ANT2020luytg
-2022-08-10 13:15:29,393 - WARNING MainThread cassandra.py:list_by_location:1169 - Catalog object not found (catalog_id=19, object_id=547152769)
+<pre>Hello Locus ANT2022ahnak
+2023-04-25 14:29:24,123 - WARNING MainThread cassandra.py:list_by_location:1167 - Catalog object not found (catalog_id=19, object_id=702384729)
 </pre>
 </div>
 </div>
-
 <div class="jp-OutputArea-child">
-
     
     <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
 
 
 <div class="jp-RenderedText jp-OutputArea-output" data-mime-type="application/vnd.jupyter.stderr">
-<pre>/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:397: RuntimeWarning: invalid value encountered in log10
+<pre>/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:396: RuntimeWarning: invalid value encountered in log10
   result = getattr(ufunc, method)(*inputs, **kwargs)
 </pre>
 </div>
 </div>
-
 <div class="jp-OutputArea-child">
-
     
     <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
 
 
 <div class="jp-RenderedText jp-OutputArea-output" data-mime-type="text/plain">
-<pre>Hello Locus ANT20212p54u
-2022-08-10 13:15:30,985 - WARNING MainThread cassandra.py:list_by_location:1169 - Catalog object not found (catalog_id=19, object_id=507360904)
+<pre>Hello Locus ANT2019kgrao
+2023-04-25 14:29:26,233 - WARNING MainThread cassandra.py:list_by_location:1167 - Catalog object not found (catalog_id=19, object_id=595144369)
 </pre>
 </div>
 </div>
-
 <div class="jp-OutputArea-child">
-
     
     <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
 
 
 <div class="jp-RenderedText jp-OutputArea-output" data-mime-type="application/vnd.jupyter.stderr">
-<pre>/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:397: RuntimeWarning: invalid value encountered in log10
+<pre>/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:396: RuntimeWarning: invalid value encountered in log10
   result = getattr(ufunc, method)(*inputs, **kwargs)
 </pre>
 </div>
 </div>
-
 <div class="jp-OutputArea-child">
-
     
     <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
 
 
 <div class="jp-RenderedText jp-OutputArea-output" data-mime-type="text/plain">
-<pre>Hello Locus ANT2020z222g
-2022-08-10 13:15:33,162 - WARNING MainThread cassandra.py:list_by_location:1169 - Catalog object not found (catalog_id=19, object_id=511807598)
+<pre>Hello Locus ANT2020a4nym
+2023-04-25 14:29:28,868 - WARNING MainThread cassandra.py:list_by_location:1167 - Catalog object not found (catalog_id=19, object_id=680209068)
 </pre>
 </div>
 </div>
-
 <div class="jp-OutputArea-child">
+    
+    <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
 
+
+<div class="jp-RenderedText jp-OutputArea-output" data-mime-type="application/vnd.jupyter.stderr">
+<pre>/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:396: RuntimeWarning: invalid value encountered in log10
+  result = getattr(ufunc, method)(*inputs, **kwargs)
+</pre>
+</div>
+</div>
+<div class="jp-OutputArea-child">
+    
+    <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
+
+
+<div class="jp-RenderedText jp-OutputArea-output" data-mime-type="text/plain">
+<pre>Hello Locus ANT2020bbbl4
+2023-04-25 14:29:31,382 - WARNING MainThread cassandra.py:list_by_location:1167 - Catalog object not found (catalog_id=19, object_id=671217303)
+</pre>
+</div>
+</div>
+<div class="jp-OutputArea-child">
+    
+    <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
+
+
+<div class="jp-RenderedText jp-OutputArea-output" data-mime-type="application/vnd.jupyter.stderr">
+<pre>/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:396: RuntimeWarning: invalid value encountered in log10
+  result = getattr(ufunc, method)(*inputs, **kwargs)
+</pre>
+</div>
+</div>
+<div class="jp-OutputArea-child">
+    
+    <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
+
+
+<div class="jp-RenderedText jp-OutputArea-output" data-mime-type="text/plain">
+<pre>Hello Locus ANT2020a4huk
+Hello Locus ANT2023v4zf9rhuttjt
+2023-04-25 14:29:34,729 - WARNING MainThread cassandra.py:list_by_location:1167 - Catalog object not found (catalog_id=19, object_id=628225256)
+</pre>
+</div>
+</div>
+<div class="jp-OutputArea-child">
+    
+    <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
+
+
+<div class="jp-RenderedText jp-OutputArea-output" data-mime-type="application/vnd.jupyter.stderr">
+<pre>/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:396: RuntimeWarning: invalid value encountered in log10
+  result = getattr(ufunc, method)(*inputs, **kwargs)
+</pre>
+</div>
+</div>
+<div class="jp-OutputArea-child">
+    
+    <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
+
+
+<div class="jp-RenderedText jp-OutputArea-output" data-mime-type="text/plain">
+<pre>Hello Locus ANT2020a7mnm
+Hello Locus ANT2023aol8q84cow9t
+2023-04-25 14:29:37,617 - WARNING MainThread cassandra.py:list_by_location:1167 - Catalog object not found (catalog_id=19, object_id=631530733)
+</pre>
+</div>
+</div>
+<div class="jp-OutputArea-child">
+    
+    <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
+
+
+<div class="jp-RenderedText jp-OutputArea-output" data-mime-type="application/vnd.jupyter.stderr">
+<pre>/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:396: RuntimeWarning: invalid value encountered in log10
+  result = getattr(ufunc, method)(*inputs, **kwargs)
+</pre>
+</div>
+</div>
+<div class="jp-OutputArea-child">
+    
+    <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
+
+
+<div class="jp-RenderedText jp-OutputArea-output" data-mime-type="text/plain">
+<pre>Hello Locus ANT2020a4vei
+2023-04-25 14:29:40,296 - WARNING MainThread cassandra.py:list_by_location:1167 - Catalog object not found (catalog_id=19, object_id=681006507)
+2023-04-25 14:29:40,297 - WARNING MainThread cassandra.py:list_by_location:1167 - Catalog object not found (catalog_id=19, object_id=681006508)
+</pre>
+</div>
+</div>
+<div class="jp-OutputArea-child">
+    
+    <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
+
+
+<div class="jp-RenderedText jp-OutputArea-output" data-mime-type="application/vnd.jupyter.stderr">
+<pre>/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:396: RuntimeWarning: invalid value encountered in log10
+  result = getattr(ufunc, method)(*inputs, **kwargs)
+</pre>
+</div>
+</div>
+<div class="jp-OutputArea-child">
+    
+    <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
+
+
+<div class="jp-RenderedText jp-OutputArea-output" data-mime-type="text/plain">
+<pre>Hello Locus ANT2020a7iqu
+Hello Locus ANT2023iyl2166056su
+2023-04-25 14:29:42,929 - WARNING MainThread cassandra.py:list_by_location:1167 - Catalog object not found (catalog_id=19, object_id=607180137)
+Hello Locus ANT2020dxbdw
+Hello Locus ANT2023vbj3pzhqasjz
+2023-04-25 14:29:46,821 - WARNING MainThread cassandra.py:list_by_location:1167 - Catalog object not found (catalog_id=19, object_id=601710656)
+</pre>
+</div>
+</div>
+<div class="jp-OutputArea-child">
+    
+    <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
+
+
+<div class="jp-RenderedText jp-OutputArea-output" data-mime-type="application/vnd.jupyter.stderr">
+<pre>/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:396: RuntimeWarning: invalid value encountered in log10
+  result = getattr(ufunc, method)(*inputs, **kwargs)
+</pre>
+</div>
+</div>
+<div class="jp-OutputArea-child">
+    
+    <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
+
+
+<div class="jp-RenderedText jp-OutputArea-output" data-mime-type="text/plain">
+<pre>Hello Locus ANT2020a4w5w
+Hello Locus ANT2023370hacslywz0
+2023-04-25 14:29:50,764 - WARNING MainThread cassandra.py:list_by_location:1167 - Catalog object not found (catalog_id=19, object_id=680475568)
+</pre>
+</div>
+</div>
+<div class="jp-OutputArea-child">
+    
+    <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
+
+
+<div class="jp-RenderedText jp-OutputArea-output" data-mime-type="application/vnd.jupyter.stderr">
+<pre>/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:396: RuntimeWarning: invalid value encountered in log10
+  result = getattr(ufunc, method)(*inputs, **kwargs)
+</pre>
+</div>
+</div>
+<div class="jp-OutputArea-child">
+    
+    <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
+
+
+<div class="jp-RenderedText jp-OutputArea-output" data-mime-type="text/plain">
+<pre>Hello Locus ANT2020dyi6a
+Hello Locus ANT2023n9naw2k6bdai
+2023-04-25 14:29:54,414 - WARNING MainThread cassandra.py:list_by_location:1167 - Catalog object not found (catalog_id=19, object_id=694556409)
+</pre>
+</div>
+</div>
+<div class="jp-OutputArea-child">
+    
+    <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
+
+
+<div class="jp-RenderedText jp-OutputArea-output" data-mime-type="application/vnd.jupyter.stderr">
+<pre>/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:396: RuntimeWarning: invalid value encountered in log10
+  result = getattr(ufunc, method)(*inputs, **kwargs)
+</pre>
+</div>
+</div>
+<div class="jp-OutputArea-child">
+    
+    <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
+
+
+<div class="jp-RenderedText jp-OutputArea-output" data-mime-type="text/plain">
+<pre>Hello Locus ANT2020bbfke
+Hello Locus ANT2023bdj85krps9kd
+2023-04-25 14:29:57,697 - WARNING MainThread cassandra.py:list_by_location:1167 - Catalog object not found (catalog_id=19, object_id=618136164)
+Hello Locus ANT2020batf4
+2023-04-25 14:30:00,575 - WARNING MainThread cassandra.py:list_by_location:1167 - Catalog object not found (catalog_id=19, object_id=665762465)
+</pre>
+</div>
+</div>
+<div class="jp-OutputArea-child">
+    
+    <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
+
+
+<div class="jp-RenderedText jp-OutputArea-output" data-mime-type="application/vnd.jupyter.stderr">
+<pre>/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:396: RuntimeWarning: invalid value encountered in log10
+  result = getattr(ufunc, method)(*inputs, **kwargs)
+</pre>
+</div>
+</div>
+<div class="jp-OutputArea-child">
+    
+    <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
+
+
+<div class="jp-RenderedText jp-OutputArea-output" data-mime-type="text/plain">
+<pre>Hello Locus ANT2020bbhd2
+2023-04-25 14:30:02,732 - WARNING MainThread cassandra.py:list_by_location:1167 - Catalog object not found (catalog_id=19, object_id=600884006)
+</pre>
+</div>
+</div>
+<div class="jp-OutputArea-child">
+    
+    <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
+
+
+<div class="jp-RenderedText jp-OutputArea-output" data-mime-type="application/vnd.jupyter.stderr">
+<pre>/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:396: RuntimeWarning: invalid value encountered in log10
+  result = getattr(ufunc, method)(*inputs, **kwargs)
+</pre>
+</div>
+</div>
+<div class="jp-OutputArea-child">
+    
+    <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
+
+
+<div class="jp-RenderedText jp-OutputArea-output" data-mime-type="text/plain">
+<pre>Hello Locus ANT2020a4lhq
+Hello Locus ANT202314jwe8jpe3gb
+2023-04-25 14:30:06,151 - WARNING MainThread cassandra.py:list_by_location:1167 - Catalog object not found (catalog_id=19, object_id=637382631)
+</pre>
+</div>
+</div>
+<div class="jp-OutputArea-child">
+    
+    <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
+
+
+<div class="jp-RenderedText jp-OutputArea-output" data-mime-type="application/vnd.jupyter.stderr">
+<pre>/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:396: RuntimeWarning: invalid value encountered in log10
+  result = getattr(ufunc, method)(*inputs, **kwargs)
+</pre>
+</div>
+</div>
+<div class="jp-OutputArea-child">
+    
+    <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
+
+
+<div class="jp-RenderedText jp-OutputArea-output" data-mime-type="text/plain">
+<pre>Hello Locus ANT2020a4wxi
+Hello Locus ANT202314jwe8jpe3gb
+2023-04-25 14:30:09,192 - WARNING MainThread cassandra.py:list_by_location:1167 - Catalog object not found (catalog_id=19, object_id=637382631)
+</pre>
+</div>
+</div>
+<div class="jp-OutputArea-child">
+    
+    <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
+
+
+<div class="jp-RenderedText jp-OutputArea-output" data-mime-type="application/vnd.jupyter.stderr">
+<pre>/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:396: RuntimeWarning: invalid value encountered in log10
+  result = getattr(ufunc, method)(*inputs, **kwargs)
+</pre>
+</div>
+</div>
+<div class="jp-OutputArea-child">
+    
+    <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
+
+
+<div class="jp-RenderedText jp-OutputArea-output" data-mime-type="text/plain">
+<pre>Hello Locus ANT2020a4wxi
+2023-04-25 14:30:12,009 - WARNING MainThread cassandra.py:list_by_location:1167 - Catalog object not found (catalog_id=19, object_id=636976955)
+</pre>
+</div>
+</div>
+<div class="jp-OutputArea-child">
+    
+    <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
+
+
+<div class="jp-RenderedText jp-OutputArea-output" data-mime-type="application/vnd.jupyter.stderr">
+<pre>/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:396: RuntimeWarning: invalid value encountered in log10
+  result = getattr(ufunc, method)(*inputs, **kwargs)
+</pre>
+</div>
+</div>
+<div class="jp-OutputArea-child">
+    
+    <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
+
+
+<div class="jp-RenderedText jp-OutputArea-output" data-mime-type="text/plain">
+<pre>Hello Locus ANT2020ba3fi
+Hello Locus ANT2023747zh5dn2sgm
+2023-04-25 14:30:15,433 - WARNING MainThread cassandra.py:list_by_location:1167 - Catalog object not found (catalog_id=19, object_id=699055598)
+Hello Locus ANT2020jojae
+Hello Locus ANT20234832qs145vmx
+2023-04-25 14:30:18,987 - WARNING MainThread cassandra.py:list_by_location:1167 - Catalog object not found (catalog_id=19, object_id=624769746)
+</pre>
+</div>
+</div>
+<div class="jp-OutputArea-child">
     
     <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
 
 
 <div class="jp-RenderedText jp-OutputArea-output" data-mime-type="application/vnd.jupyter.stderr">
 <pre>WARNING: AstropyDeprecationWarning: The truth value of a Quantity is ambiguous. In the future this will raise a ValueError. [astropy.units.quantity]
+/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:396: RuntimeWarning: invalid value encountered in log10
+  result = getattr(ufunc, method)(*inputs, **kwargs)
 </pre>
 </div>
 </div>
-
 <div class="jp-OutputArea-child">
-
     
     <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
 
 
 <div class="jp-RenderedText jp-OutputArea-output" data-mime-type="text/plain">
-<pre>Hello Locus ANT2018ibyoa
-2022-08-10 13:15:35,165 - WARNING MainThread cassandra.py:list_by_location:1169 - Catalog object not found (catalog_id=19, object_id=502154600)
+<pre>Hello Locus ANT2020a4mf6
+2023-04-25 14:30:21,842 - WARNING MainThread cassandra.py:list_by_location:1167 - Catalog object not found (catalog_id=19, object_id=691628565)
 </pre>
 </div>
 </div>
-
 <div class="jp-OutputArea-child">
-
     
     <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
 
 
 <div class="jp-RenderedText jp-OutputArea-output" data-mime-type="application/vnd.jupyter.stderr">
-<pre>/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:397: RuntimeWarning: invalid value encountered in log10
+<pre>/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:396: RuntimeWarning: invalid value encountered in log10
   result = getattr(ufunc, method)(*inputs, **kwargs)
 </pre>
 </div>
 </div>
-
 <div class="jp-OutputArea-child">
-
     
     <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
 
 
 <div class="jp-RenderedText jp-OutputArea-output" data-mime-type="text/plain">
-<pre>Hello Locus ANT2020z225k
-Hello Locus ANT2022wte1pvglgdl5
-Hello Locus ANT2022oqifuv8mxr88
-2022-08-10 13:15:37,631 - WARNING MainThread cassandra.py:list_by_location:1169 - Catalog object not found (catalog_id=19, object_id=526666788)
+<pre>Hello Locus ANT2020a4wuc
+2023-04-25 14:30:23,829 - WARNING MainThread cassandra.py:list_by_location:1167 - Catalog object not found (catalog_id=19, object_id=655240129)
 </pre>
 </div>
 </div>
-
 <div class="jp-OutputArea-child">
-
     
     <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
 
 
 <div class="jp-RenderedText jp-OutputArea-output" data-mime-type="application/vnd.jupyter.stderr">
-<pre>/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:397: RuntimeWarning: invalid value encountered in log10
+<pre>/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:396: RuntimeWarning: invalid value encountered in log10
   result = getattr(ufunc, method)(*inputs, **kwargs)
 </pre>
 </div>
 </div>
-
 <div class="jp-OutputArea-child">
-
     
     <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
 
 
 <div class="jp-RenderedText jp-OutputArea-output" data-mime-type="text/plain">
-<pre>Hello Locus ANT2022le4ty9rc8mzn
-Hello Locus ANT2022vvjfedp4ihls
-Hello Locus ANT2020lxfuy
-2022-08-10 13:15:40,684 - WARNING MainThread cassandra.py:list_by_location:1169 - Catalog object not found (catalog_id=19, object_id=517857938)
+<pre>Hello Locus ANT2020gpmum
+2023-04-25 14:30:25,920 - WARNING MainThread cassandra.py:list_by_location:1167 - Catalog object not found (catalog_id=19, object_id=634945279)
 </pre>
 </div>
 </div>
-
 <div class="jp-OutputArea-child">
-
     
     <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
 
 
 <div class="jp-RenderedText jp-OutputArea-output" data-mime-type="application/vnd.jupyter.stderr">
-<pre>/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:397: RuntimeWarning: invalid value encountered in log10
+<pre>/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:396: RuntimeWarning: invalid value encountered in log10
   result = getattr(ufunc, method)(*inputs, **kwargs)
 </pre>
 </div>
 </div>
-
 <div class="jp-OutputArea-child">
-
     
     <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
 
 
 <div class="jp-RenderedText jp-OutputArea-output" data-mime-type="text/plain">
-<pre>Hello Locus ANT2020aezxmgy
-2022-08-10 13:15:41,856 - WARNING MainThread cassandra.py:list_by_location:1169 - Catalog object not found (catalog_id=19, object_id=538965567)
+<pre>Hello Locus ANT2020bavne
+2023-04-25 14:30:28,164 - WARNING MainThread cassandra.py:list_by_location:1167 - Catalog object not found (catalog_id=19, object_id=638998376)
 </pre>
 </div>
 </div>
-
 <div class="jp-OutputArea-child">
-
     
     <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
 
 
 <div class="jp-RenderedText jp-OutputArea-output" data-mime-type="application/vnd.jupyter.stderr">
-<pre>/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:397: RuntimeWarning: invalid value encountered in log10
+<pre>/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:396: RuntimeWarning: invalid value encountered in log10
   result = getattr(ufunc, method)(*inputs, **kwargs)
 </pre>
 </div>
 </div>
-
 <div class="jp-OutputArea-child">
-
     
     <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
 
 
 <div class="jp-RenderedText jp-OutputArea-output" data-mime-type="text/plain">
-<pre>Hello Locus ANT20213hbwq
-2022-08-10 13:15:43,555 - WARNING MainThread cassandra.py:list_by_location:1169 - Catalog object not found (catalog_id=19, object_id=549799634)
+<pre>Hello Locus ANT2020eiwag
+Hello Locus ANT20237jb0i4iiw8y8
+2023-04-25 14:30:30,864 - WARNING MainThread cassandra.py:list_by_location:1167 - Catalog object not found (catalog_id=19, object_id=630843024)
+Hello Locus ANT2020a4wtg
+Hello Locus ANT2023halulggfjl42
+Hello Locus ANT20233rhp8r5irpnw
+Hello Locus ANT2023ic3autpzusc7
+2023-04-25 14:30:34,894 - WARNING MainThread cassandra.py:list_by_location:1167 - Catalog object not found (catalog_id=19, object_id=610227690)
+Hello Locus ANT2019urge6
+2023-04-25 14:30:37,840 - WARNING MainThread cassandra.py:list_by_location:1167 - Catalog object not found (catalog_id=19, object_id=668148293)
 </pre>
 </div>
 </div>
-
 <div class="jp-OutputArea-child">
-
     
     <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
 
 
 <div class="jp-RenderedText jp-OutputArea-output" data-mime-type="application/vnd.jupyter.stderr">
-<pre>/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:397: RuntimeWarning: invalid value encountered in log10
+<pre>/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:396: RuntimeWarning: invalid value encountered in log10
   result = getattr(ufunc, method)(*inputs, **kwargs)
 </pre>
 </div>
 </div>
-
 <div class="jp-OutputArea-child">
-
     
     <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
 
 
 <div class="jp-RenderedText jp-OutputArea-output" data-mime-type="text/plain">
-<pre>Hello Locus ANT2020p7s6c
-Hello Locus ANT2022sq882ybua6fu
-2022-08-10 13:15:45,963 - WARNING MainThread cassandra.py:list_by_location:1169 - Catalog object not found (catalog_id=19, object_id=489208920)
+<pre>Hello Locus ANT2020bbbr4
+Hello Locus ANT2023el71ihkdi6il
+2023-04-25 14:30:39,973 - WARNING MainThread cassandra.py:list_by_location:1167 - Catalog object not found (catalog_id=19, object_id=611468093)
+Hello Locus ANT20235qu8lr0x0ufz
+Hello Locus ANT2023clklkhk9rg7f
+2023-04-25 14:30:42,974 - WARNING MainThread cassandra.py:list_by_location:1167 - Catalog object not found (catalog_id=19, object_id=648520854)
 </pre>
 </div>
 </div>
-
 <div class="jp-OutputArea-child">
-
     
     <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
 
 
 <div class="jp-RenderedText jp-OutputArea-output" data-mime-type="application/vnd.jupyter.stderr">
-<pre>/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:397: RuntimeWarning: invalid value encountered in log10
+<pre>/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:396: RuntimeWarning: invalid value encountered in log10
   result = getattr(ufunc, method)(*inputs, **kwargs)
 </pre>
 </div>
 </div>
-
 <div class="jp-OutputArea-child">
-
     
     <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
 
 
 <div class="jp-RenderedText jp-OutputArea-output" data-mime-type="text/plain">
-<pre>Hello Locus ANT2018mnzzo
-2022-08-10 13:15:47,763 - WARNING MainThread cassandra.py:list_by_location:1169 - Catalog object not found (catalog_id=19, object_id=490800411)
+<pre>Hello Locus ANT2020a4jo6
+2023-04-25 14:30:45,258 - WARNING MainThread cassandra.py:list_by_location:1167 - Catalog object not found (catalog_id=19, object_id=589852984)
+Hello Locus ANT2019vbn5a
+2023-04-25 14:30:46,186 - WARNING MainThread cassandra.py:list_by_location:1167 - Catalog object not found (catalog_id=19, object_id=593244628)
+Hello Locus ANT2023bo8e959apozt
+2023-04-25 14:30:48,188 - WARNING MainThread cassandra.py:list_by_location:1167 - Catalog object not found (catalog_id=19, object_id=661787781)
 </pre>
 </div>
 </div>
-
 <div class="jp-OutputArea-child">
-
     
     <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
 
 
 <div class="jp-RenderedText jp-OutputArea-output" data-mime-type="application/vnd.jupyter.stderr">
-<pre>/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:397: RuntimeWarning: invalid value encountered in log10
+<pre>/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:396: RuntimeWarning: invalid value encountered in log10
   result = getattr(ufunc, method)(*inputs, **kwargs)
 </pre>
 </div>
 </div>
-
 <div class="jp-OutputArea-child">
-
     
     <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
 
 
 <div class="jp-RenderedText jp-OutputArea-output" data-mime-type="text/plain">
-<pre>Hello Locus ANT2020lumr6
-Hello Locus ANT2022bonajwguj68b
-2022-08-10 13:15:50,900 - WARNING MainThread cassandra.py:list_by_location:1169 - Catalog object not found (catalog_id=19, object_id=565470881)
+<pre>Hello Locus ANT2020a7ufq
+2023-04-25 14:30:51,368 - WARNING MainThread cassandra.py:list_by_location:1167 - Catalog object not found (catalog_id=19, object_id=661520471)
 </pre>
 </div>
 </div>
-
 <div class="jp-OutputArea-child">
-
     
     <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
 
 
 <div class="jp-RenderedText jp-OutputArea-output" data-mime-type="application/vnd.jupyter.stderr">
-<pre>/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:397: RuntimeWarning: invalid value encountered in log10
+<pre>/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:396: RuntimeWarning: invalid value encountered in log10
   result = getattr(ufunc, method)(*inputs, **kwargs)
 </pre>
 </div>
 </div>
-
 <div class="jp-OutputArea-child">
-
     
     <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
 
 
 <div class="jp-RenderedText jp-OutputArea-output" data-mime-type="text/plain">
-<pre>Hello Locus ANT2020z2vms
-Hello Locus ANT2022t3fzel65s43g
-2022-08-10 13:15:52,853 - WARNING MainThread cassandra.py:list_by_location:1169 - Catalog object not found (catalog_id=19, object_id=510706062)
+<pre>Hello Locus ANT2020akpae
+2023-04-25 14:30:55,036 - WARNING MainThread cassandra.py:list_by_location:1167 - Catalog object not found (catalog_id=19, object_id=699321356)
 </pre>
 </div>
 </div>
-
 <div class="jp-OutputArea-child">
-
     
     <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
 
 
 <div class="jp-RenderedText jp-OutputArea-output" data-mime-type="application/vnd.jupyter.stderr">
-<pre>/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:397: RuntimeWarning: invalid value encountered in log10
+<pre>/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:396: RuntimeWarning: invalid value encountered in log10
   result = getattr(ufunc, method)(*inputs, **kwargs)
 </pre>
 </div>
 </div>
-
 <div class="jp-OutputArea-child">
-
     
     <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
 
 
 <div class="jp-RenderedText jp-OutputArea-output" data-mime-type="text/plain">
-<pre>Hello Locus ANT2021fhczw
-2022-08-10 13:15:54,513 - WARNING MainThread cassandra.py:list_by_location:1169 - Catalog object not found (catalog_id=19, object_id=518954102)
+<pre>Hello Locus ANT2020a4mbm
+2023-04-25 14:30:57,540 - WARNING MainThread cassandra.py:list_by_location:1167 - Catalog object not found (catalog_id=19, object_id=605934981)
 </pre>
 </div>
 </div>
-
 <div class="jp-OutputArea-child">
-
     
     <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
 
 
 <div class="jp-RenderedText jp-OutputArea-output" data-mime-type="application/vnd.jupyter.stderr">
-<pre>/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:397: RuntimeWarning: invalid value encountered in log10
+<pre>/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:396: RuntimeWarning: invalid value encountered in log10
   result = getattr(ufunc, method)(*inputs, **kwargs)
 </pre>
 </div>
 </div>
-
 <div class="jp-OutputArea-child">
-
     
     <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
 
 
 <div class="jp-RenderedText jp-OutputArea-output" data-mime-type="text/plain">
-<pre>Hello Locus ANT2020pcx6i
-Hello Locus ANT202285kw9pprr34t
-2022-08-10 13:15:56,936 - WARNING MainThread cassandra.py:list_by_location:1169 - Catalog object not found (catalog_id=19, object_id=510981891)
+<pre>Hello Locus ANT2020bbgta
+2023-04-25 14:31:00,546 - WARNING MainThread cassandra.py:list_by_location:1167 - Catalog object not found (catalog_id=19, object_id=668148293)
 </pre>
 </div>
 </div>
-
 <div class="jp-OutputArea-child">
-
     
     <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
 
 
 <div class="jp-RenderedText jp-OutputArea-output" data-mime-type="application/vnd.jupyter.stderr">
-<pre>/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:397: RuntimeWarning: invalid value encountered in log10
+<pre>/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:396: RuntimeWarning: invalid value encountered in log10
   result = getattr(ufunc, method)(*inputs, **kwargs)
 </pre>
 </div>
 </div>
-
 <div class="jp-OutputArea-child">
-
     
     <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
 
 
 <div class="jp-RenderedText jp-OutputArea-output" data-mime-type="text/plain">
-<pre>Hello Locus ANT2020lzep4
-Hello Locus ANT2022msdzamqajuu3
-2022-08-10 13:15:59,802 - WARNING MainThread cassandra.py:list_by_location:1169 - Catalog object not found (catalog_id=19, object_id=585146141)
+<pre>Hello Locus ANT2020bbbr4
+Hello Locus ANT2023el71ihkdi6il
+Hello Locus ANT2023f3kqo5itddfu
+Hello Locus ANT2020hjubq
+Hello Locus ANT2023clklkhk9rg7f
+2023-04-25 14:31:07,229 - WARNING MainThread cassandra.py:list_by_location:1167 - Catalog object not found (catalog_id=19, object_id=648520854)
 </pre>
 </div>
 </div>
-
 <div class="jp-OutputArea-child">
-
     
     <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
 
 
 <div class="jp-RenderedText jp-OutputArea-output" data-mime-type="application/vnd.jupyter.stderr">
-<pre>/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:397: RuntimeWarning: invalid value encountered in log10
+<pre>/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:396: RuntimeWarning: invalid value encountered in log10
   result = getattr(ufunc, method)(*inputs, **kwargs)
 </pre>
 </div>
 </div>
-
 <div class="jp-OutputArea-child">
-
     
     <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
 
 
 <div class="jp-RenderedText jp-OutputArea-output" data-mime-type="text/plain">
-<pre>Hello Locus ANT2020pubp4
-Hello Locus ANT2022ci5xylord3qe
-Hello Locus ANT2022yflceiioi4he
-Hello Locus ANT20227liiraokppig
-Hello Locus ANT20223q61z9so8gzp
-Hello Locus ANT2022wifvhu1hgvj8
-2022-08-10 13:16:05,190 - WARNING MainThread cassandra.py:list_by_location:1169 - Catalog object not found (catalog_id=19, object_id=569909003)
+<pre>Hello Locus ANT2020a4jo6
+2023-04-25 14:31:09,496 - WARNING MainThread cassandra.py:list_by_location:1167 - Catalog object not found (catalog_id=19, object_id=589852984)
+Hello Locus ANT2019vbn5a
+2023-04-25 14:31:10,413 - WARNING MainThread cassandra.py:list_by_location:1167 - Catalog object not found (catalog_id=19, object_id=593244628)
+Hello Locus ANT2023bo8e959apozt
+2023-04-25 14:31:12,443 - WARNING MainThread cassandra.py:list_by_location:1167 - Catalog object not found (catalog_id=19, object_id=661787781)
 </pre>
 </div>
 </div>
-
 <div class="jp-OutputArea-child">
-
     
     <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
 
 
 <div class="jp-RenderedText jp-OutputArea-output" data-mime-type="application/vnd.jupyter.stderr">
-<pre>/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:397: RuntimeWarning: invalid value encountered in log10
+<pre>/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:396: RuntimeWarning: invalid value encountered in log10
   result = getattr(ufunc, method)(*inputs, **kwargs)
 </pre>
 </div>
 </div>
-
 <div class="jp-OutputArea-child">
-
     
     <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
 
 
 <div class="jp-RenderedText jp-OutputArea-output" data-mime-type="text/plain">
-<pre>Hello Locus ANT2020z2vnu
-2022-08-10 13:16:06,891 - WARNING MainThread cassandra.py:list_by_location:1169 - Catalog object not found (catalog_id=19, object_id=527209169)
+<pre>Hello Locus ANT2020a7ufq
+2023-04-25 14:31:15,605 - WARNING MainThread cassandra.py:list_by_location:1167 - Catalog object not found (catalog_id=19, object_id=661520471)
 </pre>
 </div>
 </div>
-
 <div class="jp-OutputArea-child">
-
     
     <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
 
 
 <div class="jp-RenderedText jp-OutputArea-output" data-mime-type="application/vnd.jupyter.stderr">
-<pre>/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:397: RuntimeWarning: invalid value encountered in log10
+<pre>/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:396: RuntimeWarning: invalid value encountered in log10
   result = getattr(ufunc, method)(*inputs, **kwargs)
 </pre>
 </div>
 </div>
-
 <div class="jp-OutputArea-child">
-
     
     <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
 
 
 <div class="jp-RenderedText jp-OutputArea-output" data-mime-type="text/plain">
-<pre>Hello Locus ANT2020qhv4s
-Hello Locus ANT20229r32zqdbx3xd
-2022-08-10 13:16:09,183 - WARNING MainThread cassandra.py:list_by_location:1169 - Catalog object not found (catalog_id=19, object_id=512769266)
-Hello Locus ANT202045hxo
-2022-08-10 13:16:10,602 - WARNING MainThread cassandra.py:list_by_location:1169 - Catalog object not found (catalog_id=19, object_id=516625498)
+<pre>Hello Locus ANT2020akpae
+2023-04-25 14:31:18,785 - WARNING MainThread cassandra.py:list_by_location:1167 - Catalog object not found (catalog_id=19, object_id=699321356)
 </pre>
 </div>
 </div>
-
 <div class="jp-OutputArea-child">
-
     
     <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
 
 
 <div class="jp-RenderedText jp-OutputArea-output" data-mime-type="application/vnd.jupyter.stderr">
-<pre>/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:397: RuntimeWarning: invalid value encountered in log10
+<pre>/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:396: RuntimeWarning: invalid value encountered in log10
   result = getattr(ufunc, method)(*inputs, **kwargs)
 </pre>
 </div>
 </div>
-
 <div class="jp-OutputArea-child">
-
     
     <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
 
 
 <div class="jp-RenderedText jp-OutputArea-output" data-mime-type="text/plain">
-<pre>Hello Locus ANT2020aekxwny
-Hello Locus ANT2022z2c9zsl3lyi1
-Hello Locus ANT20222t6123a325tg
-Hello Locus ANT2022fs81pa94uypm
-2022-08-10 13:16:13,971 - WARNING MainThread cassandra.py:list_by_location:1169 - Catalog object not found (catalog_id=19, object_id=558128352)
+<pre>Hello Locus ANT2020a4mbm
+2023-04-25 14:31:21,293 - WARNING MainThread cassandra.py:list_by_location:1167 - Catalog object not found (catalog_id=19, object_id=605934981)
 </pre>
 </div>
 </div>
-
 <div class="jp-OutputArea-child">
-
     
     <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
 
 
 <div class="jp-RenderedText jp-OutputArea-output" data-mime-type="application/vnd.jupyter.stderr">
-<pre>/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:397: RuntimeWarning: invalid value encountered in log10
+<pre>/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:396: RuntimeWarning: invalid value encountered in log10
   result = getattr(ufunc, method)(*inputs, **kwargs)
 </pre>
 </div>
 </div>
-
 <div class="jp-OutputArea-child">
-
     
     <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
 
 
 <div class="jp-RenderedText jp-OutputArea-output" data-mime-type="text/plain">
-<pre>Hello Locus ANT2020qixa4
-Hello Locus ANT2022k76yv401ugd0
-Hello Locus ANT2022hnbm13161e5p
-2022-08-10 13:16:16,701 - WARNING MainThread cassandra.py:list_by_location:1169 - Catalog object not found (catalog_id=19, object_id=510290808)
-Hello Locus ANT2021axlzi
-Hello Locus ANT2022nksgjuhh7uby
+<pre>Hello Locus ANT2020bbgta
+2023-04-25 14:31:23,744 - WARNING MainThread cassandra.py:list_by_location:1167 - Catalog object not found (catalog_id=19, object_id=678736381)
+Hello Locus ANT2020vkm6q
+2023-04-25 14:31:26,693 - WARNING MainThread cassandra.py:list_by_location:1167 - Catalog object not found (catalog_id=19, object_id=591753445)
+Hello Locus ANT2020ba2dw
+2023-04-25 14:31:29,851 - WARNING MainThread cassandra.py:list_by_location:1167 - Catalog object not found (catalog_id=19, object_id=601435246)
 </pre>
 </div>
 </div>
-
 <div class="jp-OutputArea-child">
-
     
     <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
 
 
 <div class="jp-RenderedText jp-OutputArea-output" data-mime-type="application/vnd.jupyter.stderr">
-<pre>/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:397: RuntimeWarning: invalid value encountered in log10
+<pre>/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:396: RuntimeWarning: invalid value encountered in log10
   result = getattr(ufunc, method)(*inputs, **kwargs)
 </pre>
 </div>
 </div>
-
 <div class="jp-OutputArea-child">
-
     
     <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
 
 
 <div class="jp-RenderedText jp-OutputArea-output" data-mime-type="text/plain">
-<pre>Hello Locus ANT2020k2loc
-2022-08-10 13:16:21,017 - WARNING MainThread cassandra.py:list_by_location:1169 - Catalog object not found (catalog_id=19, object_id=835737716)
+<pre>Hello Locus ANT2020a4mhe
+2023-04-25 14:31:32,496 - WARNING MainThread cassandra.py:list_by_location:1167 - Catalog object not found (catalog_id=19, object_id=595549395)
 </pre>
 </div>
 </div>
-
 <div class="jp-OutputArea-child">
-
     
     <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
 
 
 <div class="jp-RenderedText jp-OutputArea-output" data-mime-type="application/vnd.jupyter.stderr">
-<pre>/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:397: RuntimeWarning: invalid value encountered in log10
+<pre>/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:396: RuntimeWarning: invalid value encountered in log10
   result = getattr(ufunc, method)(*inputs, **kwargs)
 </pre>
 </div>
 </div>
-
 <div class="jp-OutputArea-child">
-
     
     <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
 
 
 <div class="jp-RenderedText jp-OutputArea-output" data-mime-type="text/plain">
-<pre>Hello Locus ANT2020656nu
-2022-08-10 13:16:22,792 - WARNING MainThread cassandra.py:list_by_location:1169 - Catalog object not found (catalog_id=19, object_id=887541554)
+<pre>Hello Locus ANT2020a4vwu
+Hello Locus ANT20239ug0z3idyr9y
+2023-04-25 14:31:34,440 - WARNING MainThread cassandra.py:list_by_location:1167 - Catalog object not found (catalog_id=19, object_id=633583898)
+Hello Locus ANT2023cd9o5bimvpzo
+2023-04-25 14:31:36,425 - WARNING MainThread cassandra.py:list_by_location:1167 - Catalog object not found (catalog_id=19, object_id=604542027)
+Hello Locus ANT2019yriee
+2023-04-25 14:31:38,366 - WARNING MainThread cassandra.py:list_by_location:1167 - Catalog object not found (catalog_id=19, object_id=605379424)
 </pre>
 </div>
 </div>
-
 <div class="jp-OutputArea-child">
-
     
     <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
 
 
 <div class="jp-RenderedText jp-OutputArea-output" data-mime-type="application/vnd.jupyter.stderr">
-<pre>/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:397: RuntimeWarning: invalid value encountered in log10
+<pre>/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:396: RuntimeWarning: invalid value encountered in log10
   result = getattr(ufunc, method)(*inputs, **kwargs)
 </pre>
 </div>
 </div>
-
 <div class="jp-OutputArea-child">
-
     
     <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
 
 
 <div class="jp-RenderedText jp-OutputArea-output" data-mime-type="text/plain">
-<pre>Hello Locus ANT2018g67c4
-2022-08-10 13:16:24,436 - WARNING MainThread cassandra.py:list_by_location:1169 - Catalog object not found (catalog_id=19, object_id=873749389)
-Hello Locus ANT2019ekbgq
-Hello Locus ANT2022tapq9wivg5sz
-Hello Locus ANT2022g5fwxd1lon1p
-2022-08-10 13:16:27,416 - WARNING MainThread cassandra.py:list_by_location:1169 - Catalog object not found (catalog_id=19, object_id=864703191)
+<pre>Hello Locus ANT2020baya4
+Hello Locus ANT2023wfvyxsqww87b
+2023-04-25 14:31:41,567 - WARNING MainThread cassandra.py:list_by_location:1167 - Catalog object not found (catalog_id=19, object_id=595684580)
 </pre>
 </div>
 </div>
-
 <div class="jp-OutputArea-child">
-
     
     <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
 
 
 <div class="jp-RenderedText jp-OutputArea-output" data-mime-type="application/vnd.jupyter.stderr">
-<pre>/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:397: RuntimeWarning: invalid value encountered in log10
+<pre>/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:396: RuntimeWarning: invalid value encountered in log10
   result = getattr(ufunc, method)(*inputs, **kwargs)
 </pre>
 </div>
 </div>
-
 <div class="jp-OutputArea-child">
-
     
     <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
 
 
 <div class="jp-RenderedText jp-OutputArea-output" data-mime-type="text/plain">
-<pre>Hello Locus ANT2018gcwyq
-2022-08-10 13:16:29,239 - WARNING MainThread cassandra.py:list_by_location:1169 - Catalog object not found (catalog_id=19, object_id=860504408)
-Hello Locus ANT2019bh3rm
-Hello Locus ANT2022hwf5ki4m8wcp
-Hello Locus ANT2022n25j7nbqphbi
-2022-08-10 13:16:31,588 - WARNING MainThread cassandra.py:list_by_location:1169 - Catalog object not found (catalog_id=19, object_id=898235882)
-Hello Locus ANT20228oli4o80w5yf
-2022-08-10 13:16:33,322 - WARNING MainThread cassandra.py:list_by_location:1169 - Catalog object not found (catalog_id=19, object_id=902073776)
+<pre>Hello Locus ANT2020a7n46
+Hello Locus ANT2023w11fstqn72dy
+Hello Locus ANT2023ehq8i9pcoff4
+Hello Locus ANT2023j6mxk72liaxp
+Hello Locus ANT2023hct4fvf9zhjw
+2023-04-25 14:31:46,845 - WARNING MainThread cassandra.py:list_by_location:1167 - Catalog object not found (catalog_id=19, object_id=683396236)
+Hello Locus ANT2023vxh6d9xytpsu
+Hello Locus ANT2023m1wmvtr02d43
+2023-04-25 14:31:49,418 - WARNING MainThread cassandra.py:list_by_location:1167 - Catalog object not found (catalog_id=19, object_id=619942956)
 </pre>
 </div>
 </div>
-
 <div class="jp-OutputArea-child">
-
     
     <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
 
 
 <div class="jp-RenderedText jp-OutputArea-output" data-mime-type="application/vnd.jupyter.stderr">
-<pre>/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:397: RuntimeWarning: invalid value encountered in log10
+<pre>/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:396: RuntimeWarning: invalid value encountered in log10
   result = getattr(ufunc, method)(*inputs, **kwargs)
 </pre>
 </div>
 </div>
-
 <div class="jp-OutputArea-child">
-
     
     <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
 
 
 <div class="jp-RenderedText jp-OutputArea-output" data-mime-type="text/plain">
-<pre>Hello Locus ANT2020mjq7c
-2022-08-10 13:16:36,034 - WARNING MainThread cassandra.py:list_by_location:1169 - Catalog object not found (catalog_id=19, object_id=913432592)
-</pre>
-</div>
-</div>
-
-<div class="jp-OutputArea-child">
-
-    
-    <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
-
-
-<div class="jp-RenderedText jp-OutputArea-output" data-mime-type="application/vnd.jupyter.stderr">
-<pre>/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:397: RuntimeWarning: invalid value encountered in log10
-  result = getattr(ufunc, method)(*inputs, **kwargs)
-</pre>
-</div>
-</div>
-
-<div class="jp-OutputArea-child">
-
-    
-    <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
-
-
-<div class="jp-RenderedText jp-OutputArea-output" data-mime-type="text/plain">
-<pre>Hello Locus ANT2018hxi5o
-Hello Locus ANT20227tekwp2ryqte
-Hello Locus ANT202226cmkalqs6s3
-2022-08-10 13:16:39,930 - WARNING MainThread cassandra.py:list_by_location:1169 - Catalog object not found (catalog_id=19, object_id=814997098)
-Hello Locus ANT2020maf76
-Hello Locus ANT202283bnculzwnz7
-2022-08-10 13:16:41,821 - WARNING MainThread cassandra.py:list_by_location:1169 - Catalog object not found (catalog_id=19, object_id=917436470)
-Hello Locus ANT2022414jtaogt1o3
-2022-08-10 13:16:43,197 - WARNING MainThread cassandra.py:list_by_location:1169 - Catalog object not found (catalog_id=19, object_id=869295660)
-</pre>
-</div>
-</div>
-
-<div class="jp-OutputArea-child">
-
-    
-    <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
-
-
-<div class="jp-RenderedText jp-OutputArea-output" data-mime-type="application/vnd.jupyter.stderr">
-<pre>/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:397: RuntimeWarning: invalid value encountered in log10
-  result = getattr(ufunc, method)(*inputs, **kwargs)
-</pre>
-</div>
-</div>
-
-<div class="jp-OutputArea-child">
-
-    
-    <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
-
-
-<div class="jp-RenderedText jp-OutputArea-output" data-mime-type="text/plain">
-<pre>Hello Locus ANT2020pdogm
-2022-08-10 13:16:45,393 - WARNING MainThread cassandra.py:list_by_location:1169 - Catalog object not found (catalog_id=19, object_id=828391917)
-</pre>
-</div>
-</div>
-
-<div class="jp-OutputArea-child">
-
-    
-    <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
-
-
-<div class="jp-RenderedText jp-OutputArea-output" data-mime-type="application/vnd.jupyter.stderr">
-<pre>/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:397: RuntimeWarning: invalid value encountered in log10
-  result = getattr(ufunc, method)(*inputs, **kwargs)
-</pre>
-</div>
-</div>
-
-<div class="jp-OutputArea-child">
-
-    
-    <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
-
-
-<div class="jp-RenderedText jp-OutputArea-output" data-mime-type="text/plain">
-<pre>Hello Locus ANT2018genra
-Hello Locus ANT20220crqqfr6ekcd
-2022-08-10 13:16:48,157 - WARNING MainThread cassandra.py:list_by_location:1169 - Catalog object not found (catalog_id=19, object_id=869295294)
-Hello Locus ANT2019242tg
-Hello Locus ANT2022mt866wahp7nn
-2022-08-10 13:16:50,805 - WARNING MainThread cassandra.py:list_by_location:1169 - Catalog object not found (catalog_id=19, object_id=881737998)
-Hello Locus ANT2020jpnji
-2022-08-10 13:16:53,227 - WARNING MainThread cassandra.py:list_by_location:1169 - Catalog object not found (catalog_id=19, object_id=919656063)
-</pre>
-</div>
-</div>
-
-<div class="jp-OutputArea-child">
-
-    
-    <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
-
-
-<div class="jp-RenderedText jp-OutputArea-output" data-mime-type="application/vnd.jupyter.stderr">
-<pre>/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:397: RuntimeWarning: invalid value encountered in log10
-  result = getattr(ufunc, method)(*inputs, **kwargs)
-</pre>
-</div>
-</div>
-
-<div class="jp-OutputArea-child">
-
-    
-    <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
-
-
-<div class="jp-RenderedText jp-OutputArea-output" data-mime-type="text/plain">
-<pre>Hello Locus ANT2018gezli
-Hello Locus ANT20220j6yzkuyhixs
-2022-08-10 13:16:56,431 - WARNING MainThread cassandra.py:list_by_location:1169 - Catalog object not found (catalog_id=19, object_id=898954032)
-</pre>
-</div>
-</div>
-
-<div class="jp-OutputArea-child">
-
-    
-    <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
-
-
-<div class="jp-RenderedText jp-OutputArea-output" data-mime-type="application/vnd.jupyter.stderr">
-<pre>/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:397: RuntimeWarning: invalid value encountered in log10
-  result = getattr(ufunc, method)(*inputs, **kwargs)
-</pre>
-</div>
-</div>
-
-<div class="jp-OutputArea-child">
-
-    
-    <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
-
-
-<div class="jp-RenderedText jp-OutputArea-output" data-mime-type="text/plain">
-<pre>Hello Locus ANT2018gfins
-2022-08-10 13:16:58,528 - WARNING MainThread cassandra.py:list_by_location:1169 - Catalog object not found (catalog_id=19, object_id=828391341)
-Hello Locus ANT2020uym3w
-Hello Locus ANT2022u57bscx5qs6e
-2022-08-10 13:17:01,084 - WARNING MainThread cassandra.py:list_by_location:1169 - Catalog object not found (catalog_id=19, object_id=842535323)
-Hello Locus ANT2018gexh2
-2022-08-10 13:17:03,323 - WARNING MainThread cassandra.py:list_by_location:1169 - Catalog object not found (catalog_id=19, object_id=889824228)
-</pre>
-</div>
-</div>
-
-<div class="jp-OutputArea-child">
-
-    
-    <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
-
-
-<div class="jp-RenderedText jp-OutputArea-output" data-mime-type="application/vnd.jupyter.stderr">
-<pre>/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:397: RuntimeWarning: invalid value encountered in log10
-  result = getattr(ufunc, method)(*inputs, **kwargs)
-</pre>
-</div>
-</div>
-
-<div class="jp-OutputArea-child">
-
-    
-    <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
-
-
-<div class="jp-RenderedText jp-OutputArea-output" data-mime-type="text/plain">
-<pre>Hello Locus ANT2018h5okc
-2022-08-10 13:17:05,509 - WARNING MainThread cassandra.py:list_by_location:1169 - Catalog object not found (catalog_id=19, object_id=889824391)
-</pre>
-</div>
-</div>
-
-<div class="jp-OutputArea-child">
-
-    
-    <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
-
-
-<div class="jp-RenderedText jp-OutputArea-output" data-mime-type="application/vnd.jupyter.stderr">
-<pre>/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:397: RuntimeWarning: invalid value encountered in log10
-  result = getattr(ufunc, method)(*inputs, **kwargs)
-</pre>
-</div>
-</div>
-
-<div class="jp-OutputArea-child">
-
-    
-    <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
-
-
-<div class="jp-RenderedText jp-OutputArea-output" data-mime-type="text/plain">
-<pre>Hello Locus ANT2018gaxfw
-2022-08-10 13:17:07,877 - WARNING MainThread cassandra.py:list_by_location:1169 - Catalog object not found (catalog_id=19, object_id=869293596)
-Hello Locus ANT2018gdlly
-Hello Locus ANT2022ihamovf0r4ll
-Hello Locus ANT2020o7xw6
-{&#39;n&#39;: 100, &#39;results&#39;: [{&#39;locus_id&#39;: &#39;ANT2018h5lrq&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2018h5lrq&#34;), &#39;t&#39;: 0.00010888899999983437, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT202284zos5406d9j&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT202284zos5406d9j&#34;), &#39;t&#39;: 0.0001129269999999849, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT20202uum4&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT20202uum4&#34;), &#39;t&#39;: 0.00011399999999994748, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2022sz5ssrdu1dhv&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2022sz5ssrdu1dhv&#34;), &#39;t&#39;: 0.00013392299999992474, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2022wcnvfar1iaxa&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2022wcnvfar1iaxa&#34;), &#39;t&#39;: 0.00010633800000015015, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2018hc6cm&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2018hc6cm&#34;), &#39;t&#39;: 0.00015420900000151505, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2019nbtus&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2019nbtus&#34;), &#39;t&#39;: 0.00012300600000081374, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT20217n3te&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT20217n3te&#34;), &#39;t&#39;: 0.00012011699999980863, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2019awmuk&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2019awmuk&#34;), &#39;t&#39;: 0.00010271600000066883, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT202201gghmzf3kzz&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT202201gghmzf3kzz&#34;), &#39;t&#39;: 0.00012527099999992686, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT20206tdje&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT20206tdje&#34;), &#39;t&#39;: 0.00010105199999976833, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2020qgnjo&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2020qgnjo&#34;), &#39;t&#39;: 0.00010572799999764015, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT202045kqm&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT202045kqm&#34;), &#39;t&#39;: 0.00011599899999836794, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2022om7a6nuh4lrx&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2022om7a6nuh4lrx&#34;), &#39;t&#39;: 0.00012469500000023004, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2018hayaa&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2018hayaa&#34;), &#39;t&#39;: 0.0001623769999987701, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2020aehmxqq&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2020aehmxqq&#34;), &#39;t&#39;: 0.00010303799999888952, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2022pryenjmb8vwm&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2022pryenjmb8vwm&#34;), &#39;t&#39;: 0.00010285999999837259, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2020aengcka&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2020aengcka&#34;), &#39;t&#39;: 0.00010431899999829852, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2020z2wla&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2020z2wla&#34;), &#39;t&#39;: 9.434900000115931e-05, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT20227os4qm7bi5mf&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT20227os4qm7bi5mf&#34;), &#39;t&#39;: 0.00010921800000218695, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2020sbt2e&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2020sbt2e&#34;), &#39;t&#39;: 0.0001272959999987222, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT20202uuky&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT20202uuky&#34;), &#39;t&#39;: 0.00011561399999848732, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2020luytg&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2020luytg&#34;), &#39;t&#39;: 0.00015281399999977907, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT20212p54u&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT20212p54u&#34;), &#39;t&#39;: 0.0004419609999999352, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2020z222g&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2020z222g&#34;), &#39;t&#39;: 0.00016731199999853175, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2018ibyoa&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2018ibyoa&#34;), &#39;t&#39;: 0.00017577500000243163, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2020z225k&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2020z225k&#34;), &#39;t&#39;: 0.00042429000000154815, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2022wte1pvglgdl5&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2022wte1pvglgdl5&#34;), &#39;t&#39;: 0.0001337320000018849, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2022oqifuv8mxr88&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2022oqifuv8mxr88&#34;), &#39;t&#39;: 0.00013447999999982585, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2022le4ty9rc8mzn&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2022le4ty9rc8mzn&#34;), &#39;t&#39;: 0.0004310519999997098, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2022vvjfedp4ihls&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2022vvjfedp4ihls&#34;), &#39;t&#39;: 0.00013332199999993577, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2020lxfuy&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2020lxfuy&#34;), &#39;t&#39;: 0.0002647679999974173, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2020aezxmgy&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2020aezxmgy&#34;), &#39;t&#39;: 0.0001357070000018723, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT20213hbwq&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT20213hbwq&#34;), &#39;t&#39;: 0.0004953749999998536, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2020p7s6c&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2020p7s6c&#34;), &#39;t&#39;: 0.0004338910000001306, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2022sq882ybua6fu&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2022sq882ybua6fu&#34;), &#39;t&#39;: 0.00013894699999994486, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2018mnzzo&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2018mnzzo&#34;), &#39;t&#39;: 0.00014626500000147757, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2020lumr6&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2020lumr6&#34;), &#39;t&#39;: 0.00031451899999979105, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2022bonajwguj68b&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2022bonajwguj68b&#34;), &#39;t&#39;: 0.00013667300000008709, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2020z2vms&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2020z2vms&#34;), &#39;t&#39;: 0.000135258000000249, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2022t3fzel65s43g&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2022t3fzel65s43g&#34;), &#39;t&#39;: 0.0001351679999999078, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2021fhczw&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2021fhczw&#34;), &#39;t&#39;: 0.0001241249999992533, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2020pcx6i&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2020pcx6i&#34;), &#39;t&#39;: 0.00013537299999910601, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT202285kw9pprr34t&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT202285kw9pprr34t&#34;), &#39;t&#39;: 0.0007487280000013641, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2020lzep4&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2020lzep4&#34;), &#39;t&#39;: 0.00014640399999876763, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2022msdzamqajuu3&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2022msdzamqajuu3&#34;), &#39;t&#39;: 0.00012945099999939202, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2020pubp4&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2020pubp4&#34;), &#39;t&#39;: 0.0001228189999977758, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2022ci5xylord3qe&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2022ci5xylord3qe&#34;), &#39;t&#39;: 0.00013440300000411298, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2022yflceiioi4he&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2022yflceiioi4he&#34;), &#39;t&#39;: 0.00026187799999632944, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT20227liiraokppig&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT20227liiraokppig&#34;), &#39;t&#39;: 0.0001325560000040582, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT20223q61z9so8gzp&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT20223q61z9so8gzp&#34;), &#39;t&#39;: 0.0001281740000038667, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2022wifvhu1hgvj8&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2022wifvhu1hgvj8&#34;), &#39;t&#39;: 0.000126544000004003, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2020z2vnu&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2020z2vnu&#34;), &#39;t&#39;: 0.0001434499999959371, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2020qhv4s&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2020qhv4s&#34;), &#39;t&#39;: 0.0004439160000018205, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT20229r32zqdbx3xd&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT20229r32zqdbx3xd&#34;), &#39;t&#39;: 0.00012801300000120364, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT202045hxo&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT202045hxo&#34;), &#39;t&#39;: 0.00021426600000040708, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2020aekxwny&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2020aekxwny&#34;), &#39;t&#39;: 0.00013042799999851695, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2022z2c9zsl3lyi1&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2022z2c9zsl3lyi1&#34;), &#39;t&#39;: 0.0001324039999985871, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT20222t6123a325tg&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT20222t6123a325tg&#34;), &#39;t&#39;: 0.00013124200000191877, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2022fs81pa94uypm&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2022fs81pa94uypm&#34;), &#39;t&#39;: 0.00013144599999748152, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2020qixa4&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2020qixa4&#34;), &#39;t&#39;: 0.00013467400000166663, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2022k76yv401ugd0&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2022k76yv401ugd0&#34;), &#39;t&#39;: 0.0001285539999997809, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2022hnbm13161e5p&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2022hnbm13161e5p&#34;), &#39;t&#39;: 0.0001320319999962294, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2021axlzi&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2021axlzi&#34;), &#39;t&#39;: 0.00014044499999954496, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2022nksgjuhh7uby&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2022nksgjuhh7uby&#34;), &#39;t&#39;: 0.00021017000000256303, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2020k2loc&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2020k2loc&#34;), &#39;t&#39;: 0.00043731000000235554, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2020656nu&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2020656nu&#34;), &#39;t&#39;: 0.00012778499999654969, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2018g67c4&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2018g67c4&#34;), &#39;t&#39;: 0.00013528200000223478, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2019ekbgq&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2019ekbgq&#34;), &#39;t&#39;: 0.00014316400000069507, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2022tapq9wivg5sz&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2022tapq9wivg5sz&#34;), &#39;t&#39;: 0.0002820509999992282, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2022g5fwxd1lon1p&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2022g5fwxd1lon1p&#34;), &#39;t&#39;: 0.0001310059999966029, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2018gcwyq&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2018gcwyq&#34;), &#39;t&#39;: 0.0001438440000001151, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2019bh3rm&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2019bh3rm&#34;), &#39;t&#39;: 0.0001487329999960707, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2022hwf5ki4m8wcp&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2022hwf5ki4m8wcp&#34;), &#39;t&#39;: 0.0001356249999986403, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2022n25j7nbqphbi&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2022n25j7nbqphbi&#34;), &#39;t&#39;: 0.00012455099999897357, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT20228oli4o80w5yf&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT20228oli4o80w5yf&#34;), &#39;t&#39;: 0.00013241599999957998, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2020mjq7c&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2020mjq7c&#34;), &#39;t&#39;: 7.774099999835471e-05, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2018hxi5o&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2018hxi5o&#34;), &#39;t&#39;: 0.00016229199999884258, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT20227tekwp2ryqte&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT20227tekwp2ryqte&#34;), &#39;t&#39;: 0.00013245099999892318, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT202226cmkalqs6s3&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT202226cmkalqs6s3&#34;), &#39;t&#39;: 0.00012647700000201212, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2020maf76&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2020maf76&#34;), &#39;t&#39;: 0.0001735250000010069, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT202283bnculzwnz7&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT202283bnculzwnz7&#34;), &#39;t&#39;: 0.00013343199999837907, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2022414jtaogt1o3&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2022414jtaogt1o3&#34;), &#39;t&#39;: 0.00012649100000317048, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2020pdogm&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2020pdogm&#34;), &#39;t&#39;: 0.0001676779999968403, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2018genra&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2018genra&#34;), &#39;t&#39;: 0.0004809070000035831, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT20220crqqfr6ekcd&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT20220crqqfr6ekcd&#34;), &#39;t&#39;: 0.00013373399999494495, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2019242tg&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2019242tg&#34;), &#39;t&#39;: 0.00016449299999976574, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2022mt866wahp7nn&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2022mt866wahp7nn&#34;), &#39;t&#39;: 0.0001447850000033668, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2020jpnji&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2020jpnji&#34;), &#39;t&#39;: 0.0001537810000016293, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2018gezli&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2018gezli&#34;), &#39;t&#39;: 0.00012021500000258811, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT20220j6yzkuyhixs&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT20220j6yzkuyhixs&#34;), &#39;t&#39;: 0.00013516599999974233, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2018gfins&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2018gfins&#34;), &#39;t&#39;: 0.00011442099999925404, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2020uym3w&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2020uym3w&#34;), &#39;t&#39;: 0.0001439760000039314, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2022u57bscx5qs6e&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2022u57bscx5qs6e&#34;), &#39;t&#39;: 0.00013031499999982543, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2018gexh2&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2018gexh2&#34;), &#39;t&#39;: 0.00014240100000506573, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2018h5okc&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2018h5okc&#34;), &#39;t&#39;: 0.00015007999999738786, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2018gaxfw&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2018gaxfw&#34;), &#39;t&#39;: 0.00013970099999482954, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2018gdlly&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2018gdlly&#34;), &#39;t&#39;: 0.00016776999999734699, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2022ihamovf0r4ll&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2022ihamovf0r4ll&#34;), &#39;t&#39;: 0.00014186299999607854, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2020o7xw6&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2020o7xw6&#34;), &#39;t&#39;: 0.00013190299999621402, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}], &#39;t_50_percentile&#39;: 0.00013444150000196942, &#39;t_90_percentile&#39;: 0.0002852977999992848, &#39;t_95_percentile&#39;: 0.00043754255000223453, &#39;t_99_percentile&#39;: 0.00049790852999987}
-</pre>
-</div>
-</div>
-
-<div class="jp-OutputArea-child">
-
-    
-    <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
-
-
-<div class="jp-RenderedText jp-OutputArea-output" data-mime-type="application/vnd.jupyter.stderr">
-<pre>/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:397: RuntimeWarning: invalid value encountered in log10
-  result = getattr(ufunc, method)(*inputs, **kwargs)
+<pre>Hello Locus ANT2020a4ymw
+2023-04-25 14:31:50,690 - WARNING MainThread cassandra.py:list_by_location:1167 - Catalog object not found (catalog_id=19, object_id=631393486)
+Hello Locus ANT2023fier0cypxzpk
+2023-04-25 14:31:52,728 - WARNING MainThread cassandra.py:list_by_location:1167 - Catalog object not found (catalog_id=19, object_id=656843529)
+Hello Locus ANT2021vf4zo
+Hello Locus ANT2023fk3494adih0j
+{&#39;n&#39;: 100, &#39;results&#39;: [{&#39;locus_id&#39;: &#39;ANT2020bbrei&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2020bbrei&#34;), &#39;t&#39;: 8.019599999897764e-05, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2020jojuc&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2020jojuc&#34;), &#39;t&#39;: 7.393599999261369e-05, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2018ba7as&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2018ba7as&#34;), &#39;t&#39;: 9.706100000528295e-05, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2020a4nco&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2020a4nco&#34;), &#39;t&#39;: 8.82510000081993e-05, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2023t92jq14b9zrc&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2023t92jq14b9zrc&#34;), &#39;t&#39;: 7.102499999689371e-05, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2020a4w3e&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2020a4w3e&#34;), &#39;t&#39;: 0.00010175599999229235, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2018iqoq&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2018iqoq&#34;), &#39;t&#39;: 0.00052675499999566, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2020a7khs&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2020a7khs&#34;), &#39;t&#39;: 9.260500000607408e-05, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2023ztpvwxlwgyn7&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2023ztpvwxlwgyn7&#34;), &#39;t&#39;: 6.733899999744608e-05, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2020cnps4&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2020cnps4&#34;), &#39;t&#39;: 8.855799998741531e-05, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT20195tat2&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT20195tat2&#34;), &#39;t&#39;: 8.298700001319048e-05, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2018b4w6k&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2018b4w6k&#34;), &#39;t&#39;: 9.817299999781426e-05, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2020a4sh2&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2020a4sh2&#34;), &#39;t&#39;: 9.709600000462615e-05, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2023splnbnda0wyl&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2023splnbnda0wyl&#34;), &#39;t&#39;: 9.98919999943837e-05, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT20231jsy3o1bb4eo&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT20231jsy3o1bb4eo&#34;), &#39;t&#39;: 6.993200000238176e-05, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2020a4ype&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2020a4ype&#34;), &#39;t&#39;: 9.829699999386321e-05, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2022ahnak&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2022ahnak&#34;), &#39;t&#39;: 0.00010534700000164321, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2019kgrao&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2019kgrao&#34;), &#39;t&#39;: 0.00010115199999916058, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2020a4nym&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2020a4nym&#34;), &#39;t&#39;: 9.840399999916372e-05, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2020bbbl4&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2020bbbl4&#34;), &#39;t&#39;: 9.81539999997949e-05, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2020a4huk&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2020a4huk&#34;), &#39;t&#39;: 9.36870000032286e-05, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2023v4zf9rhuttjt&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2023v4zf9rhuttjt&#34;), &#39;t&#39;: 6.862300000420873e-05, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2020a7mnm&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2020a7mnm&#34;), &#39;t&#39;: 8.577399999865065e-05, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2023aol8q84cow9t&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2023aol8q84cow9t&#34;), &#39;t&#39;: 6.495899999947596e-05, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2020a4vei&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2020a4vei&#34;), &#39;t&#39;: 9.749099999112332e-05, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2020a7iqu&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2020a7iqu&#34;), &#39;t&#39;: 9.657799999729377e-05, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2023iyl2166056su&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2023iyl2166056su&#34;), &#39;t&#39;: 7.741599999633308e-05, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2020dxbdw&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2020dxbdw&#34;), &#39;t&#39;: 9.023100000149498e-05, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2023vbj3pzhqasjz&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2023vbj3pzhqasjz&#34;), &#39;t&#39;: 6.51810000107389e-05, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2020a4w5w&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2020a4w5w&#34;), &#39;t&#39;: 7.915599999819278e-05, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2023370hacslywz0&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2023370hacslywz0&#34;), &#39;t&#39;: 6.61830000012742e-05, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2020dyi6a&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2020dyi6a&#34;), &#39;t&#39;: 6.515900000181318e-05, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2023n9naw2k6bdai&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2023n9naw2k6bdai&#34;), &#39;t&#39;: 7.257600000798448e-05, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2020bbfke&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2020bbfke&#34;), &#39;t&#39;: 9.845200000313525e-05, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2023bdj85krps9kd&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2023bdj85krps9kd&#34;), &#39;t&#39;: 7.148699999959263e-05, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2020batf4&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2020batf4&#34;), &#39;t&#39;: 8.626900000763271e-05, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2020bbhd2&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2020bbhd2&#34;), &#39;t&#39;: 8.466900000314581e-05, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2020a4lhq&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2020a4lhq&#34;), &#39;t&#39;: 9.68189999923652e-05, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT202314jwe8jpe3gb&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT202314jwe8jpe3gb&#34;), &#39;t&#39;: 0.00011679799999342322, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2020a4wxi&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2020a4wxi&#34;), &#39;t&#39;: 7.954299999823888e-05, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT202314jwe8jpe3gb&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT202314jwe8jpe3gb&#34;), &#39;t&#39;: 6.565799999691535e-05, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2020a4wxi&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2020a4wxi&#34;), &#39;t&#39;: 9.614399999691159e-05, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2020ba3fi&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2020ba3fi&#34;), &#39;t&#39;: 9.93849999986196e-05, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2023747zh5dn2sgm&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2023747zh5dn2sgm&#34;), &#39;t&#39;: 6.806300000050669e-05, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2020jojae&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2020jojae&#34;), &#39;t&#39;: 8.779099999856044e-05, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT20234832qs145vmx&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT20234832qs145vmx&#34;), &#39;t&#39;: 6.628299999533738e-05, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2020a4mf6&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2020a4mf6&#34;), &#39;t&#39;: 9.988399999372177e-05, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2020a4wuc&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2020a4wuc&#34;), &#39;t&#39;: 0.00010004099999605387, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2020gpmum&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2020gpmum&#34;), &#39;t&#39;: 9.550900000476759e-05, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2020bavne&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2020bavne&#34;), &#39;t&#39;: 9.487100000171722e-05, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2020eiwag&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2020eiwag&#34;), &#39;t&#39;: 9.812799999053823e-05, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT20237jb0i4iiw8y8&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT20237jb0i4iiw8y8&#34;), &#39;t&#39;: 0.00010106200001303023, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2020a4wtg&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2020a4wtg&#34;), &#39;t&#39;: 8.875099999272607e-05, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2023halulggfjl42&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2023halulggfjl42&#34;), &#39;t&#39;: 0.00011836699999889788, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT20233rhp8r5irpnw&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT20233rhp8r5irpnw&#34;), &#39;t&#39;: 6.806900000810856e-05, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2023ic3autpzusc7&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2023ic3autpzusc7&#34;), &#39;t&#39;: 6.972900000334903e-05, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2019urge6&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2019urge6&#34;), &#39;t&#39;: 7.419599999991533e-05, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2020bbbr4&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2020bbbr4&#34;), &#39;t&#39;: 6.415800000070249e-05, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2023el71ihkdi6il&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2023el71ihkdi6il&#34;), &#39;t&#39;: 4.858799999851726e-05, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT20235qu8lr0x0ufz&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT20235qu8lr0x0ufz&#34;), &#39;t&#39;: 6.532999999819822e-05, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2023clklkhk9rg7f&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2023clklkhk9rg7f&#34;), &#39;t&#39;: 6.516300000214414e-05, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2020a4jo6&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2020a4jo6&#34;), &#39;t&#39;: 9.701800000527783e-05, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2019vbn5a&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2019vbn5a&#34;), &#39;t&#39;: 7.765499999834446e-05, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2023bo8e959apozt&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2023bo8e959apozt&#34;), &#39;t&#39;: 6.657899999140682e-05, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2020a7ufq&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2020a7ufq&#34;), &#39;t&#39;: 0.00010892699999942579, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2020akpae&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2020akpae&#34;), &#39;t&#39;: 0.00011119600000597529, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2020a4mbm&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2020a4mbm&#34;), &#39;t&#39;: 0.0001360239999996793, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2020bbgta&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2020bbgta&#34;), &#39;t&#39;: 0.00012170799999466908, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2020bbbr4&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2020bbbr4&#34;), &#39;t&#39;: 9.686100000294573e-05, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2023el71ihkdi6il&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2023el71ihkdi6il&#34;), &#39;t&#39;: 6.77160000037702e-05, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2023f3kqo5itddfu&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2023f3kqo5itddfu&#34;), &#39;t&#39;: 6.918799999766634e-05, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2020hjubq&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2020hjubq&#34;), &#39;t&#39;: 0.00011927900000330283, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2023clklkhk9rg7f&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2023clklkhk9rg7f&#34;), &#39;t&#39;: 6.910099999402064e-05, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2020a4jo6&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2020a4jo6&#34;), &#39;t&#39;: 0.00012479500000495136, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2019vbn5a&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2019vbn5a&#34;), &#39;t&#39;: 7.803399999772864e-05, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2023bo8e959apozt&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2023bo8e959apozt&#34;), &#39;t&#39;: 0.0001713179999995873, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2020a7ufq&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2020a7ufq&#34;), &#39;t&#39;: 0.00011293800000089504, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2020akpae&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2020akpae&#34;), &#39;t&#39;: 7.436999999299587e-05, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2020a4mbm&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2020a4mbm&#34;), &#39;t&#39;: 0.00011471599999879345, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2020bbgta&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2020bbgta&#34;), &#39;t&#39;: 0.00010545399999273286, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2020vkm6q&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2020vkm6q&#34;), &#39;t&#39;: 9.381399999597306e-05, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2020ba2dw&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2020ba2dw&#34;), &#39;t&#39;: 0.00012193099999535661, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2020a4mhe&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2020a4mhe&#34;), &#39;t&#39;: 0.00011581500000090728, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2020a4vwu&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2020a4vwu&#34;), &#39;t&#39;: 9.917100000222945e-05, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT20239ug0z3idyr9y&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT20239ug0z3idyr9y&#34;), &#39;t&#39;: 7.54539999974213e-05, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2023cd9o5bimvpzo&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2023cd9o5bimvpzo&#34;), &#39;t&#39;: 7.025700000440338e-05, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2019yriee&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2019yriee&#34;), &#39;t&#39;: 9.903599999461221e-05, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2020baya4&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2020baya4&#34;), &#39;t&#39;: 7.372099999258808e-05, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2023wfvyxsqww87b&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2023wfvyxsqww87b&#34;), &#39;t&#39;: 6.997300000932682e-05, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2020a7n46&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2020a7n46&#34;), &#39;t&#39;: 6.0489000006214155e-05, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2023w11fstqn72dy&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2023w11fstqn72dy&#34;), &#39;t&#39;: 5.07100000106675e-05, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2023ehq8i9pcoff4&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2023ehq8i9pcoff4&#34;), &#39;t&#39;: 6.72720000238769e-05, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2023j6mxk72liaxp&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2023j6mxk72liaxp&#34;), &#39;t&#39;: 6.383199999504541e-05, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2023hct4fvf9zhjw&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2023hct4fvf9zhjw&#34;), &#39;t&#39;: 6.515399999784677e-05, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2023vxh6d9xytpsu&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2023vxh6d9xytpsu&#34;), &#39;t&#39;: 6.926700001486097e-05, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2023m1wmvtr02d43&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2023m1wmvtr02d43&#34;), &#39;t&#39;: 6.989599998519225e-05, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2020a4ymw&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2020a4ymw&#34;), &#39;t&#39;: 9.750899999971807e-05, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2023fier0cypxzpk&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2023fier0cypxzpk&#34;), &#39;t&#39;: 9.361200000057579e-05, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2021vf4zo&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2021vf4zo&#34;), &#39;t&#39;: 8.473200000480574e-05, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}, {&#39;locus_id&#39;: &#39;ANT2023fk3494adih0j&#39;, &#39;locus_data&#39;: FilterContext(locus_id=&#34;ANT2023fk3494adih0j&#34;), &#39;t&#39;: 7.75080000039452e-05, &#39;new_locus_properties&#39;: {}, &#39;new_alert_properties&#39;: {}, &#39;new_tags&#39;: {&#39;hello_world&#39;}, &#39;raised_halt&#39;: False}], &#39;t_50_percentile&#39;: 8.802100000337987e-05, &#39;t_90_percentile&#39;: 0.00011482589999900485, &#39;t_95_percentile&#39;: 0.00012171914999470346, &#39;t_99_percentile&#39;: 0.00017487236999954984}
 </pre>
 </div>
 </div>
@@ -16445,7 +16853,7 @@ Hello Locus ANT2020o7xw6
 </div>
 
 </div>
-<div class="jp-Cell jp-MarkdownCell jp-Notebook-cell">
+<div  class="jp-Cell jp-MarkdownCell jp-Notebook-cell">
 <div class="jp-Cell-inputWrapper">
 <div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
 </div>
@@ -16456,12 +16864,12 @@ Hello Locus ANT2020o7xw6
 </div>
 </div>
 </div>
-</div><div class="jp-Cell jp-CodeCell jp-Notebook-cell   ">
+</div><div  class="jp-Cell jp-CodeCell jp-Notebook-cell   ">
 <div class="jp-Cell-inputWrapper">
 <div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
 </div>
 <div class="jp-InputArea jp-Cell-inputArea">
-<div class="jp-InputPrompt jp-InputArea-prompt">In&nbsp;[10]:</div>
+<div class="jp-InputPrompt jp-InputArea-prompt">In&nbsp;[11]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
      <div class="CodeMirror cm-s-jupyter">
 <div class=" highlight hl-ipython3"><pre><span></span><span class="n">ra</span><span class="p">,</span> <span class="n">dec</span> <span class="o">=</span> <span class="mf">88.2744186</span><span class="p">,</span> <span class="o">-</span><span class="mf">5.0010774</span>
@@ -16513,26 +16921,22 @@ Hello Locus ANT2020o7xw6
 
 
 <div class="jp-OutputArea jp-Cell-outputArea">
-
 <div class="jp-OutputArea-child">
-
     
     <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
 
 
 <div class="jp-RenderedText jp-OutputArea-output" data-mime-type="text/plain">
-<pre>2022-08-10 13:17:11,382 - WARNING MainThread cassandra.py:list_by_location:1169 - Catalog object not found (catalog_id=19, object_id=490951081)
-2022-08-10 13:17:11,460 - WARNING MainThread ztf_flux_correction.py:correct_mags:61 - Attempt to correct magnitudes failed, missing fields
-Building the lightcurve with the following missing columns: {&#39;ant_magerr&#39;, &#39;ant_passband&#39;, &#39;ant_maglim&#39;, &#39;ant_dec&#39;, &#39;ant_survey&#39;, &#39;ant_ra&#39;}
+<pre>2023-04-25 14:36:18,488 - WARNING MainThread cassandra.py:list_by_location:1167 - Catalog object not found (catalog_id=19, object_id=490951081)
+2023-04-25 14:36:18,583 - WARNING MainThread ztf_flux_correction.py:correct_mags:62 - Attempt to correct magnitudes failed, missing fields
+Building the lightcurve with the following missing columns: {&#39;ant_maglim&#39;, &#39;ant_magerr&#39;, &#39;ant_dec&#39;, &#39;ant_passband&#39;, &#39;ant_ra&#39;, &#39;ant_survey&#39;}
 Hello Locus locus1
 </pre>
 </div>
 </div>
-
-<div class="jp-OutputArea-child">
-
+<div class="jp-OutputArea-child jp-OutputArea-executeResult">
     
-    <div class="jp-OutputPrompt jp-OutputArea-prompt">Out[10]:</div>
+    <div class="jp-OutputPrompt jp-OutputArea-prompt">Out[11]:</div>
 
 
 
@@ -16540,7 +16944,7 @@ Hello Locus locus1
 <div class="jp-RenderedText jp-OutputArea-output jp-OutputArea-executeResult" data-mime-type="text/plain">
 <pre>{&#39;locus_id&#39;: &#39;locus1&#39;,
  &#39;locus_data&#39;: FilterContext(locus_id=&#34;locus1&#34;),
- &#39;t&#39;: 0.001019798000001515,
+ &#39;t&#39;: 7.160700002373233e-05,
  &#39;new_locus_properties&#39;: {},
  &#39;new_alert_properties&#39;: {},
  &#39;new_tags&#39;: {&#39;hello_world&#39;},
@@ -16554,7 +16958,7 @@ Hello Locus locus1
 </div>
 
 </div>
-<div class="jp-Cell jp-MarkdownCell jp-Notebook-cell">
+<div  class="jp-Cell jp-MarkdownCell jp-Notebook-cell">
 <div class="jp-Cell-inputWrapper">
 <div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
 </div>
@@ -16562,13 +16966,13 @@ Hello Locus locus1
 </div><div class="jp-RenderedHTMLCommon jp-RenderedMarkdown jp-MarkdownOutput " data-mime-type="text/markdown">
 <p><a class="anchor" id="data"></a></p>
 <h2 id="4.-Upload-and-use-Data-File">4. Upload and use Data File<a class="anchor-link" href="#4.-Upload-and-use-Data-File">&#182;</a></h2><p>Some filters require access to data files, such as statistical models. ANTARES supports this by storing such files as binary blobs in a database table. These data files can then be loaded into filters when the filter’s <code>setup()</code> function is called.</p>
-<h3 id="Uploading-files-into-ANTARES">Uploading files into ANTARES<a class="anchor-link" href="#Uploading-files-into-ANTARES">&#182;</a></h3><p>The detail of uploading files into ANTARES can be found at ANTARES <a href="https://noao.gitlab.io/antares/filter-documentation/devkit/files.html">Documentation</a></p>
+<h3 id="Uploading-files-into-ANTARES">Uploading files into ANTARES<a class="anchor-link" href="#Uploading-files-into-ANTARES">&#182;</a></h3><p>The detail of uploading files into ANTARES can be found at ANTARES <a href="https://nsf-noirlab.gitlab.io/csdc/antares/antares/devkit/files.html">Documentation</a></p>
 
 </div>
 </div>
 </div>
 </div>
-<div class="jp-Cell jp-MarkdownCell jp-Notebook-cell">
+<div  class="jp-Cell jp-MarkdownCell jp-Notebook-cell">
 <div class="jp-Cell-inputWrapper">
 <div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
 </div>
@@ -16580,12 +16984,12 @@ Hello Locus locus1
 </div>
 </div>
 </div>
-</div><div class="jp-Cell jp-CodeCell jp-Notebook-cell jp-mod-noOutputs  ">
+</div><div  class="jp-Cell jp-CodeCell jp-Notebook-cell jp-mod-noOutputs  ">
 <div class="jp-Cell-inputWrapper">
 <div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
 </div>
 <div class="jp-InputArea jp-Cell-inputArea">
-<div class="jp-InputPrompt jp-InputArea-prompt">In&nbsp;[11]:</div>
+<div class="jp-InputPrompt jp-InputArea-prompt">In&nbsp;[12]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
      <div class="CodeMirror cm-s-jupyter">
 <div class=" highlight hl-ipython3"><pre><span></span><span class="kn">import</span> <span class="nn">antares.devkit</span> <span class="k">as</span> <span class="nn">dk</span>
@@ -16626,7 +17030,7 @@ Hello Locus locus1
 </div>
 
 </div>
-<div class="jp-Cell jp-MarkdownCell jp-Notebook-cell">
+<div  class="jp-Cell jp-MarkdownCell jp-Notebook-cell">
 <div class="jp-Cell-inputWrapper">
 <div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
 </div>
@@ -16638,15 +17042,15 @@ Hello Locus locus1
 </div>
 </div>
 </div>
-<div class="jp-Cell jp-MarkdownCell jp-Notebook-cell">
+<div  class="jp-Cell jp-MarkdownCell jp-Notebook-cell">
 <div class="jp-Cell-inputWrapper">
 <div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
 </div>
 <div class="jp-InputArea jp-Cell-inputArea"><div class="jp-InputPrompt jp-InputArea-prompt">
 </div><div class="jp-RenderedHTMLCommon jp-RenderedMarkdown jp-MarkdownOutput " data-mime-type="text/markdown">
 <p><a class="anchor" id="submit"></a></p>
-<h2 id="5.-Submit-Filter-to-ANTARES">5. Submit Filter to ANTARES<a class="anchor-link" href="#5.-Submit-Filter-to-ANTARES">&#182;</a></h2><p>When you're ready to submit your filter to ANTARES, go to the <a href="https://antares.noirlab.edu/filters">filters</a> page on the ANTARES website and click "Add".</p>
-<p><strong>Note</strong>: We highly recommend setting an <code>ERROR_LOG_SLACK_CHANNEL</code> on your filter so that you will receive notifications of errors. See <a href="https://noao.gitlab.io/antares/filter-documentation/devkit/debugging.html#devkit-debugging">Debugging Filters in Production</a>.</p>
+<h2 id="5.-Submit-Filter-to-ANTARES">5. Submit Filter to ANTARES<a class="anchor-link" href="#5.-Submit-Filter-to-ANTARES">&#182;</a></h2><p>When you're ready to submit your filter to ANTARES, go to the <a href="https://antares.noirlab.edu/filters">filters</a> page on the ANTARES website and click &quot;Add&quot;.</p>
+<p><strong>Note</strong>: We highly recommend setting an <code>ERROR_SLACK_CHANNEL</code> on your filter so that you will receive notifications of errors. See <a href="https://nsf-noirlab.gitlab.io/csdc/antares/antares/devkit/debugging.html">Debugging Filters in Production</a>.</p>
 <p>When you submit your filter you will need to provide:</p>
 <ul>
 <li><p><strong>Name</strong> – A unique name for your filter. Name your filter like:</p>
@@ -16657,14 +17061,10 @@ Hello Locus locus1
 </li>
 </ul>
 </li>
-</ul>
-<ul>
-<li><strong>Description</strong> – A brief text description of your filter. Will be publicly visible.</li>
-</ul>
-<ul>
-<li><strong>Handler</strong> – The name of the filter class in your code. The handler name does not need to be unique outside of your code.</li>
-</ul>
-<ul>
+<li><p><strong>Description</strong> – A brief text description of your filter. Will be publicly visible.</p>
+</li>
+<li><p><strong>Handler</strong> – The name of the filter class in your code. The handler name does not need to be unique outside of your code.</p>
+</li>
 <li><p><strong>Code</strong> – A block of code which includes:</p>
 <ul>
 <li><p>your import statements</p>

--- a/05_Contrib/TimeDomain/AntaresDevKit/AntaresFilterDevKit.ipynb
+++ b/05_Contrib/TimeDomain/AntaresDevKit/AntaresFilterDevKit.ipynb
@@ -2,13 +2,13 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [],
    "source": [
     "__author__ = 'Carl Stubens <carl.stubens@noirlab.edu>'\n",
-    "__edited__ = 'Gautham Narayan, Chien-Hsiu Lee <chien-hsiu.lee@noirlab.edu>'\n",
-    "__version__ = '20211130' # yyyymmdd\n",
+    "__edited__ = 'Gautham Narayan, Chien-Hsiu Lee <chien-hsiu.lee@noirlab.edu>, ANTARES Team <antares@noirlab.edu>'\n",
+    "__version__ = '20230425' # yyyymmdd\n",
     "__datasets__ = ['']\n",
     "__keywords__ = ['ANTARES', 'transient']"
    ]
@@ -31,7 +31,7 @@
     "\n",
     "For new Data Lab accounts, this notebook will be automatically included in your `notebooks/` directory. Otherwise, you can save this `.ipynb` notebook file locally, and then upload it to your Data Lab Jupyter notebook server (use the 'Upload' button in the upper right corner).\n",
     "\n",
-    "In Data Lab, you MUST use the Kernel version \"Python 3 (ANTARES 0.4)\".\n",
+    "In Data Lab, you MUST use the Kernel version \"Python 3 (ANTARES)\".\n",
     "## Goals\n",
     "\n",
     "To demonstrate:\n",
@@ -43,9 +43,9 @@
     "## Table of Contents\n",
     "\n",
     "* [0. Background information on ANTARES](#background)\n",
-    "* [1. Connect to ANTARES database](#connect)\n",
+    "* [1. Initalize the dev kit](#connect)\n",
     "* [2. Write a Filter](#write)\n",
-    " * [2.1 Hellow World](#write-one)\n",
+    " * [2.1 Hello World](#write-one)\n",
     " * [2.2 Example of a real Filter](#write-two)\n",
     " * [2.3 Structure of a Filter](#write-three)\n",
     "* [3. Test a Filter](#test)\n",
@@ -88,27 +88,34 @@
       "       / \\  | \\ | |_   _|/ \\  |  _ \\| ____/ ___|\n",
       "      / _ \\ |  \\| | | | / _ \\ | |_| |  _| \\___ \\\\\n",
       "     / ___ \\| |\\  | | |/ ___ \\|  _ /| |___ ___| |\n",
-      "    /_/   \\_\\_| \\_| |_/_/   \\_\\_| \\_\\_____|____/   v2.1.5\n",
-      "    \n",
-      "2022-08-10 13:13:54,643 - WARNING MainThread settings.py:setup_prometheus:106 - Prometheus failed to start with [Errno 98] Address already in use\n",
-      "Testing loading a random Locus with `dk.get_locus()`...\n",
-      "2022-08-10 13:13:58,620 - INFO MainThread settings.py:cassandra_session_factory:67 - Establishing connection to Cassandra\n",
-      "2022-08-10 13:13:59,956 - INFO MainThread settings.py:cassandra_session_factory:67 - Establishing connection to Cassandra\n",
-      "2022-08-10 13:14:01,180 - INFO MainThread settings.py:cassandra_session_factory:67 - Establishing connection to Cassandra\n",
-      "2022-08-10 13:14:05,327 - WARNING MainThread cassandra.py:list_by_location:1169 - Catalog object not found (catalog_id=19, object_id=548958647)\n",
-      "\n",
-      "ANTARES v2.1.5 DevKit is ready!\n",
-      "Website: http://antares.noirlab.edu\n",
-      "Documentation: http://noao.gitlab.io/antares/filter-documentation/\n",
-      "\n"
+      "    /_/   \\_\\_| \\_| |_/_/   \\_\\_| \\_\\_____|____/   v2.4.1\n",
+      "    \n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:397: RuntimeWarning: invalid value encountered in log10\n",
-      "  result = getattr(ufunc, method)(*inputs, **kwargs)\n"
+      "Jaeger tracer already initialized, skipping\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2023-04-25 14:22:09,019 - WARNING MainThread settings.py:setup_prometheus:124 - Prometheus failed to start with [Errno 98] Address already in use\n",
+      "Testing loading a random Locus with `dk.get_locus()`...\n",
+      "2023-04-25 14:22:11,595 - INFO MainThread settings.py:cassandra_session_factory:84 - Establishing connection to Cassandra\n",
+      "2023-04-25 14:22:12,826 - INFO MainThread settings.py:cassandra_session_factory:88 - Connection to Cassandra established\n",
+      "2023-04-25 14:22:12,827 - INFO MainThread settings.py:cassandra_session_factory:84 - Establishing connection to Cassandra\n",
+      "2023-04-25 14:22:14,039 - INFO MainThread settings.py:cassandra_session_factory:88 - Connection to Cassandra established\n",
+      "2023-04-25 14:22:14,040 - INFO MainThread settings.py:cassandra_session_factory:84 - Establishing connection to Cassandra\n",
+      "2023-04-25 14:22:15,203 - INFO MainThread settings.py:cassandra_session_factory:88 - Connection to Cassandra established\n",
+      "\n",
+      "ANTARES v2.4.1 DevKit is ready!\n",
+      "Website: http://antares.noirlab.edu\n",
+      "Documentation: https://nsf-noirlab.gitlab.io/csdc/antares/antares/\n",
+      "\n"
      ]
     }
    ],
@@ -167,16 +174,16 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2022-08-10 13:14:09,061 - WARNING MainThread cassandra.py:list_by_location:1169 - Catalog object not found (catalog_id=19, object_id=548958647)\n",
-      "Hello Locus ANT2018h5lrq\n",
-      "{'locus_id': 'ANT2018h5lrq', 'locus_data': FilterContext(locus_id=\"ANT2018h5lrq\"), 't': 0.00020771899999871835, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}\n"
+      "2023-04-25 14:22:33,115 - WARNING MainThread cassandra.py:list_by_location:1167 - Catalog object not found (catalog_id=19, object_id=634809564)\n",
+      "Hello Locus ANT2020bbrei\n",
+      "{'locus_id': 'ANT2020bbrei', 'locus_data': FilterContext(locus_id=\"ANT2020bbrei\"), 't': 9.559899999977972e-05, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:397: RuntimeWarning: invalid value encountered in log10\n",
+      "/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:396: RuntimeWarning: invalid value encountered in log10\n",
       "  result = getattr(ufunc, method)(*inputs, **kwargs)\n"
      ]
     }
@@ -264,7 +271,7 @@
     "\n",
     "The filter `MyFilter` below does nothing of scientific interest, but it demonstrates the most basic use of the filter API.\n",
     "\n",
-    "The Filter API consists of the Locus Object, which is passed to the Filter as the single parameter. The `MyFilter` shows examples of how to use the Locus data. For detailed information on the Locus Object, please visit ANTARES documentation at https://noao.gitlab.io/antares/filter-documentation/devkit/locus.html"
+    "The Filter API consists of the Locus Object, which is passed to the Filter as the single parameter. The `MyFilter` shows examples of how to use the Locus data. For detailed information on the Locus Object, please visit ANTARES documentation at https://nsf-noirlab.gitlab.io/csdc/antares/antares/devkit/locus.html"
    ]
   },
   {
@@ -286,7 +293,7 @@
     "    # List of Locus properties which the Filter depends on.\n",
     "    # If an incoming Alert's Locus does not have all properties listed here,\n",
     "    # then the Filter will not run on it.\n",
-    "    INPUT_LOCUS_PROPERTIES = [\n",
+    "    REQUIRED_LOCUS_PROPERTIES = [\n",
     "        # eg:\n",
     "        'ztf_object_id',\n",
     "        # etc.\n",
@@ -297,7 +304,7 @@
     "    # List of Alert properties which the Filter depends on.\n",
     "    # If an incoming Alert does not have all properties listed here, then\n",
     "    # the Filter will not run on it.\n",
-    "    INPUT_ALERT_PROPERTIES = [\n",
+    "    REQUIRED_ALERT_PROPERTIES = [\n",
     "        # eg:\n",
     "        'passband',\n",
     "        'mag',\n",
@@ -310,7 +317,7 @@
     "    # List of Tag names which the Filter depends on.\n",
     "    # If an incoming Alert's Locus does not have all Tags listed here, then\n",
     "    # the Filter will not run on it.\n",
-    "    INPUT_TAGS = [\n",
+    "    REQUIRED_TAGS = [\n",
     "        # eg:\n",
     "        'high_snr',\n",
     "        # etc.\n",
@@ -452,14 +459,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2022-08-10 13:14:24,790 - WARNING MainThread cassandra.py:list_by_location:1169 - Catalog object not found (catalog_id=19, object_id=548958647)\n"
+      "2023-04-25 14:23:15,922 - WARNING MainThread cassandra.py:list_by_location:1167 - Catalog object not found (catalog_id=19, object_id=634809564)\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:397: RuntimeWarning: invalid value encountered in log10\n",
+      "/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:396: RuntimeWarning: invalid value encountered in log10\n",
       "  result = getattr(ufunc, method)(*inputs, **kwargs)\n"
      ]
     },
@@ -467,10 +474,10 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Hello Locus ANT2018h5lrq\n",
-      "{'locus_id': 'ANT2018h5lrq', 'locus_data': FilterContext(locus_id=\"ANT2018h5lrq\"), 't': 0.00010604399999891712, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}\n",
+      "Hello Locus ANT2020bbrei\n",
+      "{'locus_id': 'ANT2020bbrei', 'locus_data': FilterContext(locus_id=\"ANT2020bbrei\"), 't': 9.513700000063352e-05, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}\n",
       "Hello Locus ANT2020hcm7s\n",
-      "{'locus_id': 'ANT2020hcm7s', 'locus_data': FilterContext(locus_id=\"ANT2020hcm7s\"), 't': 0.00010958000000016455, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}\n"
+      "{'locus_id': 'ANT2020hcm7s', 'locus_data': FilterContext(locus_id=\"ANT2020hcm7s\"), 't': 9.552200000051414e-05, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}\n"
      ]
     }
    ],
@@ -499,7 +506,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "metadata": {
     "scrolled": true,
     "tags": []
@@ -509,14 +516,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2022-08-10 13:14:53,649 - WARNING MainThread cassandra.py:list_by_location:1169 - Catalog object not found (catalog_id=19, object_id=548958647)\n"
+      "2023-04-25 14:28:47,805 - WARNING MainThread cassandra.py:list_by_location:1167 - Catalog object not found (catalog_id=19, object_id=634809564)\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:397: RuntimeWarning: invalid value encountered in log10\n",
+      "/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:396: RuntimeWarning: invalid value encountered in log10\n",
       "  result = getattr(ufunc, method)(*inputs, **kwargs)\n"
      ]
     },
@@ -524,21 +531,15 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Hello Locus ANT2018h5lrq\n",
-      "Hello Locus ANT202284zos5406d9j\n",
-      "2022-08-10 13:14:55,817 - WARNING MainThread cassandra.py:list_by_location:1169 - Catalog object not found (catalog_id=19, object_id=472988617)\n",
-      "Hello Locus ANT20202uum4\n",
-      "2022-08-10 13:14:56,674 - WARNING MainThread cassandra.py:list_by_location:1169 - Catalog object not found (catalog_id=19, object_id=592386369)\n",
-      "Hello Locus ANT2022sz5ssrdu1dhv\n",
-      "Hello Locus ANT2022wcnvfar1iaxa\n",
-      "2022-08-10 13:14:59,157 - WARNING MainThread cassandra.py:list_by_location:1169 - Catalog object not found (catalog_id=19, object_id=492387242)\n"
+      "Hello Locus ANT2020bbrei\n",
+      "2023-04-25 14:28:50,643 - WARNING MainThread cassandra.py:list_by_location:1167 - Catalog object not found (catalog_id=19, object_id=698523106)\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:397: RuntimeWarning: invalid value encountered in log10\n",
+      "/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:396: RuntimeWarning: invalid value encountered in log10\n",
       "  result = getattr(ufunc, method)(*inputs, **kwargs)\n"
      ]
     },
@@ -546,15 +547,15 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Hello Locus ANT2018hc6cm\n",
-      "2022-08-10 13:15:01,003 - WARNING MainThread cassandra.py:list_by_location:1169 - Catalog object not found (catalog_id=19, object_id=554583015)\n"
+      "Hello Locus ANT2020jojuc\n",
+      "2023-04-25 14:28:52,917 - WARNING MainThread cassandra.py:list_by_location:1167 - Catalog object not found (catalog_id=19, object_id=607041990)\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:397: RuntimeWarning: invalid value encountered in log10\n",
+      "/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:396: RuntimeWarning: invalid value encountered in log10\n",
       "  result = getattr(ufunc, method)(*inputs, **kwargs)\n"
      ]
     },
@@ -562,15 +563,20 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Hello Locus ANT2019nbtus\n",
-      "2022-08-10 13:15:02,619 - WARNING MainThread cassandra.py:list_by_location:1169 - Catalog object not found (catalog_id=19, object_id=471662039)\n"
+      "Hello Locus ANT2018ba7as\n",
+      "2023-04-25 14:28:55,286 - WARNING MainThread cassandra.py:list_by_location:1167 - Catalog object not found (catalog_id=19, object_id=662848338)\n",
+      "Hello Locus ANT2020a4nco\n",
+      "Hello Locus ANT2023t92jq14b9zrc\n",
+      "2023-04-25 14:28:58,366 - WARNING MainThread cassandra.py:list_by_location:1167 - Catalog object not found (catalog_id=19, object_id=597997077)\n",
+      "Hello Locus ANT2020a4w3e\n",
+      "2023-04-25 14:29:00,376 - WARNING MainThread cassandra.py:list_by_location:1167 - Catalog object not found (catalog_id=19, object_id=654300737)\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:397: RuntimeWarning: invalid value encountered in log10\n",
+      "/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:396: RuntimeWarning: invalid value encountered in log10\n",
       "  result = getattr(ufunc, method)(*inputs, **kwargs)\n"
      ]
     },
@@ -578,15 +584,20 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Hello Locus ANT20217n3te\n",
-      "2022-08-10 13:15:03,944 - WARNING MainThread cassandra.py:list_by_location:1169 - Catalog object not found (catalog_id=19, object_id=511257660)\n"
+      "Hello Locus ANT2018iqoq\n",
+      "2023-04-25 14:29:02,783 - WARNING MainThread cassandra.py:list_by_location:1167 - Catalog object not found (catalog_id=19, object_id=618970098)\n",
+      "Hello Locus ANT2020a7khs\n",
+      "Hello Locus ANT2023ztpvwxlwgyn7\n",
+      "2023-04-25 14:29:06,092 - WARNING MainThread cassandra.py:list_by_location:1167 - Catalog object not found (catalog_id=19, object_id=683662522)\n",
+      "Hello Locus ANT2020cnps4\n",
+      "2023-04-25 14:29:09,104 - WARNING MainThread cassandra.py:list_by_location:1167 - Catalog object not found (catalog_id=19, object_id=658715695)\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:397: RuntimeWarning: invalid value encountered in log10\n",
+      "/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:396: RuntimeWarning: invalid value encountered in log10\n",
       "  result = getattr(ufunc, method)(*inputs, **kwargs)\n"
      ]
     },
@@ -594,16 +605,15 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Hello Locus ANT2019awmuk\n",
-      "Hello Locus ANT202201gghmzf3kzz\n",
-      "2022-08-10 13:15:06,188 - WARNING MainThread cassandra.py:list_by_location:1169 - Catalog object not found (catalog_id=19, object_id=568623508)\n"
+      "Hello Locus ANT20195tat2\n",
+      "2023-04-25 14:29:11,879 - WARNING MainThread cassandra.py:list_by_location:1167 - Catalog object not found (catalog_id=19, object_id=611329812)\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:397: RuntimeWarning: invalid value encountered in log10\n",
+      "/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:396: RuntimeWarning: invalid value encountered in log10\n",
       "  result = getattr(ufunc, method)(*inputs, **kwargs)\n"
      ]
     },
@@ -611,59 +621,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Hello Locus ANT20206tdje\n",
-      "2022-08-10 13:15:08,734 - WARNING MainThread cassandra.py:list_by_location:1169 - Catalog object not found (catalog_id=19, object_id=468850192)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:397: RuntimeWarning: invalid value encountered in log10\n",
-      "  result = getattr(ufunc, method)(*inputs, **kwargs)\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Hello Locus ANT2020qgnjo\n",
-      "2022-08-10 13:15:10,953 - WARNING MainThread cassandra.py:list_by_location:1169 - Catalog object not found (catalog_id=19, object_id=572048708)\n",
-      "Hello Locus ANT202045kqm\n",
-      "2022-08-10 13:15:12,239 - WARNING MainThread cassandra.py:list_by_location:1169 - Catalog object not found (catalog_id=19, object_id=589266727)\n",
-      "Hello Locus ANT2022om7a6nuh4lrx\n",
-      "2022-08-10 13:15:14,911 - WARNING MainThread cassandra.py:list_by_location:1169 - Catalog object not found (catalog_id=19, object_id=592793524)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:397: RuntimeWarning: invalid value encountered in log10\n",
-      "  result = getattr(ufunc, method)(*inputs, **kwargs)\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Hello Locus ANT2018hayaa\n",
-      "2022-08-10 13:15:16,994 - WARNING MainThread cassandra.py:list_by_location:1169 - Catalog object not found (catalog_id=19, object_id=468403334)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:397: RuntimeWarning: invalid value encountered in log10\n",
-      "  result = getattr(ufunc, method)(*inputs, **kwargs)\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Hello Locus ANT2020aehmxqq\n"
+      "Hello Locus ANT2018b4w6k\n",
+      "2023-04-25 14:29:15,663 - WARNING MainThread cassandra.py:list_by_location:1167 - Catalog object not found (catalog_id=19, object_id=668679822)\n"
      ]
     },
     {
@@ -677,17 +636,18 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Hello Locus ANT2022pryenjmb8vwm\n",
-      "2022-08-10 13:15:19,545 - WARNING MainThread cassandra.py:list_by_location:1169 - Catalog object not found (catalog_id=19, object_id=544105239)\n",
-      "Hello Locus ANT2020aengcka\n",
-      "2022-08-10 13:15:21,144 - WARNING MainThread cassandra.py:list_by_location:1169 - Catalog object not found (catalog_id=19, object_id=515803367)\n"
+      "Hello Locus ANT2020a4sh2\n",
+      "2023-04-25 14:29:17,178 - WARNING MainThread cassandra.py:list_by_location:1167 - Catalog object not found (catalog_id=19, object_id=699321404)\n",
+      "Hello Locus ANT2023splnbnda0wyl\n",
+      "Hello Locus ANT20231jsy3o1bb4eo\n",
+      "2023-04-25 14:29:19,923 - WARNING MainThread cassandra.py:list_by_location:1167 - Catalog object not found (catalog_id=19, object_id=691628475)\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:397: RuntimeWarning: invalid value encountered in log10\n",
+      "/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:396: RuntimeWarning: invalid value encountered in log10\n",
       "  result = getattr(ufunc, method)(*inputs, **kwargs)\n"
      ]
     },
@@ -695,20 +655,15 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Hello Locus ANT2020z2wla\n",
-      "Hello Locus ANT20227os4qm7bi5mf\n",
-      "2022-08-10 13:15:23,546 - WARNING MainThread cassandra.py:list_by_location:1169 - Catalog object not found (catalog_id=19, object_id=504401148)\n",
-      "Hello Locus ANT2020sbt2e\n",
-      "2022-08-10 13:15:25,339 - WARNING MainThread cassandra.py:list_by_location:1169 - Catalog object not found (catalog_id=19, object_id=538687544)\n",
-      "Hello Locus ANT20202uuky\n",
-      "2022-08-10 13:15:27,861 - WARNING MainThread cassandra.py:list_by_location:1169 - Catalog object not found (catalog_id=19, object_id=591979701)\n"
+      "Hello Locus ANT2020a4ype\n",
+      "2023-04-25 14:29:21,672 - WARNING MainThread cassandra.py:list_by_location:1167 - Catalog object not found (catalog_id=19, object_id=664965152)\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:397: RuntimeWarning: invalid value encountered in log10\n",
+      "/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:396: RuntimeWarning: invalid value encountered in log10\n",
       "  result = getattr(ufunc, method)(*inputs, **kwargs)\n"
      ]
     },
@@ -716,15 +671,15 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Hello Locus ANT2020luytg\n",
-      "2022-08-10 13:15:29,393 - WARNING MainThread cassandra.py:list_by_location:1169 - Catalog object not found (catalog_id=19, object_id=547152769)\n"
+      "Hello Locus ANT2022ahnak\n",
+      "2023-04-25 14:29:24,123 - WARNING MainThread cassandra.py:list_by_location:1167 - Catalog object not found (catalog_id=19, object_id=702384729)\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:397: RuntimeWarning: invalid value encountered in log10\n",
+      "/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:396: RuntimeWarning: invalid value encountered in log10\n",
       "  result = getattr(ufunc, method)(*inputs, **kwargs)\n"
      ]
     },
@@ -732,15 +687,15 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Hello Locus ANT20212p54u\n",
-      "2022-08-10 13:15:30,985 - WARNING MainThread cassandra.py:list_by_location:1169 - Catalog object not found (catalog_id=19, object_id=507360904)\n"
+      "Hello Locus ANT2019kgrao\n",
+      "2023-04-25 14:29:26,233 - WARNING MainThread cassandra.py:list_by_location:1167 - Catalog object not found (catalog_id=19, object_id=595144369)\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:397: RuntimeWarning: invalid value encountered in log10\n",
+      "/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:396: RuntimeWarning: invalid value encountered in log10\n",
       "  result = getattr(ufunc, method)(*inputs, **kwargs)\n"
      ]
     },
@@ -748,30 +703,15 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Hello Locus ANT2020z222g\n",
-      "2022-08-10 13:15:33,162 - WARNING MainThread cassandra.py:list_by_location:1169 - Catalog object not found (catalog_id=19, object_id=511807598)\n"
+      "Hello Locus ANT2020a4nym\n",
+      "2023-04-25 14:29:28,868 - WARNING MainThread cassandra.py:list_by_location:1167 - Catalog object not found (catalog_id=19, object_id=680209068)\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "WARNING: AstropyDeprecationWarning: The truth value of a Quantity is ambiguous. In the future this will raise a ValueError. [astropy.units.quantity]\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Hello Locus ANT2018ibyoa\n",
-      "2022-08-10 13:15:35,165 - WARNING MainThread cassandra.py:list_by_location:1169 - Catalog object not found (catalog_id=19, object_id=502154600)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:397: RuntimeWarning: invalid value encountered in log10\n",
+      "/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:396: RuntimeWarning: invalid value encountered in log10\n",
       "  result = getattr(ufunc, method)(*inputs, **kwargs)\n"
      ]
     },
@@ -779,17 +719,15 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Hello Locus ANT2020z225k\n",
-      "Hello Locus ANT2022wte1pvglgdl5\n",
-      "Hello Locus ANT2022oqifuv8mxr88\n",
-      "2022-08-10 13:15:37,631 - WARNING MainThread cassandra.py:list_by_location:1169 - Catalog object not found (catalog_id=19, object_id=526666788)\n"
+      "Hello Locus ANT2020bbbl4\n",
+      "2023-04-25 14:29:31,382 - WARNING MainThread cassandra.py:list_by_location:1167 - Catalog object not found (catalog_id=19, object_id=671217303)\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:397: RuntimeWarning: invalid value encountered in log10\n",
+      "/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:396: RuntimeWarning: invalid value encountered in log10\n",
       "  result = getattr(ufunc, method)(*inputs, **kwargs)\n"
      ]
     },
@@ -797,17 +735,16 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Hello Locus ANT2022le4ty9rc8mzn\n",
-      "Hello Locus ANT2022vvjfedp4ihls\n",
-      "Hello Locus ANT2020lxfuy\n",
-      "2022-08-10 13:15:40,684 - WARNING MainThread cassandra.py:list_by_location:1169 - Catalog object not found (catalog_id=19, object_id=517857938)\n"
+      "Hello Locus ANT2020a4huk\n",
+      "Hello Locus ANT2023v4zf9rhuttjt\n",
+      "2023-04-25 14:29:34,729 - WARNING MainThread cassandra.py:list_by_location:1167 - Catalog object not found (catalog_id=19, object_id=628225256)\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:397: RuntimeWarning: invalid value encountered in log10\n",
+      "/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:396: RuntimeWarning: invalid value encountered in log10\n",
       "  result = getattr(ufunc, method)(*inputs, **kwargs)\n"
      ]
     },
@@ -815,15 +752,16 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Hello Locus ANT2020aezxmgy\n",
-      "2022-08-10 13:15:41,856 - WARNING MainThread cassandra.py:list_by_location:1169 - Catalog object not found (catalog_id=19, object_id=538965567)\n"
+      "Hello Locus ANT2020a7mnm\n",
+      "Hello Locus ANT2023aol8q84cow9t\n",
+      "2023-04-25 14:29:37,617 - WARNING MainThread cassandra.py:list_by_location:1167 - Catalog object not found (catalog_id=19, object_id=631530733)\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:397: RuntimeWarning: invalid value encountered in log10\n",
+      "/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:396: RuntimeWarning: invalid value encountered in log10\n",
       "  result = getattr(ufunc, method)(*inputs, **kwargs)\n"
      ]
     },
@@ -831,15 +769,16 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Hello Locus ANT20213hbwq\n",
-      "2022-08-10 13:15:43,555 - WARNING MainThread cassandra.py:list_by_location:1169 - Catalog object not found (catalog_id=19, object_id=549799634)\n"
+      "Hello Locus ANT2020a4vei\n",
+      "2023-04-25 14:29:40,296 - WARNING MainThread cassandra.py:list_by_location:1167 - Catalog object not found (catalog_id=19, object_id=681006507)\n",
+      "2023-04-25 14:29:40,297 - WARNING MainThread cassandra.py:list_by_location:1167 - Catalog object not found (catalog_id=19, object_id=681006508)\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:397: RuntimeWarning: invalid value encountered in log10\n",
+      "/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:396: RuntimeWarning: invalid value encountered in log10\n",
       "  result = getattr(ufunc, method)(*inputs, **kwargs)\n"
      ]
     },
@@ -847,16 +786,19 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Hello Locus ANT2020p7s6c\n",
-      "Hello Locus ANT2022sq882ybua6fu\n",
-      "2022-08-10 13:15:45,963 - WARNING MainThread cassandra.py:list_by_location:1169 - Catalog object not found (catalog_id=19, object_id=489208920)\n"
+      "Hello Locus ANT2020a7iqu\n",
+      "Hello Locus ANT2023iyl2166056su\n",
+      "2023-04-25 14:29:42,929 - WARNING MainThread cassandra.py:list_by_location:1167 - Catalog object not found (catalog_id=19, object_id=607180137)\n",
+      "Hello Locus ANT2020dxbdw\n",
+      "Hello Locus ANT2023vbj3pzhqasjz\n",
+      "2023-04-25 14:29:46,821 - WARNING MainThread cassandra.py:list_by_location:1167 - Catalog object not found (catalog_id=19, object_id=601710656)\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:397: RuntimeWarning: invalid value encountered in log10\n",
+      "/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:396: RuntimeWarning: invalid value encountered in log10\n",
       "  result = getattr(ufunc, method)(*inputs, **kwargs)\n"
      ]
     },
@@ -864,15 +806,16 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Hello Locus ANT2018mnzzo\n",
-      "2022-08-10 13:15:47,763 - WARNING MainThread cassandra.py:list_by_location:1169 - Catalog object not found (catalog_id=19, object_id=490800411)\n"
+      "Hello Locus ANT2020a4w5w\n",
+      "Hello Locus ANT2023370hacslywz0\n",
+      "2023-04-25 14:29:50,764 - WARNING MainThread cassandra.py:list_by_location:1167 - Catalog object not found (catalog_id=19, object_id=680475568)\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:397: RuntimeWarning: invalid value encountered in log10\n",
+      "/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:396: RuntimeWarning: invalid value encountered in log10\n",
       "  result = getattr(ufunc, method)(*inputs, **kwargs)\n"
      ]
     },
@@ -880,16 +823,16 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Hello Locus ANT2020lumr6\n",
-      "Hello Locus ANT2022bonajwguj68b\n",
-      "2022-08-10 13:15:50,900 - WARNING MainThread cassandra.py:list_by_location:1169 - Catalog object not found (catalog_id=19, object_id=565470881)\n"
+      "Hello Locus ANT2020dyi6a\n",
+      "Hello Locus ANT2023n9naw2k6bdai\n",
+      "2023-04-25 14:29:54,414 - WARNING MainThread cassandra.py:list_by_location:1167 - Catalog object not found (catalog_id=19, object_id=694556409)\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:397: RuntimeWarning: invalid value encountered in log10\n",
+      "/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:396: RuntimeWarning: invalid value encountered in log10\n",
       "  result = getattr(ufunc, method)(*inputs, **kwargs)\n"
      ]
     },
@@ -897,16 +840,18 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Hello Locus ANT2020z2vms\n",
-      "Hello Locus ANT2022t3fzel65s43g\n",
-      "2022-08-10 13:15:52,853 - WARNING MainThread cassandra.py:list_by_location:1169 - Catalog object not found (catalog_id=19, object_id=510706062)\n"
+      "Hello Locus ANT2020bbfke\n",
+      "Hello Locus ANT2023bdj85krps9kd\n",
+      "2023-04-25 14:29:57,697 - WARNING MainThread cassandra.py:list_by_location:1167 - Catalog object not found (catalog_id=19, object_id=618136164)\n",
+      "Hello Locus ANT2020batf4\n",
+      "2023-04-25 14:30:00,575 - WARNING MainThread cassandra.py:list_by_location:1167 - Catalog object not found (catalog_id=19, object_id=665762465)\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:397: RuntimeWarning: invalid value encountered in log10\n",
+      "/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:396: RuntimeWarning: invalid value encountered in log10\n",
       "  result = getattr(ufunc, method)(*inputs, **kwargs)\n"
      ]
     },
@@ -914,15 +859,15 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Hello Locus ANT2021fhczw\n",
-      "2022-08-10 13:15:54,513 - WARNING MainThread cassandra.py:list_by_location:1169 - Catalog object not found (catalog_id=19, object_id=518954102)\n"
+      "Hello Locus ANT2020bbhd2\n",
+      "2023-04-25 14:30:02,732 - WARNING MainThread cassandra.py:list_by_location:1167 - Catalog object not found (catalog_id=19, object_id=600884006)\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:397: RuntimeWarning: invalid value encountered in log10\n",
+      "/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:396: RuntimeWarning: invalid value encountered in log10\n",
       "  result = getattr(ufunc, method)(*inputs, **kwargs)\n"
      ]
     },
@@ -930,16 +875,16 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Hello Locus ANT2020pcx6i\n",
-      "Hello Locus ANT202285kw9pprr34t\n",
-      "2022-08-10 13:15:56,936 - WARNING MainThread cassandra.py:list_by_location:1169 - Catalog object not found (catalog_id=19, object_id=510981891)\n"
+      "Hello Locus ANT2020a4lhq\n",
+      "Hello Locus ANT202314jwe8jpe3gb\n",
+      "2023-04-25 14:30:06,151 - WARNING MainThread cassandra.py:list_by_location:1167 - Catalog object not found (catalog_id=19, object_id=637382631)\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:397: RuntimeWarning: invalid value encountered in log10\n",
+      "/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:396: RuntimeWarning: invalid value encountered in log10\n",
       "  result = getattr(ufunc, method)(*inputs, **kwargs)\n"
      ]
     },
@@ -947,16 +892,16 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Hello Locus ANT2020lzep4\n",
-      "Hello Locus ANT2022msdzamqajuu3\n",
-      "2022-08-10 13:15:59,802 - WARNING MainThread cassandra.py:list_by_location:1169 - Catalog object not found (catalog_id=19, object_id=585146141)\n"
+      "Hello Locus ANT2020a4wxi\n",
+      "Hello Locus ANT202314jwe8jpe3gb\n",
+      "2023-04-25 14:30:09,192 - WARNING MainThread cassandra.py:list_by_location:1167 - Catalog object not found (catalog_id=19, object_id=637382631)\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:397: RuntimeWarning: invalid value encountered in log10\n",
+      "/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:396: RuntimeWarning: invalid value encountered in log10\n",
       "  result = getattr(ufunc, method)(*inputs, **kwargs)\n"
      ]
     },
@@ -964,20 +909,15 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Hello Locus ANT2020pubp4\n",
-      "Hello Locus ANT2022ci5xylord3qe\n",
-      "Hello Locus ANT2022yflceiioi4he\n",
-      "Hello Locus ANT20227liiraokppig\n",
-      "Hello Locus ANT20223q61z9so8gzp\n",
-      "Hello Locus ANT2022wifvhu1hgvj8\n",
-      "2022-08-10 13:16:05,190 - WARNING MainThread cassandra.py:list_by_location:1169 - Catalog object not found (catalog_id=19, object_id=569909003)\n"
+      "Hello Locus ANT2020a4wxi\n",
+      "2023-04-25 14:30:12,009 - WARNING MainThread cassandra.py:list_by_location:1167 - Catalog object not found (catalog_id=19, object_id=636976955)\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:397: RuntimeWarning: invalid value encountered in log10\n",
+      "/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:396: RuntimeWarning: invalid value encountered in log10\n",
       "  result = getattr(ufunc, method)(*inputs, **kwargs)\n"
      ]
     },
@@ -985,15 +925,20 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Hello Locus ANT2020z2vnu\n",
-      "2022-08-10 13:16:06,891 - WARNING MainThread cassandra.py:list_by_location:1169 - Catalog object not found (catalog_id=19, object_id=527209169)\n"
+      "Hello Locus ANT2020ba3fi\n",
+      "Hello Locus ANT2023747zh5dn2sgm\n",
+      "2023-04-25 14:30:15,433 - WARNING MainThread cassandra.py:list_by_location:1167 - Catalog object not found (catalog_id=19, object_id=699055598)\n",
+      "Hello Locus ANT2020jojae\n",
+      "Hello Locus ANT20234832qs145vmx\n",
+      "2023-04-25 14:30:18,987 - WARNING MainThread cassandra.py:list_by_location:1167 - Catalog object not found (catalog_id=19, object_id=624769746)\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:397: RuntimeWarning: invalid value encountered in log10\n",
+      "WARNING: AstropyDeprecationWarning: The truth value of a Quantity is ambiguous. In the future this will raise a ValueError. [astropy.units.quantity]\n",
+      "/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:396: RuntimeWarning: invalid value encountered in log10\n",
       "  result = getattr(ufunc, method)(*inputs, **kwargs)\n"
      ]
     },
@@ -1001,18 +946,15 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Hello Locus ANT2020qhv4s\n",
-      "Hello Locus ANT20229r32zqdbx3xd\n",
-      "2022-08-10 13:16:09,183 - WARNING MainThread cassandra.py:list_by_location:1169 - Catalog object not found (catalog_id=19, object_id=512769266)\n",
-      "Hello Locus ANT202045hxo\n",
-      "2022-08-10 13:16:10,602 - WARNING MainThread cassandra.py:list_by_location:1169 - Catalog object not found (catalog_id=19, object_id=516625498)\n"
+      "Hello Locus ANT2020a4mf6\n",
+      "2023-04-25 14:30:21,842 - WARNING MainThread cassandra.py:list_by_location:1167 - Catalog object not found (catalog_id=19, object_id=691628565)\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:397: RuntimeWarning: invalid value encountered in log10\n",
+      "/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:396: RuntimeWarning: invalid value encountered in log10\n",
       "  result = getattr(ufunc, method)(*inputs, **kwargs)\n"
      ]
     },
@@ -1020,18 +962,15 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Hello Locus ANT2020aekxwny\n",
-      "Hello Locus ANT2022z2c9zsl3lyi1\n",
-      "Hello Locus ANT20222t6123a325tg\n",
-      "Hello Locus ANT2022fs81pa94uypm\n",
-      "2022-08-10 13:16:13,971 - WARNING MainThread cassandra.py:list_by_location:1169 - Catalog object not found (catalog_id=19, object_id=558128352)\n"
+      "Hello Locus ANT2020a4wuc\n",
+      "2023-04-25 14:30:23,829 - WARNING MainThread cassandra.py:list_by_location:1167 - Catalog object not found (catalog_id=19, object_id=655240129)\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:397: RuntimeWarning: invalid value encountered in log10\n",
+      "/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:396: RuntimeWarning: invalid value encountered in log10\n",
       "  result = getattr(ufunc, method)(*inputs, **kwargs)\n"
      ]
     },
@@ -1039,19 +978,15 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Hello Locus ANT2020qixa4\n",
-      "Hello Locus ANT2022k76yv401ugd0\n",
-      "Hello Locus ANT2022hnbm13161e5p\n",
-      "2022-08-10 13:16:16,701 - WARNING MainThread cassandra.py:list_by_location:1169 - Catalog object not found (catalog_id=19, object_id=510290808)\n",
-      "Hello Locus ANT2021axlzi\n",
-      "Hello Locus ANT2022nksgjuhh7uby\n"
+      "Hello Locus ANT2020gpmum\n",
+      "2023-04-25 14:30:25,920 - WARNING MainThread cassandra.py:list_by_location:1167 - Catalog object not found (catalog_id=19, object_id=634945279)\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:397: RuntimeWarning: invalid value encountered in log10\n",
+      "/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:396: RuntimeWarning: invalid value encountered in log10\n",
       "  result = getattr(ufunc, method)(*inputs, **kwargs)\n"
      ]
     },
@@ -1059,15 +994,15 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Hello Locus ANT2020k2loc\n",
-      "2022-08-10 13:16:21,017 - WARNING MainThread cassandra.py:list_by_location:1169 - Catalog object not found (catalog_id=19, object_id=835737716)\n"
+      "Hello Locus ANT2020bavne\n",
+      "2023-04-25 14:30:28,164 - WARNING MainThread cassandra.py:list_by_location:1167 - Catalog object not found (catalog_id=19, object_id=638998376)\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:397: RuntimeWarning: invalid value encountered in log10\n",
+      "/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:396: RuntimeWarning: invalid value encountered in log10\n",
       "  result = getattr(ufunc, method)(*inputs, **kwargs)\n"
      ]
     },
@@ -1075,15 +1010,23 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Hello Locus ANT2020656nu\n",
-      "2022-08-10 13:16:22,792 - WARNING MainThread cassandra.py:list_by_location:1169 - Catalog object not found (catalog_id=19, object_id=887541554)\n"
+      "Hello Locus ANT2020eiwag\n",
+      "Hello Locus ANT20237jb0i4iiw8y8\n",
+      "2023-04-25 14:30:30,864 - WARNING MainThread cassandra.py:list_by_location:1167 - Catalog object not found (catalog_id=19, object_id=630843024)\n",
+      "Hello Locus ANT2020a4wtg\n",
+      "Hello Locus ANT2023halulggfjl42\n",
+      "Hello Locus ANT20233rhp8r5irpnw\n",
+      "Hello Locus ANT2023ic3autpzusc7\n",
+      "2023-04-25 14:30:34,894 - WARNING MainThread cassandra.py:list_by_location:1167 - Catalog object not found (catalog_id=19, object_id=610227690)\n",
+      "Hello Locus ANT2019urge6\n",
+      "2023-04-25 14:30:37,840 - WARNING MainThread cassandra.py:list_by_location:1167 - Catalog object not found (catalog_id=19, object_id=668148293)\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:397: RuntimeWarning: invalid value encountered in log10\n",
+      "/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:396: RuntimeWarning: invalid value encountered in log10\n",
       "  result = getattr(ufunc, method)(*inputs, **kwargs)\n"
      ]
     },
@@ -1091,19 +1034,19 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Hello Locus ANT2018g67c4\n",
-      "2022-08-10 13:16:24,436 - WARNING MainThread cassandra.py:list_by_location:1169 - Catalog object not found (catalog_id=19, object_id=873749389)\n",
-      "Hello Locus ANT2019ekbgq\n",
-      "Hello Locus ANT2022tapq9wivg5sz\n",
-      "Hello Locus ANT2022g5fwxd1lon1p\n",
-      "2022-08-10 13:16:27,416 - WARNING MainThread cassandra.py:list_by_location:1169 - Catalog object not found (catalog_id=19, object_id=864703191)\n"
+      "Hello Locus ANT2020bbbr4\n",
+      "Hello Locus ANT2023el71ihkdi6il\n",
+      "2023-04-25 14:30:39,973 - WARNING MainThread cassandra.py:list_by_location:1167 - Catalog object not found (catalog_id=19, object_id=611468093)\n",
+      "Hello Locus ANT20235qu8lr0x0ufz\n",
+      "Hello Locus ANT2023clklkhk9rg7f\n",
+      "2023-04-25 14:30:42,974 - WARNING MainThread cassandra.py:list_by_location:1167 - Catalog object not found (catalog_id=19, object_id=648520854)\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:397: RuntimeWarning: invalid value encountered in log10\n",
+      "/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:396: RuntimeWarning: invalid value encountered in log10\n",
       "  result = getattr(ufunc, method)(*inputs, **kwargs)\n"
      ]
     },
@@ -1111,21 +1054,19 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Hello Locus ANT2018gcwyq\n",
-      "2022-08-10 13:16:29,239 - WARNING MainThread cassandra.py:list_by_location:1169 - Catalog object not found (catalog_id=19, object_id=860504408)\n",
-      "Hello Locus ANT2019bh3rm\n",
-      "Hello Locus ANT2022hwf5ki4m8wcp\n",
-      "Hello Locus ANT2022n25j7nbqphbi\n",
-      "2022-08-10 13:16:31,588 - WARNING MainThread cassandra.py:list_by_location:1169 - Catalog object not found (catalog_id=19, object_id=898235882)\n",
-      "Hello Locus ANT20228oli4o80w5yf\n",
-      "2022-08-10 13:16:33,322 - WARNING MainThread cassandra.py:list_by_location:1169 - Catalog object not found (catalog_id=19, object_id=902073776)\n"
+      "Hello Locus ANT2020a4jo6\n",
+      "2023-04-25 14:30:45,258 - WARNING MainThread cassandra.py:list_by_location:1167 - Catalog object not found (catalog_id=19, object_id=589852984)\n",
+      "Hello Locus ANT2019vbn5a\n",
+      "2023-04-25 14:30:46,186 - WARNING MainThread cassandra.py:list_by_location:1167 - Catalog object not found (catalog_id=19, object_id=593244628)\n",
+      "Hello Locus ANT2023bo8e959apozt\n",
+      "2023-04-25 14:30:48,188 - WARNING MainThread cassandra.py:list_by_location:1167 - Catalog object not found (catalog_id=19, object_id=661787781)\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:397: RuntimeWarning: invalid value encountered in log10\n",
+      "/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:396: RuntimeWarning: invalid value encountered in log10\n",
       "  result = getattr(ufunc, method)(*inputs, **kwargs)\n"
      ]
     },
@@ -1133,15 +1074,15 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Hello Locus ANT2020mjq7c\n",
-      "2022-08-10 13:16:36,034 - WARNING MainThread cassandra.py:list_by_location:1169 - Catalog object not found (catalog_id=19, object_id=913432592)\n"
+      "Hello Locus ANT2020a7ufq\n",
+      "2023-04-25 14:30:51,368 - WARNING MainThread cassandra.py:list_by_location:1167 - Catalog object not found (catalog_id=19, object_id=661520471)\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:397: RuntimeWarning: invalid value encountered in log10\n",
+      "/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:396: RuntimeWarning: invalid value encountered in log10\n",
       "  result = getattr(ufunc, method)(*inputs, **kwargs)\n"
      ]
     },
@@ -1149,22 +1090,15 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Hello Locus ANT2018hxi5o\n",
-      "Hello Locus ANT20227tekwp2ryqte\n",
-      "Hello Locus ANT202226cmkalqs6s3\n",
-      "2022-08-10 13:16:39,930 - WARNING MainThread cassandra.py:list_by_location:1169 - Catalog object not found (catalog_id=19, object_id=814997098)\n",
-      "Hello Locus ANT2020maf76\n",
-      "Hello Locus ANT202283bnculzwnz7\n",
-      "2022-08-10 13:16:41,821 - WARNING MainThread cassandra.py:list_by_location:1169 - Catalog object not found (catalog_id=19, object_id=917436470)\n",
-      "Hello Locus ANT2022414jtaogt1o3\n",
-      "2022-08-10 13:16:43,197 - WARNING MainThread cassandra.py:list_by_location:1169 - Catalog object not found (catalog_id=19, object_id=869295660)\n"
+      "Hello Locus ANT2020akpae\n",
+      "2023-04-25 14:30:55,036 - WARNING MainThread cassandra.py:list_by_location:1167 - Catalog object not found (catalog_id=19, object_id=699321356)\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:397: RuntimeWarning: invalid value encountered in log10\n",
+      "/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:396: RuntimeWarning: invalid value encountered in log10\n",
       "  result = getattr(ufunc, method)(*inputs, **kwargs)\n"
      ]
     },
@@ -1172,15 +1106,15 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Hello Locus ANT2020pdogm\n",
-      "2022-08-10 13:16:45,393 - WARNING MainThread cassandra.py:list_by_location:1169 - Catalog object not found (catalog_id=19, object_id=828391917)\n"
+      "Hello Locus ANT2020a4mbm\n",
+      "2023-04-25 14:30:57,540 - WARNING MainThread cassandra.py:list_by_location:1167 - Catalog object not found (catalog_id=19, object_id=605934981)\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:397: RuntimeWarning: invalid value encountered in log10\n",
+      "/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:396: RuntimeWarning: invalid value encountered in log10\n",
       "  result = getattr(ufunc, method)(*inputs, **kwargs)\n"
      ]
     },
@@ -1188,21 +1122,15 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Hello Locus ANT2018genra\n",
-      "Hello Locus ANT20220crqqfr6ekcd\n",
-      "2022-08-10 13:16:48,157 - WARNING MainThread cassandra.py:list_by_location:1169 - Catalog object not found (catalog_id=19, object_id=869295294)\n",
-      "Hello Locus ANT2019242tg\n",
-      "Hello Locus ANT2022mt866wahp7nn\n",
-      "2022-08-10 13:16:50,805 - WARNING MainThread cassandra.py:list_by_location:1169 - Catalog object not found (catalog_id=19, object_id=881737998)\n",
-      "Hello Locus ANT2020jpnji\n",
-      "2022-08-10 13:16:53,227 - WARNING MainThread cassandra.py:list_by_location:1169 - Catalog object not found (catalog_id=19, object_id=919656063)\n"
+      "Hello Locus ANT2020bbgta\n",
+      "2023-04-25 14:31:00,546 - WARNING MainThread cassandra.py:list_by_location:1167 - Catalog object not found (catalog_id=19, object_id=668148293)\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:397: RuntimeWarning: invalid value encountered in log10\n",
+      "/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:396: RuntimeWarning: invalid value encountered in log10\n",
       "  result = getattr(ufunc, method)(*inputs, **kwargs)\n"
      ]
     },
@@ -1210,16 +1138,19 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Hello Locus ANT2018gezli\n",
-      "Hello Locus ANT20220j6yzkuyhixs\n",
-      "2022-08-10 13:16:56,431 - WARNING MainThread cassandra.py:list_by_location:1169 - Catalog object not found (catalog_id=19, object_id=898954032)\n"
+      "Hello Locus ANT2020bbbr4\n",
+      "Hello Locus ANT2023el71ihkdi6il\n",
+      "Hello Locus ANT2023f3kqo5itddfu\n",
+      "Hello Locus ANT2020hjubq\n",
+      "Hello Locus ANT2023clklkhk9rg7f\n",
+      "2023-04-25 14:31:07,229 - WARNING MainThread cassandra.py:list_by_location:1167 - Catalog object not found (catalog_id=19, object_id=648520854)\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:397: RuntimeWarning: invalid value encountered in log10\n",
+      "/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:396: RuntimeWarning: invalid value encountered in log10\n",
       "  result = getattr(ufunc, method)(*inputs, **kwargs)\n"
      ]
     },
@@ -1227,20 +1158,19 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Hello Locus ANT2018gfins\n",
-      "2022-08-10 13:16:58,528 - WARNING MainThread cassandra.py:list_by_location:1169 - Catalog object not found (catalog_id=19, object_id=828391341)\n",
-      "Hello Locus ANT2020uym3w\n",
-      "Hello Locus ANT2022u57bscx5qs6e\n",
-      "2022-08-10 13:17:01,084 - WARNING MainThread cassandra.py:list_by_location:1169 - Catalog object not found (catalog_id=19, object_id=842535323)\n",
-      "Hello Locus ANT2018gexh2\n",
-      "2022-08-10 13:17:03,323 - WARNING MainThread cassandra.py:list_by_location:1169 - Catalog object not found (catalog_id=19, object_id=889824228)\n"
+      "Hello Locus ANT2020a4jo6\n",
+      "2023-04-25 14:31:09,496 - WARNING MainThread cassandra.py:list_by_location:1167 - Catalog object not found (catalog_id=19, object_id=589852984)\n",
+      "Hello Locus ANT2019vbn5a\n",
+      "2023-04-25 14:31:10,413 - WARNING MainThread cassandra.py:list_by_location:1167 - Catalog object not found (catalog_id=19, object_id=593244628)\n",
+      "Hello Locus ANT2023bo8e959apozt\n",
+      "2023-04-25 14:31:12,443 - WARNING MainThread cassandra.py:list_by_location:1167 - Catalog object not found (catalog_id=19, object_id=661787781)\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:397: RuntimeWarning: invalid value encountered in log10\n",
+      "/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:396: RuntimeWarning: invalid value encountered in log10\n",
       "  result = getattr(ufunc, method)(*inputs, **kwargs)\n"
      ]
     },
@@ -1248,15 +1178,15 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Hello Locus ANT2018h5okc\n",
-      "2022-08-10 13:17:05,509 - WARNING MainThread cassandra.py:list_by_location:1169 - Catalog object not found (catalog_id=19, object_id=889824391)\n"
+      "Hello Locus ANT2020a7ufq\n",
+      "2023-04-25 14:31:15,605 - WARNING MainThread cassandra.py:list_by_location:1167 - Catalog object not found (catalog_id=19, object_id=661520471)\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:397: RuntimeWarning: invalid value encountered in log10\n",
+      "/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:396: RuntimeWarning: invalid value encountered in log10\n",
       "  result = getattr(ufunc, method)(*inputs, **kwargs)\n"
      ]
     },
@@ -1264,20 +1194,142 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Hello Locus ANT2018gaxfw\n",
-      "2022-08-10 13:17:07,877 - WARNING MainThread cassandra.py:list_by_location:1169 - Catalog object not found (catalog_id=19, object_id=869293596)\n",
-      "Hello Locus ANT2018gdlly\n",
-      "Hello Locus ANT2022ihamovf0r4ll\n",
-      "Hello Locus ANT2020o7xw6\n",
-      "{'n': 100, 'results': [{'locus_id': 'ANT2018h5lrq', 'locus_data': FilterContext(locus_id=\"ANT2018h5lrq\"), 't': 0.00010888899999983437, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT202284zos5406d9j', 'locus_data': FilterContext(locus_id=\"ANT202284zos5406d9j\"), 't': 0.0001129269999999849, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT20202uum4', 'locus_data': FilterContext(locus_id=\"ANT20202uum4\"), 't': 0.00011399999999994748, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2022sz5ssrdu1dhv', 'locus_data': FilterContext(locus_id=\"ANT2022sz5ssrdu1dhv\"), 't': 0.00013392299999992474, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2022wcnvfar1iaxa', 'locus_data': FilterContext(locus_id=\"ANT2022wcnvfar1iaxa\"), 't': 0.00010633800000015015, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2018hc6cm', 'locus_data': FilterContext(locus_id=\"ANT2018hc6cm\"), 't': 0.00015420900000151505, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2019nbtus', 'locus_data': FilterContext(locus_id=\"ANT2019nbtus\"), 't': 0.00012300600000081374, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT20217n3te', 'locus_data': FilterContext(locus_id=\"ANT20217n3te\"), 't': 0.00012011699999980863, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2019awmuk', 'locus_data': FilterContext(locus_id=\"ANT2019awmuk\"), 't': 0.00010271600000066883, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT202201gghmzf3kzz', 'locus_data': FilterContext(locus_id=\"ANT202201gghmzf3kzz\"), 't': 0.00012527099999992686, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT20206tdje', 'locus_data': FilterContext(locus_id=\"ANT20206tdje\"), 't': 0.00010105199999976833, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2020qgnjo', 'locus_data': FilterContext(locus_id=\"ANT2020qgnjo\"), 't': 0.00010572799999764015, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT202045kqm', 'locus_data': FilterContext(locus_id=\"ANT202045kqm\"), 't': 0.00011599899999836794, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2022om7a6nuh4lrx', 'locus_data': FilterContext(locus_id=\"ANT2022om7a6nuh4lrx\"), 't': 0.00012469500000023004, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2018hayaa', 'locus_data': FilterContext(locus_id=\"ANT2018hayaa\"), 't': 0.0001623769999987701, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2020aehmxqq', 'locus_data': FilterContext(locus_id=\"ANT2020aehmxqq\"), 't': 0.00010303799999888952, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2022pryenjmb8vwm', 'locus_data': FilterContext(locus_id=\"ANT2022pryenjmb8vwm\"), 't': 0.00010285999999837259, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2020aengcka', 'locus_data': FilterContext(locus_id=\"ANT2020aengcka\"), 't': 0.00010431899999829852, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2020z2wla', 'locus_data': FilterContext(locus_id=\"ANT2020z2wla\"), 't': 9.434900000115931e-05, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT20227os4qm7bi5mf', 'locus_data': FilterContext(locus_id=\"ANT20227os4qm7bi5mf\"), 't': 0.00010921800000218695, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2020sbt2e', 'locus_data': FilterContext(locus_id=\"ANT2020sbt2e\"), 't': 0.0001272959999987222, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT20202uuky', 'locus_data': FilterContext(locus_id=\"ANT20202uuky\"), 't': 0.00011561399999848732, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2020luytg', 'locus_data': FilterContext(locus_id=\"ANT2020luytg\"), 't': 0.00015281399999977907, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT20212p54u', 'locus_data': FilterContext(locus_id=\"ANT20212p54u\"), 't': 0.0004419609999999352, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2020z222g', 'locus_data': FilterContext(locus_id=\"ANT2020z222g\"), 't': 0.00016731199999853175, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2018ibyoa', 'locus_data': FilterContext(locus_id=\"ANT2018ibyoa\"), 't': 0.00017577500000243163, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2020z225k', 'locus_data': FilterContext(locus_id=\"ANT2020z225k\"), 't': 0.00042429000000154815, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2022wte1pvglgdl5', 'locus_data': FilterContext(locus_id=\"ANT2022wte1pvglgdl5\"), 't': 0.0001337320000018849, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2022oqifuv8mxr88', 'locus_data': FilterContext(locus_id=\"ANT2022oqifuv8mxr88\"), 't': 0.00013447999999982585, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2022le4ty9rc8mzn', 'locus_data': FilterContext(locus_id=\"ANT2022le4ty9rc8mzn\"), 't': 0.0004310519999997098, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2022vvjfedp4ihls', 'locus_data': FilterContext(locus_id=\"ANT2022vvjfedp4ihls\"), 't': 0.00013332199999993577, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2020lxfuy', 'locus_data': FilterContext(locus_id=\"ANT2020lxfuy\"), 't': 0.0002647679999974173, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2020aezxmgy', 'locus_data': FilterContext(locus_id=\"ANT2020aezxmgy\"), 't': 0.0001357070000018723, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT20213hbwq', 'locus_data': FilterContext(locus_id=\"ANT20213hbwq\"), 't': 0.0004953749999998536, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2020p7s6c', 'locus_data': FilterContext(locus_id=\"ANT2020p7s6c\"), 't': 0.0004338910000001306, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2022sq882ybua6fu', 'locus_data': FilterContext(locus_id=\"ANT2022sq882ybua6fu\"), 't': 0.00013894699999994486, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2018mnzzo', 'locus_data': FilterContext(locus_id=\"ANT2018mnzzo\"), 't': 0.00014626500000147757, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2020lumr6', 'locus_data': FilterContext(locus_id=\"ANT2020lumr6\"), 't': 0.00031451899999979105, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2022bonajwguj68b', 'locus_data': FilterContext(locus_id=\"ANT2022bonajwguj68b\"), 't': 0.00013667300000008709, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2020z2vms', 'locus_data': FilterContext(locus_id=\"ANT2020z2vms\"), 't': 0.000135258000000249, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2022t3fzel65s43g', 'locus_data': FilterContext(locus_id=\"ANT2022t3fzel65s43g\"), 't': 0.0001351679999999078, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2021fhczw', 'locus_data': FilterContext(locus_id=\"ANT2021fhczw\"), 't': 0.0001241249999992533, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2020pcx6i', 'locus_data': FilterContext(locus_id=\"ANT2020pcx6i\"), 't': 0.00013537299999910601, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT202285kw9pprr34t', 'locus_data': FilterContext(locus_id=\"ANT202285kw9pprr34t\"), 't': 0.0007487280000013641, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2020lzep4', 'locus_data': FilterContext(locus_id=\"ANT2020lzep4\"), 't': 0.00014640399999876763, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2022msdzamqajuu3', 'locus_data': FilterContext(locus_id=\"ANT2022msdzamqajuu3\"), 't': 0.00012945099999939202, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2020pubp4', 'locus_data': FilterContext(locus_id=\"ANT2020pubp4\"), 't': 0.0001228189999977758, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2022ci5xylord3qe', 'locus_data': FilterContext(locus_id=\"ANT2022ci5xylord3qe\"), 't': 0.00013440300000411298, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2022yflceiioi4he', 'locus_data': FilterContext(locus_id=\"ANT2022yflceiioi4he\"), 't': 0.00026187799999632944, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT20227liiraokppig', 'locus_data': FilterContext(locus_id=\"ANT20227liiraokppig\"), 't': 0.0001325560000040582, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT20223q61z9so8gzp', 'locus_data': FilterContext(locus_id=\"ANT20223q61z9so8gzp\"), 't': 0.0001281740000038667, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2022wifvhu1hgvj8', 'locus_data': FilterContext(locus_id=\"ANT2022wifvhu1hgvj8\"), 't': 0.000126544000004003, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2020z2vnu', 'locus_data': FilterContext(locus_id=\"ANT2020z2vnu\"), 't': 0.0001434499999959371, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2020qhv4s', 'locus_data': FilterContext(locus_id=\"ANT2020qhv4s\"), 't': 0.0004439160000018205, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT20229r32zqdbx3xd', 'locus_data': FilterContext(locus_id=\"ANT20229r32zqdbx3xd\"), 't': 0.00012801300000120364, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT202045hxo', 'locus_data': FilterContext(locus_id=\"ANT202045hxo\"), 't': 0.00021426600000040708, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2020aekxwny', 'locus_data': FilterContext(locus_id=\"ANT2020aekxwny\"), 't': 0.00013042799999851695, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2022z2c9zsl3lyi1', 'locus_data': FilterContext(locus_id=\"ANT2022z2c9zsl3lyi1\"), 't': 0.0001324039999985871, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT20222t6123a325tg', 'locus_data': FilterContext(locus_id=\"ANT20222t6123a325tg\"), 't': 0.00013124200000191877, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2022fs81pa94uypm', 'locus_data': FilterContext(locus_id=\"ANT2022fs81pa94uypm\"), 't': 0.00013144599999748152, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2020qixa4', 'locus_data': FilterContext(locus_id=\"ANT2020qixa4\"), 't': 0.00013467400000166663, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2022k76yv401ugd0', 'locus_data': FilterContext(locus_id=\"ANT2022k76yv401ugd0\"), 't': 0.0001285539999997809, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2022hnbm13161e5p', 'locus_data': FilterContext(locus_id=\"ANT2022hnbm13161e5p\"), 't': 0.0001320319999962294, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2021axlzi', 'locus_data': FilterContext(locus_id=\"ANT2021axlzi\"), 't': 0.00014044499999954496, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2022nksgjuhh7uby', 'locus_data': FilterContext(locus_id=\"ANT2022nksgjuhh7uby\"), 't': 0.00021017000000256303, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2020k2loc', 'locus_data': FilterContext(locus_id=\"ANT2020k2loc\"), 't': 0.00043731000000235554, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2020656nu', 'locus_data': FilterContext(locus_id=\"ANT2020656nu\"), 't': 0.00012778499999654969, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2018g67c4', 'locus_data': FilterContext(locus_id=\"ANT2018g67c4\"), 't': 0.00013528200000223478, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2019ekbgq', 'locus_data': FilterContext(locus_id=\"ANT2019ekbgq\"), 't': 0.00014316400000069507, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2022tapq9wivg5sz', 'locus_data': FilterContext(locus_id=\"ANT2022tapq9wivg5sz\"), 't': 0.0002820509999992282, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2022g5fwxd1lon1p', 'locus_data': FilterContext(locus_id=\"ANT2022g5fwxd1lon1p\"), 't': 0.0001310059999966029, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2018gcwyq', 'locus_data': FilterContext(locus_id=\"ANT2018gcwyq\"), 't': 0.0001438440000001151, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2019bh3rm', 'locus_data': FilterContext(locus_id=\"ANT2019bh3rm\"), 't': 0.0001487329999960707, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2022hwf5ki4m8wcp', 'locus_data': FilterContext(locus_id=\"ANT2022hwf5ki4m8wcp\"), 't': 0.0001356249999986403, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2022n25j7nbqphbi', 'locus_data': FilterContext(locus_id=\"ANT2022n25j7nbqphbi\"), 't': 0.00012455099999897357, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT20228oli4o80w5yf', 'locus_data': FilterContext(locus_id=\"ANT20228oli4o80w5yf\"), 't': 0.00013241599999957998, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2020mjq7c', 'locus_data': FilterContext(locus_id=\"ANT2020mjq7c\"), 't': 7.774099999835471e-05, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2018hxi5o', 'locus_data': FilterContext(locus_id=\"ANT2018hxi5o\"), 't': 0.00016229199999884258, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT20227tekwp2ryqte', 'locus_data': FilterContext(locus_id=\"ANT20227tekwp2ryqte\"), 't': 0.00013245099999892318, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT202226cmkalqs6s3', 'locus_data': FilterContext(locus_id=\"ANT202226cmkalqs6s3\"), 't': 0.00012647700000201212, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2020maf76', 'locus_data': FilterContext(locus_id=\"ANT2020maf76\"), 't': 0.0001735250000010069, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT202283bnculzwnz7', 'locus_data': FilterContext(locus_id=\"ANT202283bnculzwnz7\"), 't': 0.00013343199999837907, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2022414jtaogt1o3', 'locus_data': FilterContext(locus_id=\"ANT2022414jtaogt1o3\"), 't': 0.00012649100000317048, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2020pdogm', 'locus_data': FilterContext(locus_id=\"ANT2020pdogm\"), 't': 0.0001676779999968403, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2018genra', 'locus_data': FilterContext(locus_id=\"ANT2018genra\"), 't': 0.0004809070000035831, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT20220crqqfr6ekcd', 'locus_data': FilterContext(locus_id=\"ANT20220crqqfr6ekcd\"), 't': 0.00013373399999494495, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2019242tg', 'locus_data': FilterContext(locus_id=\"ANT2019242tg\"), 't': 0.00016449299999976574, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2022mt866wahp7nn', 'locus_data': FilterContext(locus_id=\"ANT2022mt866wahp7nn\"), 't': 0.0001447850000033668, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2020jpnji', 'locus_data': FilterContext(locus_id=\"ANT2020jpnji\"), 't': 0.0001537810000016293, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2018gezli', 'locus_data': FilterContext(locus_id=\"ANT2018gezli\"), 't': 0.00012021500000258811, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT20220j6yzkuyhixs', 'locus_data': FilterContext(locus_id=\"ANT20220j6yzkuyhixs\"), 't': 0.00013516599999974233, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2018gfins', 'locus_data': FilterContext(locus_id=\"ANT2018gfins\"), 't': 0.00011442099999925404, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2020uym3w', 'locus_data': FilterContext(locus_id=\"ANT2020uym3w\"), 't': 0.0001439760000039314, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2022u57bscx5qs6e', 'locus_data': FilterContext(locus_id=\"ANT2022u57bscx5qs6e\"), 't': 0.00013031499999982543, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2018gexh2', 'locus_data': FilterContext(locus_id=\"ANT2018gexh2\"), 't': 0.00014240100000506573, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2018h5okc', 'locus_data': FilterContext(locus_id=\"ANT2018h5okc\"), 't': 0.00015007999999738786, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2018gaxfw', 'locus_data': FilterContext(locus_id=\"ANT2018gaxfw\"), 't': 0.00013970099999482954, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2018gdlly', 'locus_data': FilterContext(locus_id=\"ANT2018gdlly\"), 't': 0.00016776999999734699, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2022ihamovf0r4ll', 'locus_data': FilterContext(locus_id=\"ANT2022ihamovf0r4ll\"), 't': 0.00014186299999607854, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2020o7xw6', 'locus_data': FilterContext(locus_id=\"ANT2020o7xw6\"), 't': 0.00013190299999621402, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}], 't_50_percentile': 0.00013444150000196942, 't_90_percentile': 0.0002852977999992848, 't_95_percentile': 0.00043754255000223453, 't_99_percentile': 0.00049790852999987}\n"
+      "Hello Locus ANT2020akpae\n",
+      "2023-04-25 14:31:18,785 - WARNING MainThread cassandra.py:list_by_location:1167 - Catalog object not found (catalog_id=19, object_id=699321356)\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:397: RuntimeWarning: invalid value encountered in log10\n",
+      "/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:396: RuntimeWarning: invalid value encountered in log10\n",
       "  result = getattr(ufunc, method)(*inputs, **kwargs)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Hello Locus ANT2020a4mbm\n",
+      "2023-04-25 14:31:21,293 - WARNING MainThread cassandra.py:list_by_location:1167 - Catalog object not found (catalog_id=19, object_id=605934981)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:396: RuntimeWarning: invalid value encountered in log10\n",
+      "  result = getattr(ufunc, method)(*inputs, **kwargs)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Hello Locus ANT2020bbgta\n",
+      "2023-04-25 14:31:23,744 - WARNING MainThread cassandra.py:list_by_location:1167 - Catalog object not found (catalog_id=19, object_id=678736381)\n",
+      "Hello Locus ANT2020vkm6q\n",
+      "2023-04-25 14:31:26,693 - WARNING MainThread cassandra.py:list_by_location:1167 - Catalog object not found (catalog_id=19, object_id=591753445)\n",
+      "Hello Locus ANT2020ba2dw\n",
+      "2023-04-25 14:31:29,851 - WARNING MainThread cassandra.py:list_by_location:1167 - Catalog object not found (catalog_id=19, object_id=601435246)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:396: RuntimeWarning: invalid value encountered in log10\n",
+      "  result = getattr(ufunc, method)(*inputs, **kwargs)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Hello Locus ANT2020a4mhe\n",
+      "2023-04-25 14:31:32,496 - WARNING MainThread cassandra.py:list_by_location:1167 - Catalog object not found (catalog_id=19, object_id=595549395)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:396: RuntimeWarning: invalid value encountered in log10\n",
+      "  result = getattr(ufunc, method)(*inputs, **kwargs)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Hello Locus ANT2020a4vwu\n",
+      "Hello Locus ANT20239ug0z3idyr9y\n",
+      "2023-04-25 14:31:34,440 - WARNING MainThread cassandra.py:list_by_location:1167 - Catalog object not found (catalog_id=19, object_id=633583898)\n",
+      "Hello Locus ANT2023cd9o5bimvpzo\n",
+      "2023-04-25 14:31:36,425 - WARNING MainThread cassandra.py:list_by_location:1167 - Catalog object not found (catalog_id=19, object_id=604542027)\n",
+      "Hello Locus ANT2019yriee\n",
+      "2023-04-25 14:31:38,366 - WARNING MainThread cassandra.py:list_by_location:1167 - Catalog object not found (catalog_id=19, object_id=605379424)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:396: RuntimeWarning: invalid value encountered in log10\n",
+      "  result = getattr(ufunc, method)(*inputs, **kwargs)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Hello Locus ANT2020baya4\n",
+      "Hello Locus ANT2023wfvyxsqww87b\n",
+      "2023-04-25 14:31:41,567 - WARNING MainThread cassandra.py:list_by_location:1167 - Catalog object not found (catalog_id=19, object_id=595684580)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:396: RuntimeWarning: invalid value encountered in log10\n",
+      "  result = getattr(ufunc, method)(*inputs, **kwargs)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Hello Locus ANT2020a7n46\n",
+      "Hello Locus ANT2023w11fstqn72dy\n",
+      "Hello Locus ANT2023ehq8i9pcoff4\n",
+      "Hello Locus ANT2023j6mxk72liaxp\n",
+      "Hello Locus ANT2023hct4fvf9zhjw\n",
+      "2023-04-25 14:31:46,845 - WARNING MainThread cassandra.py:list_by_location:1167 - Catalog object not found (catalog_id=19, object_id=683396236)\n",
+      "Hello Locus ANT2023vxh6d9xytpsu\n",
+      "Hello Locus ANT2023m1wmvtr02d43\n",
+      "2023-04-25 14:31:49,418 - WARNING MainThread cassandra.py:list_by_location:1167 - Catalog object not found (catalog_id=19, object_id=619942956)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/data0/sw/antares-kernel/lib/python3.9/site-packages/pandas/core/arraylike.py:396: RuntimeWarning: invalid value encountered in log10\n",
+      "  result = getattr(ufunc, method)(*inputs, **kwargs)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Hello Locus ANT2020a4ymw\n",
+      "2023-04-25 14:31:50,690 - WARNING MainThread cassandra.py:list_by_location:1167 - Catalog object not found (catalog_id=19, object_id=631393486)\n",
+      "Hello Locus ANT2023fier0cypxzpk\n",
+      "2023-04-25 14:31:52,728 - WARNING MainThread cassandra.py:list_by_location:1167 - Catalog object not found (catalog_id=19, object_id=656843529)\n",
+      "Hello Locus ANT2021vf4zo\n",
+      "Hello Locus ANT2023fk3494adih0j\n",
+      "{'n': 100, 'results': [{'locus_id': 'ANT2020bbrei', 'locus_data': FilterContext(locus_id=\"ANT2020bbrei\"), 't': 8.019599999897764e-05, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2020jojuc', 'locus_data': FilterContext(locus_id=\"ANT2020jojuc\"), 't': 7.393599999261369e-05, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2018ba7as', 'locus_data': FilterContext(locus_id=\"ANT2018ba7as\"), 't': 9.706100000528295e-05, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2020a4nco', 'locus_data': FilterContext(locus_id=\"ANT2020a4nco\"), 't': 8.82510000081993e-05, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2023t92jq14b9zrc', 'locus_data': FilterContext(locus_id=\"ANT2023t92jq14b9zrc\"), 't': 7.102499999689371e-05, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2020a4w3e', 'locus_data': FilterContext(locus_id=\"ANT2020a4w3e\"), 't': 0.00010175599999229235, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2018iqoq', 'locus_data': FilterContext(locus_id=\"ANT2018iqoq\"), 't': 0.00052675499999566, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2020a7khs', 'locus_data': FilterContext(locus_id=\"ANT2020a7khs\"), 't': 9.260500000607408e-05, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2023ztpvwxlwgyn7', 'locus_data': FilterContext(locus_id=\"ANT2023ztpvwxlwgyn7\"), 't': 6.733899999744608e-05, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2020cnps4', 'locus_data': FilterContext(locus_id=\"ANT2020cnps4\"), 't': 8.855799998741531e-05, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT20195tat2', 'locus_data': FilterContext(locus_id=\"ANT20195tat2\"), 't': 8.298700001319048e-05, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2018b4w6k', 'locus_data': FilterContext(locus_id=\"ANT2018b4w6k\"), 't': 9.817299999781426e-05, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2020a4sh2', 'locus_data': FilterContext(locus_id=\"ANT2020a4sh2\"), 't': 9.709600000462615e-05, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2023splnbnda0wyl', 'locus_data': FilterContext(locus_id=\"ANT2023splnbnda0wyl\"), 't': 9.98919999943837e-05, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT20231jsy3o1bb4eo', 'locus_data': FilterContext(locus_id=\"ANT20231jsy3o1bb4eo\"), 't': 6.993200000238176e-05, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2020a4ype', 'locus_data': FilterContext(locus_id=\"ANT2020a4ype\"), 't': 9.829699999386321e-05, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2022ahnak', 'locus_data': FilterContext(locus_id=\"ANT2022ahnak\"), 't': 0.00010534700000164321, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2019kgrao', 'locus_data': FilterContext(locus_id=\"ANT2019kgrao\"), 't': 0.00010115199999916058, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2020a4nym', 'locus_data': FilterContext(locus_id=\"ANT2020a4nym\"), 't': 9.840399999916372e-05, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2020bbbl4', 'locus_data': FilterContext(locus_id=\"ANT2020bbbl4\"), 't': 9.81539999997949e-05, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2020a4huk', 'locus_data': FilterContext(locus_id=\"ANT2020a4huk\"), 't': 9.36870000032286e-05, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2023v4zf9rhuttjt', 'locus_data': FilterContext(locus_id=\"ANT2023v4zf9rhuttjt\"), 't': 6.862300000420873e-05, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2020a7mnm', 'locus_data': FilterContext(locus_id=\"ANT2020a7mnm\"), 't': 8.577399999865065e-05, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2023aol8q84cow9t', 'locus_data': FilterContext(locus_id=\"ANT2023aol8q84cow9t\"), 't': 6.495899999947596e-05, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2020a4vei', 'locus_data': FilterContext(locus_id=\"ANT2020a4vei\"), 't': 9.749099999112332e-05, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2020a7iqu', 'locus_data': FilterContext(locus_id=\"ANT2020a7iqu\"), 't': 9.657799999729377e-05, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2023iyl2166056su', 'locus_data': FilterContext(locus_id=\"ANT2023iyl2166056su\"), 't': 7.741599999633308e-05, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2020dxbdw', 'locus_data': FilterContext(locus_id=\"ANT2020dxbdw\"), 't': 9.023100000149498e-05, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2023vbj3pzhqasjz', 'locus_data': FilterContext(locus_id=\"ANT2023vbj3pzhqasjz\"), 't': 6.51810000107389e-05, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2020a4w5w', 'locus_data': FilterContext(locus_id=\"ANT2020a4w5w\"), 't': 7.915599999819278e-05, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2023370hacslywz0', 'locus_data': FilterContext(locus_id=\"ANT2023370hacslywz0\"), 't': 6.61830000012742e-05, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2020dyi6a', 'locus_data': FilterContext(locus_id=\"ANT2020dyi6a\"), 't': 6.515900000181318e-05, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2023n9naw2k6bdai', 'locus_data': FilterContext(locus_id=\"ANT2023n9naw2k6bdai\"), 't': 7.257600000798448e-05, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2020bbfke', 'locus_data': FilterContext(locus_id=\"ANT2020bbfke\"), 't': 9.845200000313525e-05, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2023bdj85krps9kd', 'locus_data': FilterContext(locus_id=\"ANT2023bdj85krps9kd\"), 't': 7.148699999959263e-05, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2020batf4', 'locus_data': FilterContext(locus_id=\"ANT2020batf4\"), 't': 8.626900000763271e-05, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2020bbhd2', 'locus_data': FilterContext(locus_id=\"ANT2020bbhd2\"), 't': 8.466900000314581e-05, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2020a4lhq', 'locus_data': FilterContext(locus_id=\"ANT2020a4lhq\"), 't': 9.68189999923652e-05, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT202314jwe8jpe3gb', 'locus_data': FilterContext(locus_id=\"ANT202314jwe8jpe3gb\"), 't': 0.00011679799999342322, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2020a4wxi', 'locus_data': FilterContext(locus_id=\"ANT2020a4wxi\"), 't': 7.954299999823888e-05, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT202314jwe8jpe3gb', 'locus_data': FilterContext(locus_id=\"ANT202314jwe8jpe3gb\"), 't': 6.565799999691535e-05, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2020a4wxi', 'locus_data': FilterContext(locus_id=\"ANT2020a4wxi\"), 't': 9.614399999691159e-05, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2020ba3fi', 'locus_data': FilterContext(locus_id=\"ANT2020ba3fi\"), 't': 9.93849999986196e-05, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2023747zh5dn2sgm', 'locus_data': FilterContext(locus_id=\"ANT2023747zh5dn2sgm\"), 't': 6.806300000050669e-05, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2020jojae', 'locus_data': FilterContext(locus_id=\"ANT2020jojae\"), 't': 8.779099999856044e-05, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT20234832qs145vmx', 'locus_data': FilterContext(locus_id=\"ANT20234832qs145vmx\"), 't': 6.628299999533738e-05, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2020a4mf6', 'locus_data': FilterContext(locus_id=\"ANT2020a4mf6\"), 't': 9.988399999372177e-05, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2020a4wuc', 'locus_data': FilterContext(locus_id=\"ANT2020a4wuc\"), 't': 0.00010004099999605387, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2020gpmum', 'locus_data': FilterContext(locus_id=\"ANT2020gpmum\"), 't': 9.550900000476759e-05, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2020bavne', 'locus_data': FilterContext(locus_id=\"ANT2020bavne\"), 't': 9.487100000171722e-05, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2020eiwag', 'locus_data': FilterContext(locus_id=\"ANT2020eiwag\"), 't': 9.812799999053823e-05, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT20237jb0i4iiw8y8', 'locus_data': FilterContext(locus_id=\"ANT20237jb0i4iiw8y8\"), 't': 0.00010106200001303023, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2020a4wtg', 'locus_data': FilterContext(locus_id=\"ANT2020a4wtg\"), 't': 8.875099999272607e-05, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2023halulggfjl42', 'locus_data': FilterContext(locus_id=\"ANT2023halulggfjl42\"), 't': 0.00011836699999889788, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT20233rhp8r5irpnw', 'locus_data': FilterContext(locus_id=\"ANT20233rhp8r5irpnw\"), 't': 6.806900000810856e-05, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2023ic3autpzusc7', 'locus_data': FilterContext(locus_id=\"ANT2023ic3autpzusc7\"), 't': 6.972900000334903e-05, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2019urge6', 'locus_data': FilterContext(locus_id=\"ANT2019urge6\"), 't': 7.419599999991533e-05, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2020bbbr4', 'locus_data': FilterContext(locus_id=\"ANT2020bbbr4\"), 't': 6.415800000070249e-05, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2023el71ihkdi6il', 'locus_data': FilterContext(locus_id=\"ANT2023el71ihkdi6il\"), 't': 4.858799999851726e-05, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT20235qu8lr0x0ufz', 'locus_data': FilterContext(locus_id=\"ANT20235qu8lr0x0ufz\"), 't': 6.532999999819822e-05, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2023clklkhk9rg7f', 'locus_data': FilterContext(locus_id=\"ANT2023clklkhk9rg7f\"), 't': 6.516300000214414e-05, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2020a4jo6', 'locus_data': FilterContext(locus_id=\"ANT2020a4jo6\"), 't': 9.701800000527783e-05, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2019vbn5a', 'locus_data': FilterContext(locus_id=\"ANT2019vbn5a\"), 't': 7.765499999834446e-05, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2023bo8e959apozt', 'locus_data': FilterContext(locus_id=\"ANT2023bo8e959apozt\"), 't': 6.657899999140682e-05, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2020a7ufq', 'locus_data': FilterContext(locus_id=\"ANT2020a7ufq\"), 't': 0.00010892699999942579, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2020akpae', 'locus_data': FilterContext(locus_id=\"ANT2020akpae\"), 't': 0.00011119600000597529, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2020a4mbm', 'locus_data': FilterContext(locus_id=\"ANT2020a4mbm\"), 't': 0.0001360239999996793, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2020bbgta', 'locus_data': FilterContext(locus_id=\"ANT2020bbgta\"), 't': 0.00012170799999466908, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2020bbbr4', 'locus_data': FilterContext(locus_id=\"ANT2020bbbr4\"), 't': 9.686100000294573e-05, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2023el71ihkdi6il', 'locus_data': FilterContext(locus_id=\"ANT2023el71ihkdi6il\"), 't': 6.77160000037702e-05, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2023f3kqo5itddfu', 'locus_data': FilterContext(locus_id=\"ANT2023f3kqo5itddfu\"), 't': 6.918799999766634e-05, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2020hjubq', 'locus_data': FilterContext(locus_id=\"ANT2020hjubq\"), 't': 0.00011927900000330283, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2023clklkhk9rg7f', 'locus_data': FilterContext(locus_id=\"ANT2023clklkhk9rg7f\"), 't': 6.910099999402064e-05, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2020a4jo6', 'locus_data': FilterContext(locus_id=\"ANT2020a4jo6\"), 't': 0.00012479500000495136, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2019vbn5a', 'locus_data': FilterContext(locus_id=\"ANT2019vbn5a\"), 't': 7.803399999772864e-05, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2023bo8e959apozt', 'locus_data': FilterContext(locus_id=\"ANT2023bo8e959apozt\"), 't': 0.0001713179999995873, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2020a7ufq', 'locus_data': FilterContext(locus_id=\"ANT2020a7ufq\"), 't': 0.00011293800000089504, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2020akpae', 'locus_data': FilterContext(locus_id=\"ANT2020akpae\"), 't': 7.436999999299587e-05, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2020a4mbm', 'locus_data': FilterContext(locus_id=\"ANT2020a4mbm\"), 't': 0.00011471599999879345, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2020bbgta', 'locus_data': FilterContext(locus_id=\"ANT2020bbgta\"), 't': 0.00010545399999273286, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2020vkm6q', 'locus_data': FilterContext(locus_id=\"ANT2020vkm6q\"), 't': 9.381399999597306e-05, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2020ba2dw', 'locus_data': FilterContext(locus_id=\"ANT2020ba2dw\"), 't': 0.00012193099999535661, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2020a4mhe', 'locus_data': FilterContext(locus_id=\"ANT2020a4mhe\"), 't': 0.00011581500000090728, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2020a4vwu', 'locus_data': FilterContext(locus_id=\"ANT2020a4vwu\"), 't': 9.917100000222945e-05, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT20239ug0z3idyr9y', 'locus_data': FilterContext(locus_id=\"ANT20239ug0z3idyr9y\"), 't': 7.54539999974213e-05, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2023cd9o5bimvpzo', 'locus_data': FilterContext(locus_id=\"ANT2023cd9o5bimvpzo\"), 't': 7.025700000440338e-05, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2019yriee', 'locus_data': FilterContext(locus_id=\"ANT2019yriee\"), 't': 9.903599999461221e-05, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2020baya4', 'locus_data': FilterContext(locus_id=\"ANT2020baya4\"), 't': 7.372099999258808e-05, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2023wfvyxsqww87b', 'locus_data': FilterContext(locus_id=\"ANT2023wfvyxsqww87b\"), 't': 6.997300000932682e-05, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2020a7n46', 'locus_data': FilterContext(locus_id=\"ANT2020a7n46\"), 't': 6.0489000006214155e-05, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2023w11fstqn72dy', 'locus_data': FilterContext(locus_id=\"ANT2023w11fstqn72dy\"), 't': 5.07100000106675e-05, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2023ehq8i9pcoff4', 'locus_data': FilterContext(locus_id=\"ANT2023ehq8i9pcoff4\"), 't': 6.72720000238769e-05, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2023j6mxk72liaxp', 'locus_data': FilterContext(locus_id=\"ANT2023j6mxk72liaxp\"), 't': 6.383199999504541e-05, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2023hct4fvf9zhjw', 'locus_data': FilterContext(locus_id=\"ANT2023hct4fvf9zhjw\"), 't': 6.515399999784677e-05, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2023vxh6d9xytpsu', 'locus_data': FilterContext(locus_id=\"ANT2023vxh6d9xytpsu\"), 't': 6.926700001486097e-05, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2023m1wmvtr02d43', 'locus_data': FilterContext(locus_id=\"ANT2023m1wmvtr02d43\"), 't': 6.989599998519225e-05, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2020a4ymw', 'locus_data': FilterContext(locus_id=\"ANT2020a4ymw\"), 't': 9.750899999971807e-05, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2023fier0cypxzpk', 'locus_data': FilterContext(locus_id=\"ANT2023fier0cypxzpk\"), 't': 9.361200000057579e-05, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2021vf4zo', 'locus_data': FilterContext(locus_id=\"ANT2021vf4zo\"), 't': 8.473200000480574e-05, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}, {'locus_id': 'ANT2023fk3494adih0j', 'locus_data': FilterContext(locus_id=\"ANT2023fk3494adih0j\"), 't': 7.75080000039452e-05, 'new_locus_properties': {}, 'new_alert_properties': {}, 'new_tags': {'hello_world'}, 'raised_halt': False}], 't_50_percentile': 8.802100000337987e-05, 't_90_percentile': 0.00011482589999900485, 't_95_percentile': 0.00012171914999470346, 't_99_percentile': 0.00017487236999954984}\n"
      ]
     }
    ],
@@ -1299,16 +1351,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2022-08-10 13:17:11,382 - WARNING MainThread cassandra.py:list_by_location:1169 - Catalog object not found (catalog_id=19, object_id=490951081)\n",
-      "2022-08-10 13:17:11,460 - WARNING MainThread ztf_flux_correction.py:correct_mags:61 - Attempt to correct magnitudes failed, missing fields\n",
-      "Building the lightcurve with the following missing columns: {'ant_magerr', 'ant_passband', 'ant_maglim', 'ant_dec', 'ant_survey', 'ant_ra'}\n",
+      "2023-04-25 14:36:18,488 - WARNING MainThread cassandra.py:list_by_location:1167 - Catalog object not found (catalog_id=19, object_id=490951081)\n",
+      "2023-04-25 14:36:18,583 - WARNING MainThread ztf_flux_correction.py:correct_mags:62 - Attempt to correct magnitudes failed, missing fields\n",
+      "Building the lightcurve with the following missing columns: {'ant_maglim', 'ant_magerr', 'ant_dec', 'ant_passband', 'ant_ra', 'ant_survey'}\n",
       "Hello Locus locus1\n"
      ]
     },
@@ -1317,14 +1369,14 @@
       "text/plain": [
        "{'locus_id': 'locus1',\n",
        " 'locus_data': FilterContext(locus_id=\"locus1\"),\n",
-       " 't': 0.001019798000001515,\n",
+       " 't': 7.160700002373233e-05,\n",
        " 'new_locus_properties': {},\n",
        " 'new_alert_properties': {},\n",
        " 'new_tags': {'hello_world'},\n",
        " 'raised_halt': False}"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1379,7 +1431,7 @@
     "\n",
     "### Uploading files into ANTARES\n",
     "\n",
-    "The detail of uploading files into ANTARES can be found at ANTARES [Documentation](https://noao.gitlab.io/antares/filter-documentation/devkit/files.html)"
+    "The detail of uploading files into ANTARES can be found at ANTARES [Documentation](https://nsf-noirlab.gitlab.io/csdc/antares/antares/devkit/files.html)"
    ]
   },
   {
@@ -1394,7 +1446,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1447,7 +1499,7 @@
     "\n",
     "When you're ready to submit your filter to ANTARES, go to the [filters](https://antares.noirlab.edu/filters) page on the ANTARES website and click \"Add\".\n",
     "\n",
-    "**Note**: We highly recommend setting an `ERROR_LOG_SLACK_CHANNEL` on your filter so that you will receive notifications of errors. See [Debugging Filters in Production](https://noao.gitlab.io/antares/filter-documentation/devkit/debugging.html#devkit-debugging).\n",
+    "**Note**: We highly recommend setting an `ERROR_SLACK_CHANNEL` on your filter so that you will receive notifications of errors. See [Debugging Filters in Production](https://nsf-noirlab.gitlab.io/csdc/antares/antares/devkit/debugging.html).\n",
     "\n",
     "When you submit your filter you will need to provide:\n",
     "\n",
@@ -1490,7 +1542,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.12"
+   "version": "3.9.16"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Hello from the ANTARES dev team!

The `AntaresFilterDevKit` notebook needs some updates as follows (mostly documentation-related):
- Metadata: `__edited__` and `__version__` fields
- Table of contents typos
- "Structure of a Filter" section code uses now `REQUIRED_LOCUS_PROPERTIES`, `REQUIRED_ALERT_PROPERTIES` and `REQUIRED_TAGS`
- Links to external documentation updated to the current [ANTARES documentation](https://nsf-noirlab.gitlab.io/csdc/antares/antares/index.html)
- Small typo in the last section which should say `ERROR_SLACK_CHANNEL`

I was not sure of how to update the HTML file associated to the notebook. What I did was to click (inside Data Lab) on the notebook in the file browser at the left side . Then click on File -> Export Notebook As -> HTML. Let me know if it's ok or if I need to update it differently.

Thanks!