### PR TITLE
testnotebooks.py code now traps two kernel exceptions: DeadKernelErro…

### DIFF
--- a/tests/testnotebooks.py
+++ b/tests/testnotebooks.py
@@ -325,6 +325,9 @@ def run(paths,include=('/**/*.ipynb',),exclude=('/**/*_tested.ipynb',),plain=Fal
         except NoSuchKernel:
             cprint('REQUIRED KERNEL NOT PRESENT','red')
             test = 'FAIL'
+        except Exception as e:
+            cprint('AN EXCEPTION OCCURRED: %e' % e,'red')
+            test = 'FAIL'
         else:
             try:
                 assert errors == []

--- a/tests/testnotebooks.py
+++ b/tests/testnotebooks.py
@@ -1,4 +1,4 @@
-__version__ = '20230619'
+__version__ = '20230620'
 __author__ = 'Robert Nikutta <robert.nikutta@noirlab.edu>'
 
 # imports
@@ -326,7 +326,7 @@ def run(paths,include=('/**/*.ipynb',),exclude=('/**/*_tested.ipynb',),plain=Fal
             cprint('REQUIRED KERNEL NOT PRESENT','red')
             test = 'FAIL'
         except Exception as e:
-            cprint('AN EXCEPTION OCCURRED: %e' % e,'red')
+            cprint('AN EXCEPTION OCCURRED: %s' % e,'red')
             test = 'FAIL'
         else:
             try:


### PR DESCRIPTION
…r (likely due to RAM exhaustion), and NoSuchKernel. The test suite continues with the next NB in both cases, rather than quiting.