### PR TITLE
Fix fully-masked SDSS spectrum

### DIFF
--- a/04_HowTos/SPARCL/Plot_SPARCL_Spectra_with_Prospect.ipynb
+++ b/04_HowTos/SPARCL/Plot_SPARCL_Spectra_with_Prospect.ipynb
@@ -2,20 +2,12 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2023-08-16T17:27:39.943059Z",
-     "iopub.status.busy": "2023-08-16T17:27:39.942752Z",
-     "iopub.status.idle": "2023-08-16T17:27:39.948412Z",
-     "shell.execute_reply": "2023-08-16T17:27:39.947306Z",
-     "shell.execute_reply.started": "2023-08-16T17:27:39.943021Z"
-    }
-   },
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": [
     "__author__ = 'Eric Armengaud, Benjamin Weaver <benjamin.weaver@noirlab.edu>, Alice Jacques <alice.jacques@noirlab.edu>'\n",
-    "__version__ = '20230816' # yyyymmdd\n",
+    "__version__ = '20240124' # yyyymmdd\n",
     "__datasets__ = ['sdss_dr16', 'boss_dr16', 'desi_edr']  \n",
     "__keywords__ = ['sparcl', 'spectroscopy', 'sdss spectra', 'desi spectra', 'tutorial', 'prospect', 'specutils']"
    ]
@@ -87,35 +79,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2023-08-16T17:27:39.951051Z",
-     "iopub.status.busy": "2023-08-16T17:27:39.950531Z",
-     "iopub.status.idle": "2023-08-16T17:27:58.267864Z",
-     "shell.execute_reply": "2023-08-16T17:27:58.266294Z",
-     "shell.execute_reply.started": "2023-08-16T17:27:39.951020Z"
-    }
+    "tags": []
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "astro-datalab==2.21.3\n",
-      "specutils==1.9.1\n",
-      "prospect==1.2.5\n",
-      "sparcl==1.2.0\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
+    "from numba import NumbaDeprecationWarning\n",
     "import warnings\n",
-    "warnings.filterwarnings(\"ignore\")\n",
+    "warnings.filterwarnings(\"ignore\", category=NumbaDeprecationWarning, message=r'.*numba\\.jit.*')\n",
     "import numpy as np\n",
     "import astropy.units as u\n",
     "from astropy.nddata import InverseVariance\n",
     "from specutils import __version__ as specutils_version, Spectrum1D\n",
+    "from bokeh import __version__ as bokeh_version\n",
     "from prospect import __version__ as prospect_version\n",
     "from prospect.viewer import plotspectra\n",
     "from prospect.specutils import Spectra\n",
@@ -124,6 +101,7 @@
     "from dl import __version__ as dl_version, queryClient as qc\n",
     "print(f\"astro-datalab=={dl_version}\")\n",
     "print(f\"specutils=={specutils_version}\")\n",
+    "print(f\"bokeh=={bokeh_version}\")\n",
     "print(f\"prospect=={prospect_version}\")\n",
     "print(f\"sparcl=={sparcl_version}\")"
    ]
@@ -137,28 +115,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2023-08-16T17:27:58.270959Z",
-     "iopub.status.busy": "2023-08-16T17:27:58.270283Z",
-     "iopub.status.idle": "2023-08-16T17:27:58.432520Z",
-     "shell.execute_reply": "2023-08-16T17:27:58.431255Z",
-     "shell.execute_reply.started": "2023-08-16T17:27:58.270914Z"
-    }
+    "tags": []
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "(sparclclient:1.2.0, api:9.0, https://astrosparcl.datalab.noirlab.edu/sparc, verbose=False, connect_timeout=1.1, read_timeout=5400.0)"
-      ]
-     },
-     "execution_count": 3,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "client = SparclClient()\n",
     "client"
@@ -175,28 +136,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2023-08-16T17:27:58.434679Z",
-     "iopub.status.busy": "2023-08-16T17:27:58.434215Z",
-     "iopub.status.idle": "2023-08-16T17:27:58.441581Z",
-     "shell.execute_reply": "2023-08-16T17:27:58.440456Z",
-     "shell.execute_reply.started": "2023-08-16T17:27:58.434632Z"
-    }
+    "tags": []
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "'default'"
-      ]
-     },
-     "execution_count": 4,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "qc.get_profile()"
    ]
@@ -220,80 +164,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2023-08-16T17:27:58.443486Z",
-     "iopub.status.busy": "2023-08-16T17:27:58.443059Z",
-     "iopub.status.idle": "2023-08-16T17:27:58.613737Z",
-     "shell.execute_reply": "2023-08-16T17:27:58.612566Z",
-     "shell.execute_reply.started": "2023-08-16T17:27:58.443437Z"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div><i>Table length=50</i>\n",
-       "<table id=\"table140011841076336\" class=\"table-striped table-bordered table-condensed\">\n",
-       "<thead><tr><th>targetid</th><th>chi2</th><th>z</th><th>zerr</th><th>zwarn</th><th>spectype</th><th>subtype</th><th>coadd_numexp</th><th>coadd_exptime</th><th>healpix</th><th>deltachi2</th></tr></thead>\n",
-       "<thead><tr><th>int64</th><th>float64</th><th>float64</th><th>float64</th><th>int64</th><th>str6</th><th>int64</th><th>int64</th><th>float64</th><th>int64</th><th>float64</th></tr></thead>\n",
-       "<tr><td>1018147809263616</td><td>7365.986792743206</td><td>0.5242944629168498</td><td>6.0633200133966495e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>1</td><td>733.9571</td><td>10517</td><td>71.94141682237387</td></tr>\n",
-       "<tr><td>1030495978651648</td><td>8103.990616310388</td><td>0.7552786543004375</td><td>0.00017749836792365145</td><td>0</td><td>GALAXY</td><td>--</td><td>1</td><td>1228.5404</td><td>25934</td><td>20.647511329501867</td></tr>\n",
-       "<tr><td>1030507408130048</td><td>7649.292701952159</td><td>0.6367214865921862</td><td>0.00010330595538305078</td><td>0</td><td>GALAXY</td><td>--</td><td>1</td><td>1521.4265</td><td>25599</td><td>133.98583871871233</td></tr>\n",
-       "<tr><td>1030526211194880</td><td>7539.091522403061</td><td>0.8053032876978878</td><td>0.00011301271093738162</td><td>0</td><td>GALAXY</td><td>--</td><td>1</td><td>979.7707</td><td>25945</td><td>156.96490418165922</td></tr>\n",
-       "<tr><td>1030538257235968</td><td>8134.653569459915</td><td>0.5719903498779939</td><td>3.223043052206872e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>2</td><td>1719.2445</td><td>25957</td><td>609.7288934141397</td></tr>\n",
-       "<tr><td>1030538257235969</td><td>7135.108882904053</td><td>0.5722036123057208</td><td>1.620413588830633e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>1</td><td>979.7707</td><td>25957</td><td>487.25401762500405</td></tr>\n",
-       "<tr><td>1030550353608705</td><td>7867.883817739785</td><td>0.7842247194907328</td><td>0.0001135860568130856</td><td>0</td><td>GALAXY</td><td>--</td><td>3</td><td>2420.4485</td><td>25968</td><td>37.140998892486095</td></tr>\n",
-       "<tr><td>1030568439447553</td><td>8961.871326968074</td><td>0.754500761465981</td><td>0.00010126469934510125</td><td>0</td><td>GALAXY</td><td>--</td><td>4</td><td>3522.769</td><td>25976</td><td>10.445683613419533</td></tr>\n",
-       "<tr><td>1030573330006017</td><td>8754.344732429832</td><td>0.5732047635328416</td><td>0.00012256537277712583</td><td>0</td><td>GALAXY</td><td>--</td><td>4</td><td>5545.4507</td><td>27247</td><td>310.3479618281126</td></tr>\n",
-       "<tr><td>1031504037675008</td><td>7480.231691986322</td><td>0.6514473439669506</td><td>6.622491253337035e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>1</td><td>941.1897</td><td>9929</td><td>256.8893585279584</td></tr>\n",
-       "<tr><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td></tr>\n",
-       "<tr><td>1084078698790912</td><td>8082.1450235862285</td><td>0.5538389287047147</td><td>0.0005284074865208822</td><td>0</td><td>GALAXY</td><td>--</td><td>2</td><td>2001.6584</td><td>10512</td><td>18.699554620310664</td></tr>\n",
-       "<tr><td>1084079202107393</td><td>7683.44479547441</td><td>0.8871215972756863</td><td>7.686933698533896e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>1</td><td>1039.5458</td><td>9342</td><td>17.911938205361366</td></tr>\n",
-       "<tr><td>1084083752927238</td><td>7599.528635233641</td><td>0.5019248697451463</td><td>4.989704264975716e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>1</td><td>1266.5073</td><td>9150</td><td>10.690924648195505</td></tr>\n",
-       "<tr><td>1084089213911042</td><td>7343.692225933075</td><td>0.6519883320942474</td><td>7.267464562064621e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>2</td><td>1538.5286</td><td>9425</td><td>9.654731012880802</td></tr>\n",
-       "<tr><td>1084094209327112</td><td>9197.105464577675</td><td>0.6807816884993237</td><td>2.589359578514029e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>2</td><td>2043.0839</td><td>9425</td><td>30.95276916027069</td></tr>\n",
-       "<tr><td>1084094213521414</td><td>7594.119990326464</td><td>0.5491421976493851</td><td>8.221539032230453e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>1</td><td>1039.5458</td><td>9425</td><td>12.318490572273731</td></tr>\n",
-       "<tr><td>1084099200548870</td><td>7922.7978156507015</td><td>0.5420632178811425</td><td>5.248537797530134e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>2</td><td>2043.0839</td><td>9428</td><td>15.281807787716389</td></tr>\n",
-       "<tr><td>1084104162410503</td><td>7799.4767319485545</td><td>0.5129965664056207</td><td>6.47509440134427e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>1</td><td>719.255</td><td>9428</td><td>9.173644490540028</td></tr>\n",
-       "<tr><td>1084104162410508</td><td>7731.811375722289</td><td>0.6724520231637495</td><td>5.926636400790151e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>1</td><td>1039.5458</td><td>9428</td><td>15.01417849957943</td></tr>\n",
-       "<tr><td>1084104174993420</td><td>17191.26975917816</td><td>0.7053922442542426</td><td>1.0702979036256088e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>2</td><td>1893.018</td><td>9343</td><td>31.31516170501709</td></tr>\n",
-       "</table></div>"
-      ],
-      "text/plain": [
-       "<Table length=50>\n",
-       "    targetid            chi2        ... healpix     deltachi2     \n",
-       "     int64            float64       ...  int64       float64      \n",
-       "---------------- ------------------ ... ------- ------------------\n",
-       "1018147809263616  7365.986792743206 ...   10517  71.94141682237387\n",
-       "1030495978651648  8103.990616310388 ...   25934 20.647511329501867\n",
-       "1030507408130048  7649.292701952159 ...   25599 133.98583871871233\n",
-       "1030526211194880  7539.091522403061 ...   25945 156.96490418165922\n",
-       "1030538257235968  8134.653569459915 ...   25957  609.7288934141397\n",
-       "1030538257235969  7135.108882904053 ...   25957 487.25401762500405\n",
-       "1030550353608705  7867.883817739785 ...   25968 37.140998892486095\n",
-       "1030568439447553  8961.871326968074 ...   25976 10.445683613419533\n",
-       "1030573330006017  8754.344732429832 ...   27247  310.3479618281126\n",
-       "1031504037675008  7480.231691986322 ...    9929  256.8893585279584\n",
-       "             ...                ... ...     ...                ...\n",
-       "1084078698790912 8082.1450235862285 ...   10512 18.699554620310664\n",
-       "1084079202107393   7683.44479547441 ...    9342 17.911938205361366\n",
-       "1084083752927238  7599.528635233641 ...    9150 10.690924648195505\n",
-       "1084089213911042  7343.692225933075 ...    9425  9.654731012880802\n",
-       "1084094209327112  9197.105464577675 ...    9425  30.95276916027069\n",
-       "1084094213521414  7594.119990326464 ...    9425 12.318490572273731\n",
-       "1084099200548870 7922.7978156507015 ...    9428 15.281807787716389\n",
-       "1084104162410503 7799.4767319485545 ...    9428  9.173644490540028\n",
-       "1084104162410508  7731.811375722289 ...    9428  15.01417849957943\n",
-       "1084104174993420  17191.26975917816 ...    9343  31.31516170501709"
-      ]
-     },
-     "execution_count": 5,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "q = \"\"\"\n",
     "SELECT z.targetid, z.chi2, z.z, z.zerr, z.zwarn, z.spectype, z.subtype,\n",
@@ -321,16 +194,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2023-08-16T17:27:58.615698Z",
-     "iopub.status.busy": "2023-08-16T17:27:58.615266Z",
-     "iopub.status.idle": "2023-08-16T17:27:58.621617Z",
-     "shell.execute_reply": "2023-08-16T17:27:58.620367Z",
-     "shell.execute_reply.started": "2023-08-16T17:27:58.615653Z"
-    }
-   },
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": [
     "assert (np.unique(desi_ids['targetid']) == desi_ids['targetid']).all()"
@@ -347,31 +212,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2023-08-16T17:27:58.623406Z",
-     "iopub.status.busy": "2023-08-16T17:27:58.623014Z",
-     "iopub.status.idle": "2023-08-16T17:28:00.900052Z",
-     "shell.execute_reply": "2023-08-16T17:28:00.896426Z",
-     "shell.execute_reply.started": "2023-08-16T17:27:58.623366Z"
-    },
     "tags": []
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'status': {'success': True,\n",
-       "  'info': [\"Successfully found 50 records in dr_list=['DESI-EDR']\"],\n",
-       "  'warnings': []}}"
-      ]
-     },
-     "execution_count": 7,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "include = client.get_all_fields(dataset_list=['DESI-EDR'])\n",
     "desi_spectra = client.retrieve_by_specid(specid_list=desi_ids['targetid'].value.tolist(),\n",
@@ -389,16 +234,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2023-08-16T17:28:00.905077Z",
-     "iopub.status.busy": "2023-08-16T17:28:00.904714Z",
-     "iopub.status.idle": "2023-08-16T17:28:00.911833Z",
-     "shell.execute_reply": "2023-08-16T17:28:00.910762Z",
-     "shell.execute_reply.started": "2023-08-16T17:28:00.905020Z"
-    }
-   },
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": [
     "targetids_sorted = sorted(desi_spectra.records, key=lambda x: x.targetid)\n",
@@ -416,19 +253,33 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2023-08-16T17:28:00.913718Z",
-     "iopub.status.busy": "2023-08-16T17:28:00.913499Z",
-     "iopub.status.idle": "2023-08-16T17:28:00.935154Z",
-     "shell.execute_reply": "2023-08-16T17:28:00.934117Z",
-     "shell.execute_reply.started": "2023-08-16T17:28:00.913697Z"
-    }
-   },
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": [
     "assert all([(r.wavelength == desi_spectra.records[0].wavelength).all() for r in desi_spectra.records])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**QA**: Are any of the spectra fully masked?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "for k in range(len(desi_spectra.records)):\n",
+    "    assert np.isfinite(desi_spectra.records[k].flux).all()\n",
+    "    assert np.isfinite(desi_spectra.records[k].ivar).all()\n",
+    "    if (desi_spectra.records[k].mask > 0).all():\n",
+    "        print(f\"WARNING: Spectrum record {k:d} is fully masked!\")"
    ]
   },
   {
@@ -440,135 +291,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2023-08-16T17:28:00.936361Z",
-     "iopub.status.busy": "2023-08-16T17:28:00.936148Z",
-     "iopub.status.idle": "2023-08-16T17:28:00.952166Z",
-     "shell.execute_reply": "2023-08-16T17:28:00.951387Z",
-     "shell.execute_reply.started": "2023-08-16T17:28:00.936339Z"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'specid': 1084094209327112,\n",
-       " 'datasetgroup': 'DESI',\n",
-       " 'redshift_err': 2.58935957851403e-05,\n",
-       " 'telescope': 'kp4m',\n",
-       " 'spectype': 'GALAXY',\n",
-       " 'instrument': 'DESI',\n",
-       " 'targetid': 1084094209327112,\n",
-       " 'wavemax': 9800.0,\n",
-       " 'redshift_warning': 0,\n",
-       " 'dec': 34.4909674837506,\n",
-       " 'ra': 251.046383671818,\n",
-       " 'specprimary': True,\n",
-       " 'exptime': 2043.08386230469,\n",
-       " 'site': 'kpno',\n",
-       " 'redshift': 0.680781688499324,\n",
-       " 'data_release': 'DESI-EDR',\n",
-       " 'wavemin': 3600.0,\n",
-       " 'std_fiber_ra': 0.0,\n",
-       " 'pmra': 0.0,\n",
-       " 'sv3_desi_target': 4611686018427387904,\n",
-       " 'sv3_mws_target': 0,\n",
-       " 'healpix': 9425,\n",
-       " 'fa_type': 1,\n",
-       " 'npixels': 7925,\n",
-       " 'rms_delta_x': 0.004000000189989805,\n",
-       " 'program': 'dark',\n",
-       " 'tsnr2_elg': 169.35247802734375,\n",
-       " 'pmdec': 0.0,\n",
-       " 'deltachi2': 30.95276916027069,\n",
-       " 'priority_init': 1700,\n",
-       " 'target_ra': None,\n",
-       " 'zcat_nspec': 1,\n",
-       " 'cmx_target': 0,\n",
-       " 'sv1_desi_target': 0,\n",
-       " 'mean_mjd': 59325.4455512,\n",
-       " 'objtype': 'TGT',\n",
-       " 'coadd_fiberstatus': 0,\n",
-       " 'sv2_scnd_target': 0,\n",
-       " 'sv_primary': True,\n",
-       " 'plate_dec': 34.49096748375056,\n",
-       " 'plate_ra': 251.046383671818,\n",
-       " 'rms_delta_y': 0.004999999888241291,\n",
-       " 'sv2_mws_target': 0,\n",
-       " 'sv1_mws_target': 0,\n",
-       " 'coadd_numnight': 1,\n",
-       " 'sv3_bgs_target': 0,\n",
-       " 'chi2': 9197.105464577675,\n",
-       " 'sv2_bgs_target': 0,\n",
-       " 'subtype': '',\n",
-       " 'survey': 'sv3',\n",
-       " 'sv3_scnd_target': 70368744177664,\n",
-       " 'target_dec': None,\n",
-       " 'coeff': [-25.51869871906527,\n",
-       "  53.140944787638894,\n",
-       "  -29.807739589998427,\n",
-       "  33.65364472688803,\n",
-       "  3.8906922759272136,\n",
-       "  -5.233573046246487,\n",
-       "  -10.112239147902963,\n",
-       "  -2.0839650322750187,\n",
-       "  5.412344258789117,\n",
-       "  -5.17894099275291],\n",
-       " 'mean_delta_y': 0.004999999888241291,\n",
-       " 'bgs_target': 0,\n",
-       " 'lastnight': 20210420,\n",
-       " 'desi_target': 0,\n",
-       " 'sv_nspec': 1,\n",
-       " 'coadd_numtile': 1,\n",
-       " 'tsnr2_bgs': 9716.763671875,\n",
-       " 'numobs_init': 5,\n",
-       " 'sv2_desi_target': 0,\n",
-       " 'tsnr2_lya': 128.94442749023438,\n",
-       " 'sv1_scnd_target': 0,\n",
-       " 'tsnr2_qso': 42.80076599121094,\n",
-       " 'std_fiber_dec': 0.0,\n",
-       " 'mean_fiber_dec': 34.49094744813409,\n",
-       " 'tsnr2_gpbdark': 14932.283203125,\n",
-       " 'tsnr2_gpbbackup': 17583.5859375,\n",
-       " 'scnd_target': 0,\n",
-       " 'mean_fiber_ra': 251.0464028870182,\n",
-       " 'sv1_bgs_target': 0,\n",
-       " 'fa_target': 4611686018427387904,\n",
-       " 'tsnr2_gpbbright': 2693.44287109375,\n",
-       " 'tsnr2_lrg': 109.68939971923828,\n",
-       " 'coadd_numexp': 2,\n",
-       " 'subpriority': 0.621237875361596,\n",
-       " 'obsconditions': 63,\n",
-       " 'mean_delta_x': 0.004000000189989805,\n",
-       " 'mws_target': 0,\n",
-       " 'firstnight': 20210420,\n",
-       " 'ref_epoch': 2015.5,\n",
-       " 'spgrpval': 9425,\n",
-       " 'ncoeff': 10,\n",
-       " 'mean_psf_to_fiber_specflux': 0.7919076085090637,\n",
-       " 'wave_sigma': array([0.65058374, 0.6509847 , 0.6523146 , ..., 0.81115586, 0.81793427,\n",
-       "        0.83779615]),\n",
-       " 'ivar': array([ 0.05370376,  0.0903969 ,  0.07890871, ..., 16.917099  ,\n",
-       "        23.1467514 , 26.40428162]),\n",
-       " 'mask': array([0, 0, 0, ..., 0, 0, 0]),\n",
-       " 'model': array([-0.13465281, -0.17642727, -0.1826259 , ...,  0.05010873,\n",
-       "         0.04731604,  0.03256743]),\n",
-       " 'wavelength': array([3600. , 3600.8, 3601.6, ..., 9822.4, 9823.2, 9824. ]),\n",
-       " 'flux': array([-2.30227423, -1.29785132, -1.67398036, ...,  0.35962611,\n",
-       "        -0.07549828,  0.22138898]),\n",
-       " 'dateobs': '[\"2021-04-21 10:30:22.076928+00\",\"2021-04-21 10:52:49.170432+00\"]',\n",
-       " 'dateobs_center': '2021-04-21 10:41:35.62368+00',\n",
-       " 'sparcl_id': '0bbeae4d-1dc3-4e73-b602-6bf40ae6aec3',\n",
-       " '_dr': 'DESI-EDR'}"
-      ]
-     },
-     "execution_count": 10,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "desi_spectra.records[0]"
    ]
@@ -594,16 +319,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2023-08-16T17:28:00.953329Z",
-     "iopub.status.busy": "2023-08-16T17:28:00.953119Z",
-     "iopub.status.idle": "2023-08-16T17:28:00.984773Z",
-     "shell.execute_reply": "2023-08-16T17:28:00.983744Z",
-     "shell.execute_reply.started": "2023-08-16T17:28:00.953307Z"
-    }
-   },
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": [
     "flux = np.zeros((len(desi_spectra.records), desi_spectra.records[0].flux.shape[0]),\n",
@@ -634,16 +351,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2023-08-16T17:28:00.986058Z",
-     "iopub.status.busy": "2023-08-16T17:28:00.985820Z",
-     "iopub.status.idle": "2023-08-16T17:28:01.150335Z",
-     "shell.execute_reply": "2023-08-16T17:28:01.148825Z",
-     "shell.execute_reply.started": "2023-08-16T17:28:00.986035Z"
-    }
-   },
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": [
     "columns = ('targetid', 'ra', 'dec', 'ref_epoch', 'pmra', 'pmdec', 'ebv',\n",
@@ -660,16 +369,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2023-08-16T17:28:01.152631Z",
-     "iopub.status.busy": "2023-08-16T17:28:01.152153Z",
-     "iopub.status.idle": "2023-08-16T17:28:01.160213Z",
-     "shell.execute_reply": "2023-08-16T17:28:01.158899Z",
-     "shell.execute_reply.started": "2023-08-16T17:28:01.152571Z"
-    }
-   },
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": [
     "for col in fibermap.colnames:\n",
@@ -688,16 +389,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2023-08-16T17:28:01.162236Z",
-     "iopub.status.busy": "2023-08-16T17:28:01.161779Z",
-     "iopub.status.idle": "2023-08-16T17:28:01.180902Z",
-     "shell.execute_reply": "2023-08-16T17:28:01.179572Z",
-     "shell.execute_reply.started": "2023-08-16T17:28:01.162189Z"
-    }
-   },
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": [
     "assert (fibermap['TARGETID'] == desi_ids['targetid']).all()"
@@ -712,16 +405,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2023-08-16T17:28:01.182821Z",
-     "iopub.status.busy": "2023-08-16T17:28:01.182386Z",
-     "iopub.status.idle": "2023-08-16T17:28:01.415461Z",
-     "shell.execute_reply": "2023-08-16T17:28:01.413936Z",
-     "shell.execute_reply.started": "2023-08-16T17:28:01.182776Z"
-    }
-   },
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": [
     "columns = ('targetid', 'sv3_desi_target', 'sv3_bgs_target', 'sv3_mws_target', 'sv3_scnd_target')\n",
@@ -737,16 +422,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2023-08-16T17:28:01.417728Z",
-     "iopub.status.busy": "2023-08-16T17:28:01.417252Z",
-     "iopub.status.idle": "2023-08-16T17:28:01.423588Z",
-     "shell.execute_reply": "2023-08-16T17:28:01.422315Z",
-     "shell.execute_reply.started": "2023-08-16T17:28:01.417679Z"
-    }
-   },
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": [
     "for col in targeting.colnames:\n",
@@ -762,16 +439,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2023-08-16T17:28:01.425593Z",
-     "iopub.status.busy": "2023-08-16T17:28:01.425142Z",
-     "iopub.status.idle": "2023-08-16T17:28:01.442083Z",
-     "shell.execute_reply": "2023-08-16T17:28:01.440872Z",
-     "shell.execute_reply.started": "2023-08-16T17:28:01.425547Z"
-    }
-   },
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": [
     "assert (targeting['TARGETID'] == fibermap['TARGETID']).all()"
@@ -786,80 +455,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2023-08-16T17:28:01.443957Z",
-     "iopub.status.busy": "2023-08-16T17:28:01.443520Z",
-     "iopub.status.idle": "2023-08-16T17:28:01.469799Z",
-     "shell.execute_reply": "2023-08-16T17:28:01.468811Z",
-     "shell.execute_reply.started": "2023-08-16T17:28:01.443914Z"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div><i>Table length=50</i>\n",
-       "<table id=\"table140011840986800\" class=\"table-striped table-bordered table-condensed\">\n",
-       "<thead><tr><th>TARGETID</th><th>TARGET_RA</th><th>TARGET_DEC</th><th>REF_EPOCH</th><th>PMRA</th><th>PMDEC</th><th>EBV</th><th>FLUX_G</th><th>FLUX_R</th><th>FLUX_Z</th><th>FLUX_W1</th><th>FLUX_W2</th><th>SV3_DESI_TARGET</th><th>SV3_BGS_TARGET</th><th>SV3_MWS_TARGET</th><th>SV3_SCND_TARGET</th></tr></thead>\n",
-       "<thead><tr><th>int64</th><th>float64</th><th>float64</th><th>float64</th><th>int64</th><th>int64</th><th>float64</th><th>float64</th><th>float64</th><th>float64</th><th>float64</th><th>float64</th><th>int64</th><th>int64</th><th>int64</th><th>int64</th></tr></thead>\n",
-       "<tr><td>1018147809263616</td><td>218.15530210149535</td><td>35.769959220507396</td><td>0.0</td><td>0</td><td>0</td><td>0.011083154</td><td>0.48597622</td><td>1.2058442</td><td>1.5106901</td><td>2.482841</td><td>1.3636942</td><td>4611686018427387904</td><td>0</td><td>0</td><td>2147483648</td></tr>\n",
-       "<tr><td>1030495978651648</td><td>218.82868695999053</td><td>-1.4239743152821387</td><td>0.0</td><td>0</td><td>0</td><td>0.040679332</td><td>0.6364655</td><td>1.2522537</td><td>4.010964</td><td>13.028034</td><td>7.1272125</td><td>4611686018427387904</td><td>0</td><td>0</td><td>17179869184</td></tr>\n",
-       "<tr><td>1030507408130048</td><td>180.1889661147553</td><td>-0.9613644465384479</td><td>0.0</td><td>0</td><td>0</td><td>0.024523733</td><td>0.48548192</td><td>1.483542</td><td>4.9795527</td><td>15.609289</td><td>7.899148</td><td>4611686018427387904</td><td>0</td><td>0</td><td>17179869184</td></tr>\n",
-       "<tr><td>1030526211194880</td><td>220.97916752669602</td><td>-0.12526168095554563</td><td>0.0</td><td>0</td><td>0</td><td>0.03961234</td><td>2.365766</td><td>4.175312</td><td>9.775242</td><td>57.561703</td><td>120.945496</td><td>4611686018427387904</td><td>0</td><td>0</td><td>17179869184</td></tr>\n",
-       "<tr><td>1030538257235968</td><td>218.87134476858458</td><td>0.3034533715013907</td><td>0.0</td><td>0</td><td>0</td><td>0.038472127</td><td>1.699776</td><td>4.9637136</td><td>11.5170145</td><td>23.5799</td><td>13.483782</td><td>4611686018427387904</td><td>0</td><td>0</td><td>17179869184</td></tr>\n",
-       "<tr><td>1030538257235969</td><td>218.8711</td><td>0.3036</td><td>2015.5</td><td>0</td><td>0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>4611686018427387904</td><td>0</td><td>0</td><td>17179869184</td></tr>\n",
-       "<tr><td>1030550353608705</td><td>219.75550234102283</td><td>0.8547659846230762</td><td>0.0</td><td>0</td><td>0</td><td>0.04603932</td><td>0.748148</td><td>1.0393113</td><td>2.4640872</td><td>7.8900027</td><td>14.943021</td><td>4611686018427387904</td><td>0</td><td>0</td><td>17179869184</td></tr>\n",
-       "<tr><td>1030568439447553</td><td>217.962</td><td>1.5059</td><td>2015.5</td><td>0</td><td>0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>4611686018427387904</td><td>0</td><td>0</td><td>17179869184</td></tr>\n",
-       "<tr><td>1030573330006017</td><td>149.459078510057</td><td>1.7517805116389942</td><td>0.0</td><td>0</td><td>0</td><td>0.021018779</td><td>0.29732797</td><td>0.36820117</td><td>0.07077911</td><td>0.44191432</td><td>5.732679</td><td>4611686018427387904</td><td>0</td><td>0</td><td>17179869184</td></tr>\n",
-       "<tr><td>1031504037675008</td><td>236.22257223003703</td><td>44.46367776807275</td><td>0.0</td><td>0</td><td>0</td><td>0.017812433</td><td>0.9394297</td><td>2.6696484</td><td>8.393229</td><td>24.123352</td><td>15.881443</td><td>4611686018427387904</td><td>0</td><td>0</td><td>17179869184</td></tr>\n",
-       "<tr><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td></tr>\n",
-       "<tr><td>1084078698790912</td><td>216.3758661941111</td><td>33.86380538698533</td><td>2015.5</td><td>0</td><td>0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>4611686018427387904</td><td>0</td><td>0</td><td>70368744177664</td></tr>\n",
-       "<tr><td>1084079202107393</td><td>252.48958065997311</td><td>33.71384019990504</td><td>2015.5</td><td>0</td><td>0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>4611686018427387904</td><td>0</td><td>0</td><td>70368744177664</td></tr>\n",
-       "<tr><td>1084083752927238</td><td>218.55653821513727</td><td>34.013552434290446</td><td>2015.5</td><td>0</td><td>0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>4611686018427387904</td><td>0</td><td>0</td><td>70368744177664</td></tr>\n",
-       "<tr><td>1084089213911042</td><td>251.04852052764727</td><td>34.175781013868544</td><td>2015.5</td><td>0</td><td>0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>4611686018427387904</td><td>0</td><td>0</td><td>70368744177664</td></tr>\n",
-       "<tr><td>1084094209327112</td><td>251.046383671818</td><td>34.49096748375056</td><td>2015.5</td><td>0</td><td>0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>4611686018427387904</td><td>0</td><td>0</td><td>70368744177664</td></tr>\n",
-       "<tr><td>1084094213521414</td><td>251.13129732325746</td><td>34.47655381083552</td><td>2015.5</td><td>0</td><td>0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>4611686018427387904</td><td>0</td><td>0</td><td>70368744177664</td></tr>\n",
-       "<tr><td>1084099200548870</td><td>251.92148148981218</td><td>34.66294674127848</td><td>2015.5</td><td>0</td><td>0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>4611686018427387904</td><td>0</td><td>0</td><td>70368744177664</td></tr>\n",
-       "<tr><td>1084104162410503</td><td>251.85737208059027</td><td>34.8870362692651</td><td>2015.5</td><td>0</td><td>0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>4611686018427387904</td><td>0</td><td>0</td><td>70368744177664</td></tr>\n",
-       "<tr><td>1084104162410508</td><td>251.86491325762373</td><td>34.8836792111499</td><td>2015.5</td><td>0</td><td>0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>4611686018427387904</td><td>0</td><td>0</td><td>70368744177664</td></tr>\n",
-       "<tr><td>1084104174993420</td><td>252.62041501561</td><td>35.06214822458531</td><td>2015.5</td><td>0</td><td>0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>4611686018427387904</td><td>0</td><td>0</td><td>70368744177664</td></tr>\n",
-       "</table></div>"
-      ],
-      "text/plain": [
-       "<Table length=50>\n",
-       "    TARGETID         TARGET_RA      ... SV3_MWS_TARGET SV3_SCND_TARGET\n",
-       "     int64            float64       ...     int64           int64     \n",
-       "---------------- ------------------ ... -------------- ---------------\n",
-       "1018147809263616 218.15530210149535 ...              0      2147483648\n",
-       "1030495978651648 218.82868695999053 ...              0     17179869184\n",
-       "1030507408130048  180.1889661147553 ...              0     17179869184\n",
-       "1030526211194880 220.97916752669602 ...              0     17179869184\n",
-       "1030538257235968 218.87134476858458 ...              0     17179869184\n",
-       "1030538257235969           218.8711 ...              0     17179869184\n",
-       "1030550353608705 219.75550234102283 ...              0     17179869184\n",
-       "1030568439447553            217.962 ...              0     17179869184\n",
-       "1030573330006017   149.459078510057 ...              0     17179869184\n",
-       "1031504037675008 236.22257223003703 ...              0     17179869184\n",
-       "             ...                ... ...            ...             ...\n",
-       "1084078698790912  216.3758661941111 ...              0  70368744177664\n",
-       "1084079202107393 252.48958065997311 ...              0  70368744177664\n",
-       "1084083752927238 218.55653821513727 ...              0  70368744177664\n",
-       "1084089213911042 251.04852052764727 ...              0  70368744177664\n",
-       "1084094209327112   251.046383671818 ...              0  70368744177664\n",
-       "1084094213521414 251.13129732325746 ...              0  70368744177664\n",
-       "1084099200548870 251.92148148981218 ...              0  70368744177664\n",
-       "1084104162410503 251.85737208059027 ...              0  70368744177664\n",
-       "1084104162410508 251.86491325762373 ...              0  70368744177664\n",
-       "1084104174993420    252.62041501561 ...              0  70368744177664"
-      ]
-     },
-     "execution_count": 18,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "for col in ('SV3_DESI_TARGET', 'SV3_BGS_TARGET', 'SV3_MWS_TARGET', 'SV3_SCND_TARGET'):\n",
     "    fibermap.add_column(targeting[col])\n",
@@ -875,16 +473,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2023-08-16T17:28:01.471464Z",
-     "iopub.status.busy": "2023-08-16T17:28:01.471087Z",
-     "iopub.status.idle": "2023-08-16T17:28:01.505774Z",
-     "shell.execute_reply": "2023-08-16T17:28:01.504476Z",
-     "shell.execute_reply.started": "2023-08-16T17:28:01.471425Z"
-    }
-   },
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": [
     "desi_prospect = Spectra(bands=['coadd'],\n",
@@ -907,80 +497,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2023-08-16T17:28:01.507318Z",
-     "iopub.status.busy": "2023-08-16T17:28:01.506992Z",
-     "iopub.status.idle": "2023-08-16T17:28:01.521799Z",
-     "shell.execute_reply": "2023-08-16T17:28:01.520954Z",
-     "shell.execute_reply.started": "2023-08-16T17:28:01.507283Z"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div><i>Table length=50</i>\n",
-       "<table id=\"table140010889074768\" class=\"table-striped table-bordered table-condensed\">\n",
-       "<thead><tr><th>TARGETID</th><th>CHI2</th><th>Z</th><th>ZERR</th><th>ZWARN</th><th>SPECTYPE</th><th>SUBTYPE</th><th>COADD_NUMEXP</th><th>COADD_EXPTIME</th><th>HPXPIXEL</th><th>DELTACHI2</th></tr></thead>\n",
-       "<thead><tr><th>int64</th><th>float64</th><th>float64</th><th>float64</th><th>int64</th><th>str6</th><th>int64</th><th>int64</th><th>float64</th><th>int64</th><th>float64</th></tr></thead>\n",
-       "<tr><td>1018147809263616</td><td>7365.986792743206</td><td>0.5242944629168498</td><td>6.0633200133966495e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>1</td><td>733.9571</td><td>10517</td><td>71.94141682237387</td></tr>\n",
-       "<tr><td>1030495978651648</td><td>8103.990616310388</td><td>0.7552786543004375</td><td>0.00017749836792365145</td><td>0</td><td>GALAXY</td><td>--</td><td>1</td><td>1228.5404</td><td>25934</td><td>20.647511329501867</td></tr>\n",
-       "<tr><td>1030507408130048</td><td>7649.292701952159</td><td>0.6367214865921862</td><td>0.00010330595538305078</td><td>0</td><td>GALAXY</td><td>--</td><td>1</td><td>1521.4265</td><td>25599</td><td>133.98583871871233</td></tr>\n",
-       "<tr><td>1030526211194880</td><td>7539.091522403061</td><td>0.8053032876978878</td><td>0.00011301271093738162</td><td>0</td><td>GALAXY</td><td>--</td><td>1</td><td>979.7707</td><td>25945</td><td>156.96490418165922</td></tr>\n",
-       "<tr><td>1030538257235968</td><td>8134.653569459915</td><td>0.5719903498779939</td><td>3.223043052206872e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>2</td><td>1719.2445</td><td>25957</td><td>609.7288934141397</td></tr>\n",
-       "<tr><td>1030538257235969</td><td>7135.108882904053</td><td>0.5722036123057208</td><td>1.620413588830633e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>1</td><td>979.7707</td><td>25957</td><td>487.25401762500405</td></tr>\n",
-       "<tr><td>1030550353608705</td><td>7867.883817739785</td><td>0.7842247194907328</td><td>0.0001135860568130856</td><td>0</td><td>GALAXY</td><td>--</td><td>3</td><td>2420.4485</td><td>25968</td><td>37.140998892486095</td></tr>\n",
-       "<tr><td>1030568439447553</td><td>8961.871326968074</td><td>0.754500761465981</td><td>0.00010126469934510125</td><td>0</td><td>GALAXY</td><td>--</td><td>4</td><td>3522.769</td><td>25976</td><td>10.445683613419533</td></tr>\n",
-       "<tr><td>1030573330006017</td><td>8754.344732429832</td><td>0.5732047635328416</td><td>0.00012256537277712583</td><td>0</td><td>GALAXY</td><td>--</td><td>4</td><td>5545.4507</td><td>27247</td><td>310.3479618281126</td></tr>\n",
-       "<tr><td>1031504037675008</td><td>7480.231691986322</td><td>0.6514473439669506</td><td>6.622491253337035e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>1</td><td>941.1897</td><td>9929</td><td>256.8893585279584</td></tr>\n",
-       "<tr><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td></tr>\n",
-       "<tr><td>1084078698790912</td><td>8082.1450235862285</td><td>0.5538389287047147</td><td>0.0005284074865208822</td><td>0</td><td>GALAXY</td><td>--</td><td>2</td><td>2001.6584</td><td>10512</td><td>18.699554620310664</td></tr>\n",
-       "<tr><td>1084079202107393</td><td>7683.44479547441</td><td>0.8871215972756863</td><td>7.686933698533896e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>1</td><td>1039.5458</td><td>9342</td><td>17.911938205361366</td></tr>\n",
-       "<tr><td>1084083752927238</td><td>7599.528635233641</td><td>0.5019248697451463</td><td>4.989704264975716e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>1</td><td>1266.5073</td><td>9150</td><td>10.690924648195505</td></tr>\n",
-       "<tr><td>1084089213911042</td><td>7343.692225933075</td><td>0.6519883320942474</td><td>7.267464562064621e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>2</td><td>1538.5286</td><td>9425</td><td>9.654731012880802</td></tr>\n",
-       "<tr><td>1084094209327112</td><td>9197.105464577675</td><td>0.6807816884993237</td><td>2.589359578514029e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>2</td><td>2043.0839</td><td>9425</td><td>30.95276916027069</td></tr>\n",
-       "<tr><td>1084094213521414</td><td>7594.119990326464</td><td>0.5491421976493851</td><td>8.221539032230453e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>1</td><td>1039.5458</td><td>9425</td><td>12.318490572273731</td></tr>\n",
-       "<tr><td>1084099200548870</td><td>7922.7978156507015</td><td>0.5420632178811425</td><td>5.248537797530134e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>2</td><td>2043.0839</td><td>9428</td><td>15.281807787716389</td></tr>\n",
-       "<tr><td>1084104162410503</td><td>7799.4767319485545</td><td>0.5129965664056207</td><td>6.47509440134427e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>1</td><td>719.255</td><td>9428</td><td>9.173644490540028</td></tr>\n",
-       "<tr><td>1084104162410508</td><td>7731.811375722289</td><td>0.6724520231637495</td><td>5.926636400790151e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>1</td><td>1039.5458</td><td>9428</td><td>15.01417849957943</td></tr>\n",
-       "<tr><td>1084104174993420</td><td>17191.26975917816</td><td>0.7053922442542426</td><td>1.0702979036256088e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>2</td><td>1893.018</td><td>9343</td><td>31.31516170501709</td></tr>\n",
-       "</table></div>"
-      ],
-      "text/plain": [
-       "<Table length=50>\n",
-       "    TARGETID            CHI2        ... HPXPIXEL     DELTACHI2     \n",
-       "     int64            float64       ...  int64        float64      \n",
-       "---------------- ------------------ ... -------- ------------------\n",
-       "1018147809263616  7365.986792743206 ...    10517  71.94141682237387\n",
-       "1030495978651648  8103.990616310388 ...    25934 20.647511329501867\n",
-       "1030507408130048  7649.292701952159 ...    25599 133.98583871871233\n",
-       "1030526211194880  7539.091522403061 ...    25945 156.96490418165922\n",
-       "1030538257235968  8134.653569459915 ...    25957  609.7288934141397\n",
-       "1030538257235969  7135.108882904053 ...    25957 487.25401762500405\n",
-       "1030550353608705  7867.883817739785 ...    25968 37.140998892486095\n",
-       "1030568439447553  8961.871326968074 ...    25976 10.445683613419533\n",
-       "1030573330006017  8754.344732429832 ...    27247  310.3479618281126\n",
-       "1031504037675008  7480.231691986322 ...     9929  256.8893585279584\n",
-       "             ...                ... ...      ...                ...\n",
-       "1084078698790912 8082.1450235862285 ...    10512 18.699554620310664\n",
-       "1084079202107393   7683.44479547441 ...     9342 17.911938205361366\n",
-       "1084083752927238  7599.528635233641 ...     9150 10.690924648195505\n",
-       "1084089213911042  7343.692225933075 ...     9425  9.654731012880802\n",
-       "1084094209327112  9197.105464577675 ...     9425  30.95276916027069\n",
-       "1084094213521414  7594.119990326464 ...     9425 12.318490572273731\n",
-       "1084099200548870 7922.7978156507015 ...     9428 15.281807787716389\n",
-       "1084104162410503 7799.4767319485545 ...     9428  9.173644490540028\n",
-       "1084104162410508  7731.811375722289 ...     9428  15.01417849957943\n",
-       "1084104174993420  17191.26975917816 ...     9343  31.31516170501709"
-      ]
-     },
-     "execution_count": 20,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "desi_zcatalog = desi_ids.copy()\n",
     "for col in desi_zcatalog.colnames:\n",
@@ -1002,16 +521,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2023-08-16T17:28:01.523140Z",
-     "iopub.status.busy": "2023-08-16T17:28:01.522847Z",
-     "iopub.status.idle": "2023-08-16T17:28:01.547115Z",
-     "shell.execute_reply": "2023-08-16T17:28:01.546193Z",
-     "shell.execute_reply.started": "2023-08-16T17:28:01.523109Z"
-    }
-   },
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": [
     "model_flux = np.zeros((len(desi_spectra.records), desi_spectra.records[0].model.shape[0]),\n",
@@ -1067,80 +578,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": null,
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2023-08-16T17:28:02.998757Z",
-     "iopub.status.busy": "2023-08-16T17:28:02.998463Z",
-     "iopub.status.idle": "2023-08-16T17:28:03.141189Z",
-     "shell.execute_reply": "2023-08-16T17:28:03.140036Z",
-     "shell.execute_reply.started": "2023-08-16T17:28:02.998729Z"
-    }
+    "tags": []
    },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div><i>Table length=50</i>\n",
-       "<table id=\"table140010886114656\" class=\"table-striped table-bordered table-condensed\">\n",
-       "<thead><tr><th>specobjid</th><th>bestobjid</th><th>z</th><th>zerr</th><th>zwarning</th><th>class</th><th>subclass</th><th>rchi2diff</th><th>primtarget</th><th>sectarget</th></tr></thead>\n",
-       "<thead><tr><th>int64</th><th>int64</th><th>float64</th><th>float64</th><th>int64</th><th>str6</th><th>str11</th><th>float64</th><th>int64</th><th>int64</th></tr></thead>\n",
-       "<tr><td>3327035125891360768</td><td>1237655468065620461</td><td>0.26219922</td><td>6.426468e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>0.16153336</td><td>96</td><td>0</td></tr>\n",
-       "<tr><td>3327036500280895488</td><td>1237655468065489538</td><td>0.21097003</td><td>5.7919853e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>0.13921309</td><td>64</td><td>0</td></tr>\n",
-       "<tr><td>3327038424426244096</td><td>1237655468065620456</td><td>0.2605426</td><td>6.229882e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>0.22558784</td><td>32</td><td>0</td></tr>\n",
-       "<tr><td>3327038974182057984</td><td>1237655468065620382</td><td>0.11276812</td><td>1.5994665e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>0.510905</td><td>64</td><td>0</td></tr>\n",
-       "<tr><td>3327040073693685760</td><td>1237651736318574966</td><td>0.06364931</td><td>2.8312488e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>0.42436635</td><td>64</td><td>0</td></tr>\n",
-       "<tr><td>3327040348571592704</td><td>1237651736318640378</td><td>0.20836118</td><td>4.189276e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>1.1794078</td><td>96</td><td>0</td></tr>\n",
-       "<tr><td>3327040898327406592</td><td>1237655468602491146</td><td>0.20784536</td><td>4.1236628e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>0.61972916</td><td>64</td><td>0</td></tr>\n",
-       "<tr><td>3327041722961127424</td><td>1237651736318575080</td><td>0.1408417</td><td>1.9260546e-05</td><td>0</td><td>GALAXY</td><td>STARFORMING</td><td>0.49670327</td><td>64</td><td>0</td></tr>\n",
-       "<tr><td>3327042822472755200</td><td>1237651736318574838</td><td>0.21259658</td><td>7.138862e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>0.14038157</td><td>96</td><td>0</td></tr>\n",
-       "<tr><td>3327044196862289920</td><td>1237655468602556710</td><td>0.12747255</td><td>1.0024814e-05</td><td>0</td><td>GALAXY</td><td>STARFORMING</td><td>0.9118272</td><td>64</td><td>0</td></tr>\n",
-       "<tr><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td></tr>\n",
-       "<tr><td>3327063988071589888</td><td>1237655468602294437</td><td>0.117277816</td><td>1.2225097e-05</td><td>0</td><td>GALAXY</td><td>STARBURST</td><td>2.301178</td><td>64</td><td>0</td></tr>\n",
-       "<tr><td>3327065087583217664</td><td>1237651736318378283</td><td>0.02987722</td><td>6.544521e-06</td><td>0</td><td>GALAXY</td><td>STARBURST</td><td>6.2372937</td><td>64</td><td>0</td></tr>\n",
-       "<tr><td>3327065362461124608</td><td>1237655468602360140</td><td>0.08503898</td><td>2.8198616e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>0.38777363</td><td>64</td><td>0</td></tr>\n",
-       "<tr><td>3327065912216938496</td><td>1237651736318443551</td><td>0.16617252</td><td>3.350158e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>0.5785748</td><td>64</td><td>0</td></tr>\n",
-       "<tr><td>3327066187094845440</td><td>1237655468602294603</td><td>0.084284484</td><td>1.1737382e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>0.53542316</td><td>64</td><td>0</td></tr>\n",
-       "<tr><td>3327066736850659328</td><td>1237651736318378031</td><td>0.050459415</td><td>3.3662614e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>0.066199064</td><td>64</td><td>0</td></tr>\n",
-       "<tr><td>3327067011728566272</td><td>1237651735781377183</td><td>0.44971278</td><td>0.00015747716</td><td>0</td><td>GALAXY</td><td>--</td><td>0.060908318</td><td>32</td><td>0</td></tr>\n",
-       "<tr><td>3327067286606473216</td><td>1237651736318444114</td><td>0.15844806</td><td>2.7416756e-05</td><td>0</td><td>GALAXY</td><td>STARFORMING</td><td>0.13396144</td><td>64</td><td>0</td></tr>\n",
-       "<tr><td>3327067561484380160</td><td>1237655468064965078</td><td>0.0846016</td><td>2.5953486e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>0.16839969</td><td>64</td><td>0</td></tr>\n",
-       "<tr><td>3327068111240194048</td><td>1237655468064964823</td><td>0.08544502</td><td>3.2923934e-05</td><td>0</td><td>GALAXY</td><td>STARFORMING</td><td>0.3577659</td><td>64</td><td>0</td></tr>\n",
-       "</table></div>"
-      ],
-      "text/plain": [
-       "<Table length=50>\n",
-       "     specobjid           bestobjid           z      ... primtarget sectarget\n",
-       "       int64               int64          float64   ...   int64      int64  \n",
-       "------------------- ------------------- ----------- ... ---------- ---------\n",
-       "3327035125891360768 1237655468065620461  0.26219922 ...         96         0\n",
-       "3327036500280895488 1237655468065489538  0.21097003 ...         64         0\n",
-       "3327038424426244096 1237655468065620456   0.2605426 ...         32         0\n",
-       "3327038974182057984 1237655468065620382  0.11276812 ...         64         0\n",
-       "3327040073693685760 1237651736318574966  0.06364931 ...         64         0\n",
-       "3327040348571592704 1237651736318640378  0.20836118 ...         96         0\n",
-       "3327040898327406592 1237655468602491146  0.20784536 ...         64         0\n",
-       "3327041722961127424 1237651736318575080   0.1408417 ...         64         0\n",
-       "3327042822472755200 1237651736318574838  0.21259658 ...         96         0\n",
-       "3327044196862289920 1237655468602556710  0.12747255 ...         64         0\n",
-       "                ...                 ...         ... ...        ...       ...\n",
-       "3327063988071589888 1237655468602294437 0.117277816 ...         64         0\n",
-       "3327065087583217664 1237651736318378283  0.02987722 ...         64         0\n",
-       "3327065362461124608 1237655468602360140  0.08503898 ...         64         0\n",
-       "3327065912216938496 1237651736318443551  0.16617252 ...         64         0\n",
-       "3327066187094845440 1237655468602294603 0.084284484 ...         64         0\n",
-       "3327066736850659328 1237651736318378031 0.050459415 ...         64         0\n",
-       "3327067011728566272 1237651735781377183  0.44971278 ...         32         0\n",
-       "3327067286606473216 1237651736318444114  0.15844806 ...         64         0\n",
-       "3327067561484380160 1237655468064965078   0.0846016 ...         64         0\n",
-       "3327068111240194048 1237655468064964823  0.08544502 ...         64         0"
-      ]
-     },
-     "execution_count": 23,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "q = \"\"\"\n",
     "SELECT z.specobjid, z.bestobjid, z.z, z.zerr, z.zwarning, z.class, z.subclass,\n",
@@ -1168,15 +610,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": null,
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2023-08-16T17:28:03.143209Z",
-     "iopub.status.busy": "2023-08-16T17:28:03.142798Z",
-     "iopub.status.idle": "2023-08-16T17:28:03.149169Z",
-     "shell.execute_reply": "2023-08-16T17:28:03.148007Z",
-     "shell.execute_reply.started": "2023-08-16T17:28:03.143166Z"
-    }
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -1194,31 +630,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": null,
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2023-08-16T17:28:03.150909Z",
-     "iopub.status.busy": "2023-08-16T17:28:03.150512Z",
-     "iopub.status.idle": "2023-08-16T17:28:05.029008Z",
-     "shell.execute_reply": "2023-08-16T17:28:05.027960Z",
-     "shell.execute_reply.started": "2023-08-16T17:28:03.150871Z"
-    },
     "tags": []
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'status': {'success': True,\n",
-       "  'info': [\"Successfully found 50 records in dr_list=['SDSS-DR16']\"],\n",
-       "  'warnings': []}}"
-      ]
-     },
-     "execution_count": 25,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "include = client.get_all_fields(dataset_list=['SDSS-DR16'])\n",
     "sdss_spectra = client.retrieve_by_specid(specid_list=sdss_ids['specobjid'].value.tolist(),\n",
@@ -1236,15 +652,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": null,
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2023-08-16T17:28:05.034242Z",
-     "iopub.status.busy": "2023-08-16T17:28:05.034012Z",
-     "iopub.status.idle": "2023-08-16T17:28:05.040008Z",
-     "shell.execute_reply": "2023-08-16T17:28:05.039022Z",
-     "shell.execute_reply.started": "2023-08-16T17:28:05.034218Z"
-    },
     "tags": []
    },
    "outputs": [],
@@ -1264,19 +673,42 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": null,
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2023-08-16T17:28:05.041864Z",
-     "iopub.status.busy": "2023-08-16T17:28:05.041583Z",
-     "iopub.status.idle": "2023-08-16T17:28:05.060812Z",
-     "shell.execute_reply": "2023-08-16T17:28:05.059819Z",
-     "shell.execute_reply.started": "2023-08-16T17:28:05.041839Z"
-    }
+    "tags": []
    },
    "outputs": [],
    "source": [
     "assert all([(r.wavelength == sdss_spectra.records[0].wavelength).all() for r in sdss_spectra.records])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**QA**: Are any of the spectra fully masked?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "for k in range(len(sdss_spectra.records)):\n",
+    "    assert np.isfinite(sdss_spectra.records[k].flux).all()\n",
+    "    assert np.isfinite(sdss_spectra.records[k].ivar).all()\n",
+    "    if (sdss_spectra.records[k].mask > 0).all():\n",
+    "        print(f\"WARNING: Spectrum record {k:d} is fully masked!\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Note** that one of the spectra has a non-zero mask for every pixel. This will cause problems with some versions of Prospect, so for the demonstration below, we will not attempt to plot that spectrum. Future versions of Prospect will handle this more gracefully."
    ]
   },
   {
@@ -1288,247 +720,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": null,
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2023-08-16T17:28:05.061971Z",
-     "iopub.status.busy": "2023-08-16T17:28:05.061754Z",
-     "iopub.status.idle": "2023-08-16T17:28:05.083151Z",
-     "shell.execute_reply": "2023-08-16T17:28:05.082301Z",
-     "shell.execute_reply.started": "2023-08-16T17:28:05.061948Z"
-    }
+    "tags": []
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'specid': 3327046121007638528,\n",
-       " 'datasetgroup': 'SDSS_BOSS',\n",
-       " 'redshift_err': 2.27969903789926e-05,\n",
-       " 'telescope': 'sloan25m',\n",
-       " 'spectype': 'GALAXY',\n",
-       " 'instrument': 'SDSS',\n",
-       " 'targetid': 1237655468065292360,\n",
-       " 'wavemax': 9191.7880859375,\n",
-       " 'redshift_warning': 0,\n",
-       " 'dec': 0.79150642,\n",
-       " 'ra': 235.80015,\n",
-       " 'specprimary': True,\n",
-       " 'exptime': 3002.0,\n",
-       " 'site': 'apo',\n",
-       " 'redshift': 0.0843528062105179,\n",
-       " 'data_release': 'SDSS-DR16',\n",
-       " 'wavemin': 3812.41357421875,\n",
-       " 'fiberid': 43,\n",
-       " 'class_noqso': '',\n",
-       " 'special_target1': 0,\n",
-       " 'elodie_filename': '',\n",
-       " 'platesn2': 20.60099983215332,\n",
-       " 'targetobjid': '     11268994536964194',\n",
-       " 'specsegue': 0,\n",
-       " 'calibflux': [5.839175701141357,\n",
-       "  32.200157165527344,\n",
-       "  82.3163070678711,\n",
-       "  126.0885009765625,\n",
-       "  179.93894958496094],\n",
-       " 'subclass_noqso': '',\n",
-       " 'spec2_i': 23.063199996948242,\n",
-       " 'rchi2': 0.9485337138175964,\n",
-       " 'survey': 'sdss',\n",
-       " 'segue1_target1': 0,\n",
-       " 'plate': 2955,\n",
-       " 'elodie_object': '',\n",
-       " 'mjd': 54562,\n",
-       " 'vdispz': 0.0,\n",
-       " 'spec1_i': 20.87619972229004,\n",
-       " 'eboss_target2': 0,\n",
-       " 'elodie_feh': 0.0,\n",
-       " 'fluxobjid': '1237655468065292360',\n",
-       " 'cx': -0.5620275803368721,\n",
-       " 'elodie_bv': 0.0,\n",
-       " 'platequality': 'good',\n",
-       " 'theta': [0.0032299787271767855,\n",
-       "  -0.003086125710979104,\n",
-       "  0.004519165027886629,\n",
-       "  -0.0018139064777642488,\n",
-       "  -4.29939079284668,\n",
-       "  10.22780704498291,\n",
-       "  -4.929110050201416,\n",
-       "  0.0,\n",
-       "  0.0,\n",
-       "  0.0],\n",
-       " 'chi68p': 0.9453041553497314,\n",
-       " 'specsegue1': 0,\n",
-       " 'designid': -1,\n",
-       " 'targettype': 'SCIENCE',\n",
-       " 'tfile': 'spEigenGal-53724.fits',\n",
-       " 'firstrelease': 'dr7',\n",
-       " 'spec2_g': 24.95490074157715,\n",
-       " 'vdisp_err': 8.152422904968262,\n",
-       " 'specsdss': 1,\n",
-       " 'z_noqso': 0.0,\n",
-       " 'elodie_dof': 0,\n",
-       " 'spectroflux': [9.332414627075195,\n",
-       "  31.732585906982422,\n",
-       "  82.59172058105469,\n",
-       "  126.56288146972656,\n",
-       "  169.82315063476562],\n",
-       " 'rchi2diff_noqso': 0.0,\n",
-       " 'elodie_rchi2': 0.0,\n",
-       " 'specboss': 0,\n",
-       " 'nspecobs': 2,\n",
-       " 'platerun': 'dr2008.02.1',\n",
-       " 'wcoverage': 0.374099999666214,\n",
-       " 'vdispdof': 2117,\n",
-       " 'spectrosynflux': [8.001383781433105,\n",
-       "  31.711828231811523,\n",
-       "  82.3985824584961,\n",
-       "  126.65225982666016,\n",
-       "  170.72434997558594],\n",
-       " 'rchi2diff': 1.071800947189331,\n",
-       " 'ancillary_target2': 0,\n",
-       " 'elodie_logg': 0.0,\n",
-       " 'anyandmask': 226557952,\n",
-       " 'chunk': 'chunk186',\n",
-       " 'fracnsighi': [0.14675220847129822,\n",
-       "  0.01790964975953102,\n",
-       "  0.002138465642929077,\n",
-       "  0.0005346164107322693,\n",
-       "  0.0,\n",
-       "  0.0,\n",
-       "  0.0,\n",
-       "  0.0,\n",
-       "  0.0,\n",
-       "  0.0],\n",
-       " 'dof': 3734,\n",
-       " 'elodie_teff': 0.0,\n",
-       " 'run2d': 26,\n",
-       " 'calibflux_ivar': [3.595198631286621,\n",
-       "  14.76074504852295,\n",
-       "  7.691927433013916,\n",
-       "  3.182457208633423,\n",
-       "  0.31164321303367615],\n",
-       " 'subclass': '',\n",
-       " 'eboss_target1': 0,\n",
-       " 'zwarning_noqso': 0,\n",
-       " 'class_person': 0,\n",
-       " 'elodie_z_err': 0.0,\n",
-       " 'xfocal': 82.68842315673828,\n",
-       " 'vdispz_err': 0.0,\n",
-       " 'segue2_target2': 0,\n",
-       " 'snturnoff': -9999.0,\n",
-       " 'marvels_target2': 0,\n",
-       " 'thing_id': 0,\n",
-       " 'sn_median': [1.9228945970535278,\n",
-       "  10.949285507202148,\n",
-       "  24.799718856811523,\n",
-       "  29.473806381225586,\n",
-       "  20.79361915588379],\n",
-       " 'marvels_target1': 0,\n",
-       " 'z_person': 0.0,\n",
-       " 'primtarget': 64,\n",
-       " 'spec2_r': 26.778099060058594,\n",
-       " 'thing_id_targeting': 0,\n",
-       " 'tile': 1929,\n",
-       " 'fracnsigma': [0.29109862446784973,\n",
-       "  0.04036353901028633,\n",
-       "  0.0034750066697597504,\n",
-       "  0.0005346164107322693,\n",
-       "  0.0,\n",
-       "  0.0,\n",
-       "  0.0,\n",
-       "  0.0,\n",
-       "  0.0,\n",
-       "  0.0],\n",
-       " 'tcolumn': [0, 1, 2, 3, -1, -1, -1, -1, -1, -1],\n",
-       " 'spectrographid': 1,\n",
-       " 'zoffset': 0.0,\n",
-       " 'objid': [2327, 40, 2, 90, 98],\n",
-       " 'plateid': '3327034301257639936',\n",
-       " 'sourcetype': 'GALAXY',\n",
-       " 'spectrosynflux_ivar': [2.1609764099121094,\n",
-       "  4.695135116577148,\n",
-       "  2.821389675140381,\n",
-       "  1.6888610124588013,\n",
-       "  0.8614444136619568],\n",
-       " 'segue2_target1': 0,\n",
-       " 'yfocal': -185.64418029785156,\n",
-       " 'specsegue2': 0,\n",
-       " 'comments_person': '',\n",
-       " 'sectarget': 0,\n",
-       " 'spec1_g': 20.60099983215332,\n",
-       " 'run1d': 0,\n",
-       " 'z_err_noqso': 0.0,\n",
-       " 'special_target2': 0,\n",
-       " 'vdispchi2': 1636.79052734375,\n",
-       " 'anyormask': 262078464,\n",
-       " 'deredsn2': 0.0,\n",
-       " 'spectroskyflux': [7.107358932495117,\n",
-       "  10.76518726348877,\n",
-       "  27.018781661987305,\n",
-       "  45.612754821777344,\n",
-       "  82.89754486083984],\n",
-       " 'lambda_eff': 5000.0,\n",
-       " 'boss_specobj_id': 0,\n",
-       " 'z_conf_person': 0,\n",
-       " 'vdisp': 152.95208740234375,\n",
-       " 'cz': 0.01381395369992667,\n",
-       " 'sn_median_all': 18.48808479309082,\n",
-       " 'legacy_target1': 64,\n",
-       " 'vdispnpix': 2168.0,\n",
-       " 'fracnsiglo': [0.1443464308977127,\n",
-       "  0.02245388925075531,\n",
-       "  0.0013365410268306732,\n",
-       "  0.0,\n",
-       "  0.0,\n",
-       "  0.0,\n",
-       "  0.0,\n",
-       "  0.0,\n",
-       "  0.0,\n",
-       "  0.0],\n",
-       " 'eboss_target0': 0,\n",
-       " 'boss_target2': 0,\n",
-       " 'nturnoff': -1,\n",
-       " 'legacy_target2': 0,\n",
-       " 'spec1_r': 21.144100189208984,\n",
-       " 'ancillary_target1': 0,\n",
-       " 'speclegacy': 1,\n",
-       " 'elodie_z_modelerr': 0.0,\n",
-       " 'elodie_z': 0.0,\n",
-       " 'npoly': 3,\n",
-       " 'cy': -0.8270031279407939,\n",
-       " 'bluefiber': -1,\n",
-       " 'eboss_target_id': 0,\n",
-       " 'boss_target1': 0,\n",
-       " 'programname': 'legacy',\n",
-       " 'segue1_target2': 0,\n",
-       " 'elodie_sptype': '',\n",
-       " 'spectroflux_ivar': [1.5567643642425537,\n",
-       "  4.762773513793945,\n",
-       "  2.497319459915161,\n",
-       "  1.469778060913086,\n",
-       "  0.6877836585044861],\n",
-       " 'wave_sigma': array([0., 0., 0., ..., 0., 0., 0.]),\n",
-       " 'ivar': array([0., 0., 0., ..., 0., 0., 0.]),\n",
-       " 'sky': array([0., 0., 0., ..., 0., 0., 0.]),\n",
-       " 'mask': array([16777216, 16777216, 16777216, ..., 16777216, 16777216, 16777216]),\n",
-       " 'model': array([ 6.41936302,  6.48199415,  6.59158564, ..., 22.07676125,\n",
-       "        22.27691269, 22.87110901]),\n",
-       " 'wavelength': array([3802.76948244, 3803.64520329, 3804.5211258 , ..., 9217.22098659,\n",
-       "        9219.34357452, 9221.46665124]),\n",
-       " 'flux': array([ 5.68828678,  5.68669415,  5.68510437, ..., 21.37030602,\n",
-       "        21.3703804 , 21.37045288]),\n",
-       " 'dateobs': '[\"2008-04-06 00:00:00+00\",\"2008-04-06 00:00:00+00\"]',\n",
-       " 'dateobs_center': '2008-04-06 00:00:00+00',\n",
-       " 'sparcl_id': '0ab82ff3-5500-4ae4-97d5-72cc573fa96b',\n",
-       " '_dr': 'SDSS-DR16'}"
-      ]
-     },
-     "execution_count": 28,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "sdss_spectra.records[0]"
    ]
@@ -1554,15 +750,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": null,
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2023-08-16T17:28:05.084429Z",
-     "iopub.status.busy": "2023-08-16T17:28:05.084213Z",
-     "iopub.status.idle": "2023-08-16T17:28:05.103950Z",
-     "shell.execute_reply": "2023-08-16T17:28:05.102963Z",
-     "shell.execute_reply.started": "2023-08-16T17:28:05.084407Z"
-    }
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -1594,15 +784,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": null,
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2023-08-16T17:28:05.105236Z",
-     "iopub.status.busy": "2023-08-16T17:28:05.105020Z",
-     "iopub.status.idle": "2023-08-16T17:28:05.230037Z",
-     "shell.execute_reply": "2023-08-16T17:28:05.228435Z",
-     "shell.execute_reply.started": "2023-08-16T17:28:05.105213Z"
-    }
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -1619,15 +803,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": null,
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2023-08-16T17:28:05.232425Z",
-     "iopub.status.busy": "2023-08-16T17:28:05.231983Z",
-     "iopub.status.idle": "2023-08-16T17:28:05.242994Z",
-     "shell.execute_reply": "2023-08-16T17:28:05.241907Z",
-     "shell.execute_reply.started": "2023-08-16T17:28:05.232379Z"
-    }
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -1639,7 +817,7 @@
     "plugmap.add_column(mag, name='MAG')\n",
     "plugmap.add_column(sdss_ids['primtarget'], name='PRIMTARGET')\n",
     "plugmap.add_column(sdss_ids['sectarget'], name='SECTARGET')\n",
-    "meta['plugmap'] = plugmap"
+    "meta['plugmap'] = plugmap[1:]"
    ]
   },
   {
@@ -1651,15 +829,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": null,
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2023-08-16T17:28:05.244785Z",
-     "iopub.status.busy": "2023-08-16T17:28:05.244370Z",
-     "iopub.status.idle": "2023-08-16T17:28:05.262147Z",
-     "shell.execute_reply": "2023-08-16T17:28:05.260824Z",
-     "shell.execute_reply.started": "2023-08-16T17:28:05.244743Z"
-    },
     "tags": []
    },
    "outputs": [],
@@ -1676,23 +847,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": null,
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2023-08-16T17:28:05.263930Z",
-     "iopub.status.busy": "2023-08-16T17:28:05.263526Z",
-     "iopub.status.idle": "2023-08-16T17:28:05.296149Z",
-     "shell.execute_reply": "2023-08-16T17:28:05.294901Z",
-     "shell.execute_reply.started": "2023-08-16T17:28:05.263890Z"
-    },
     "tags": []
    },
    "outputs": [],
    "source": [
-    "sdss_prospect = Spectrum1D(flux=flux * u.Unit('1e-17 erg / (Angstrom cm2 s)'),\n",
+    "sdss_prospect = Spectrum1D(flux=flux[1:, :] * u.Unit('1e-17 erg / (Angstrom cm2 s)'),\n",
     "                           spectral_axis=sdss_spectra.records[0].wavelength * u.Unit('Angstrom'),\n",
-    "                           uncertainty=InverseVariance(uncertainty),\n",
-    "                           mask=mask != 0,\n",
+    "                           uncertainty=InverseVariance(uncertainty[1:, :]),\n",
+    "                           mask=mask[1:, :] != 0,\n",
     "                           meta=meta)"
    ]
   },
@@ -1707,81 +871,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": null,
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2023-08-16T17:28:05.298012Z",
-     "iopub.status.busy": "2023-08-16T17:28:05.297620Z",
-     "iopub.status.idle": "2023-08-16T17:28:05.317535Z",
-     "shell.execute_reply": "2023-08-16T17:28:05.316506Z",
-     "shell.execute_reply.started": "2023-08-16T17:28:05.297970Z"
-    },
     "tags": []
    },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div><i>Table length=50</i>\n",
-       "<table id=\"table140010885843792\" class=\"table-striped table-bordered table-condensed\">\n",
-       "<thead><tr><th>SPECOBJID</th><th>BESTOBJID</th><th>Z</th><th>Z_ERR</th><th>ZWARNING</th><th>CLASS</th><th>SUBCLASS</th><th>RCHI2DIFF</th><th>PRIMTARGET</th><th>SECTARGET</th></tr></thead>\n",
-       "<thead><tr><th>int64</th><th>int64</th><th>float64</th><th>float64</th><th>int64</th><th>str6</th><th>str11</th><th>float64</th><th>int64</th><th>int64</th></tr></thead>\n",
-       "<tr><td>3327035125891360768</td><td>1237655468065620461</td><td>0.26219922</td><td>6.426468e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>0.16153336</td><td>96</td><td>0</td></tr>\n",
-       "<tr><td>3327036500280895488</td><td>1237655468065489538</td><td>0.21097003</td><td>5.7919853e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>0.13921309</td><td>64</td><td>0</td></tr>\n",
-       "<tr><td>3327038424426244096</td><td>1237655468065620456</td><td>0.2605426</td><td>6.229882e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>0.22558784</td><td>32</td><td>0</td></tr>\n",
-       "<tr><td>3327038974182057984</td><td>1237655468065620382</td><td>0.11276812</td><td>1.5994665e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>0.510905</td><td>64</td><td>0</td></tr>\n",
-       "<tr><td>3327040073693685760</td><td>1237651736318574966</td><td>0.06364931</td><td>2.8312488e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>0.42436635</td><td>64</td><td>0</td></tr>\n",
-       "<tr><td>3327040348571592704</td><td>1237651736318640378</td><td>0.20836118</td><td>4.189276e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>1.1794078</td><td>96</td><td>0</td></tr>\n",
-       "<tr><td>3327040898327406592</td><td>1237655468602491146</td><td>0.20784536</td><td>4.1236628e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>0.61972916</td><td>64</td><td>0</td></tr>\n",
-       "<tr><td>3327041722961127424</td><td>1237651736318575080</td><td>0.1408417</td><td>1.9260546e-05</td><td>0</td><td>GALAXY</td><td>STARFORMING</td><td>0.49670327</td><td>64</td><td>0</td></tr>\n",
-       "<tr><td>3327042822472755200</td><td>1237651736318574838</td><td>0.21259658</td><td>7.138862e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>0.14038157</td><td>96</td><td>0</td></tr>\n",
-       "<tr><td>3327044196862289920</td><td>1237655468602556710</td><td>0.12747255</td><td>1.0024814e-05</td><td>0</td><td>GALAXY</td><td>STARFORMING</td><td>0.9118272</td><td>64</td><td>0</td></tr>\n",
-       "<tr><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td></tr>\n",
-       "<tr><td>3327063988071589888</td><td>1237655468602294437</td><td>0.117277816</td><td>1.2225097e-05</td><td>0</td><td>GALAXY</td><td>STARBURST</td><td>2.301178</td><td>64</td><td>0</td></tr>\n",
-       "<tr><td>3327065087583217664</td><td>1237651736318378283</td><td>0.02987722</td><td>6.544521e-06</td><td>0</td><td>GALAXY</td><td>STARBURST</td><td>6.2372937</td><td>64</td><td>0</td></tr>\n",
-       "<tr><td>3327065362461124608</td><td>1237655468602360140</td><td>0.08503898</td><td>2.8198616e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>0.38777363</td><td>64</td><td>0</td></tr>\n",
-       "<tr><td>3327065912216938496</td><td>1237651736318443551</td><td>0.16617252</td><td>3.350158e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>0.5785748</td><td>64</td><td>0</td></tr>\n",
-       "<tr><td>3327066187094845440</td><td>1237655468602294603</td><td>0.084284484</td><td>1.1737382e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>0.53542316</td><td>64</td><td>0</td></tr>\n",
-       "<tr><td>3327066736850659328</td><td>1237651736318378031</td><td>0.050459415</td><td>3.3662614e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>0.066199064</td><td>64</td><td>0</td></tr>\n",
-       "<tr><td>3327067011728566272</td><td>1237651735781377183</td><td>0.44971278</td><td>0.00015747716</td><td>0</td><td>GALAXY</td><td>--</td><td>0.060908318</td><td>32</td><td>0</td></tr>\n",
-       "<tr><td>3327067286606473216</td><td>1237651736318444114</td><td>0.15844806</td><td>2.7416756e-05</td><td>0</td><td>GALAXY</td><td>STARFORMING</td><td>0.13396144</td><td>64</td><td>0</td></tr>\n",
-       "<tr><td>3327067561484380160</td><td>1237655468064965078</td><td>0.0846016</td><td>2.5953486e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>0.16839969</td><td>64</td><td>0</td></tr>\n",
-       "<tr><td>3327068111240194048</td><td>1237655468064964823</td><td>0.08544502</td><td>3.2923934e-05</td><td>0</td><td>GALAXY</td><td>STARFORMING</td><td>0.3577659</td><td>64</td><td>0</td></tr>\n",
-       "</table></div>"
-      ],
-      "text/plain": [
-       "<Table length=50>\n",
-       "     SPECOBJID           BESTOBJID           Z      ... PRIMTARGET SECTARGET\n",
-       "       int64               int64          float64   ...   int64      int64  \n",
-       "------------------- ------------------- ----------- ... ---------- ---------\n",
-       "3327035125891360768 1237655468065620461  0.26219922 ...         96         0\n",
-       "3327036500280895488 1237655468065489538  0.21097003 ...         64         0\n",
-       "3327038424426244096 1237655468065620456   0.2605426 ...         32         0\n",
-       "3327038974182057984 1237655468065620382  0.11276812 ...         64         0\n",
-       "3327040073693685760 1237651736318574966  0.06364931 ...         64         0\n",
-       "3327040348571592704 1237651736318640378  0.20836118 ...         96         0\n",
-       "3327040898327406592 1237655468602491146  0.20784536 ...         64         0\n",
-       "3327041722961127424 1237651736318575080   0.1408417 ...         64         0\n",
-       "3327042822472755200 1237651736318574838  0.21259658 ...         96         0\n",
-       "3327044196862289920 1237655468602556710  0.12747255 ...         64         0\n",
-       "                ...                 ...         ... ...        ...       ...\n",
-       "3327063988071589888 1237655468602294437 0.117277816 ...         64         0\n",
-       "3327065087583217664 1237651736318378283  0.02987722 ...         64         0\n",
-       "3327065362461124608 1237655468602360140  0.08503898 ...         64         0\n",
-       "3327065912216938496 1237651736318443551  0.16617252 ...         64         0\n",
-       "3327066187094845440 1237655468602294603 0.084284484 ...         64         0\n",
-       "3327066736850659328 1237651736318378031 0.050459415 ...         64         0\n",
-       "3327067011728566272 1237651735781377183  0.44971278 ...         32         0\n",
-       "3327067286606473216 1237651736318444114  0.15844806 ...         64         0\n",
-       "3327067561484380160 1237655468064965078   0.0846016 ...         64         0\n",
-       "3327068111240194048 1237655468064964823  0.08544502 ...         64         0"
-      ]
-     },
-     "execution_count": 34,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "sdss_zcatalog = sdss_ids.copy()\n",
     "for col in sdss_zcatalog.colnames:\n",
@@ -1803,15 +897,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": null,
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2023-08-16T17:28:05.319121Z",
-     "iopub.status.busy": "2023-08-16T17:28:05.318780Z",
-     "iopub.status.idle": "2023-08-16T17:28:05.347556Z",
-     "shell.execute_reply": "2023-08-16T17:28:05.346539Z",
-     "shell.execute_reply.started": "2023-08-16T17:28:05.319085Z"
-    },
     "tags": []
    },
    "outputs": [],
@@ -1822,7 +909,7 @@
     "for k in range(len(sdss_spectra.records)):\n",
     "        model_flux[k, :] = sdss_spectra.records[k].model\n",
     "        \n",
-    "sdss_model = (sdss_spectra.records[0].wavelength, model_flux)"
+    "sdss_model = (sdss_spectra.records[0].wavelength, model_flux[1:, :])"
    ]
   },
   {
@@ -1837,11 +924,13 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "plotspectra(sdss_prospect,\n",
-    "            zcatalog=sdss_zcatalog,\n",
+    "            zcatalog=sdss_zcatalog[1:],\n",
     "            redrock_cat=None,\n",
     "            notebook=True,\n",
     "            with_thumb_tab=False,\n",
@@ -1869,81 +958,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": null,
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2023-08-16T17:28:06.401107Z",
-     "iopub.status.busy": "2023-08-16T17:28:06.400832Z",
-     "iopub.status.idle": "2023-08-16T17:28:06.517392Z",
-     "shell.execute_reply": "2023-08-16T17:28:06.516198Z",
-     "shell.execute_reply.started": "2023-08-16T17:28:06.401080Z"
-    },
     "tags": []
    },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div><i>Table length=50</i>\n",
-       "<table id=\"table140010886248144\" class=\"table-striped table-bordered table-condensed\">\n",
-       "<thead><tr><th>specobjid</th><th>bestobjid</th><th>z</th><th>zerr</th><th>zwarning</th><th>class</th><th>subclass</th><th>rchi2diff</th><th>boss_target1</th><th>eboss_target0</th><th>eboss_target1</th><th>eboss_target2</th></tr></thead>\n",
-       "<thead><tr><th>int64</th><th>int64</th><th>float64</th><th>float64</th><th>int64</th><th>str6</th><th>int64</th><th>float64</th><th>int64</th><th>int64</th><th>int64</th><th>int64</th></tr></thead>\n",
-       "<tr><td>-7639230456632422400</td><td>1237665127987282622</td><td>0.88640094</td><td>7.4862786e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>0.06782746</td><td>0</td><td>0</td><td>17592186044416</td><td>562949953421312</td></tr>\n",
-       "<tr><td>-7639227982731259904</td><td>1237665098459972441</td><td>0.91102755</td><td>0.00010790457</td><td>0</td><td>GALAXY</td><td>--</td><td>0.017501831</td><td>0</td><td>0</td><td>17592186044416</td><td>562949953421312</td></tr>\n",
-       "<tr><td>-7639227707853352960</td><td>1237665128524284395</td><td>0.38422388</td><td>3.725687e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>0.04291892</td><td>0</td><td>0</td><td>17592186044416</td><td>562949953421312</td></tr>\n",
-       "<tr><td>-7639227432975446016</td><td>1237665098459972179</td><td>0.80037284</td><td>7.310519e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>0.027097106</td><td>0</td><td>0</td><td>17592186044416</td><td>562949953421312</td></tr>\n",
-       "<tr><td>-7639226333463818240</td><td>1237665128524350020</td><td>0.7552472</td><td>0.00021918201</td><td>0</td><td>GALAXY</td><td>--</td><td>0.013135433</td><td>0</td><td>0</td><td>17592186044416</td><td>562949953421312</td></tr>\n",
-       "<tr><td>-7639225783708004352</td><td>1237665128524415517</td><td>0.821098</td><td>8.6746266e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>0.024078012</td><td>0</td><td>0</td><td>17592186044416</td><td>562949953421312</td></tr>\n",
-       "<tr><td>-7639225233952190464</td><td>1237665098460037767</td><td>1.4448227</td><td>0.28259814</td><td>0</td><td>GALAXY</td><td>--</td><td>0.011102319</td><td>0</td><td>0</td><td>17592186044416</td><td>562949953421312</td></tr>\n",
-       "<tr><td>-7639224959074283520</td><td>1237665128524153288</td><td>0.921071</td><td>0.00011867128</td><td>0</td><td>GALAXY</td><td>--</td><td>0.018088818</td><td>0</td><td>0</td><td>17592186044416</td><td>562949953421312</td></tr>\n",
-       "<tr><td>-7639224409318469632</td><td>1237665097923035567</td><td>0.9825296</td><td>0.00013494636</td><td>0</td><td>GALAXY</td><td>--</td><td>0.012501717</td><td>0</td><td>0</td><td>17592186044416</td><td>562949953421312</td></tr>\n",
-       "<tr><td>-7639224134440562688</td><td>1237665128524153695</td><td>0.72651744</td><td>0.00017377117</td><td>0</td><td>GALAXY</td><td>--</td><td>0.0122798085</td><td>0</td><td>0</td><td>17592186044416</td><td>562949953421312</td></tr>\n",
-       "<tr><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td></tr>\n",
-       "<tr><td>-7639198021039403008</td><td>1237664834855306140</td><td>0.84657186</td><td>0.00014326358</td><td>0</td><td>GALAXY</td><td>--</td><td>0.010893226</td><td>0</td><td>0</td><td>17592186044416</td><td>562949953421312</td></tr>\n",
-       "<tr><td>-7639197196405682176</td><td>1237665097385771894</td><td>0.956134</td><td>0.00012707015</td><td>0</td><td>GALAXY</td><td>--</td><td>0.014543593</td><td>0</td><td>0</td><td>17592186044416</td><td>562949953421312</td></tr>\n",
-       "<tr><td>-7639196371771961344</td><td>1237665097385772080</td><td>0.9289425</td><td>0.00012458111</td><td>0</td><td>GALAXY</td><td>--</td><td>0.020382047</td><td>0</td><td>0</td><td>17592186044416</td><td>562949953421312</td></tr>\n",
-       "<tr><td>-7639191698847543296</td><td>1237665098459644688</td><td>0.8261575</td><td>6.600007e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>0.044630587</td><td>0</td><td>0</td><td>17592186044416</td><td>562949953421312</td></tr>\n",
-       "<tr><td>-7639191423969636352</td><td>1237665128523891276</td><td>0.87418866</td><td>0.00013456396</td><td>0</td><td>GALAXY</td><td>--</td><td>0.012468994</td><td>0</td><td>0</td><td>17592186044416</td><td>562949953421312</td></tr>\n",
-       "<tr><td>-7639190874213822464</td><td>1237665098459644459</td><td>0.8458766</td><td>0.00012213441</td><td>0</td><td>GALAXY</td><td>--</td><td>0.019898295</td><td>0</td><td>0</td><td>17592186044416</td><td>562949953421312</td></tr>\n",
-       "<tr><td>-7639190599335915520</td><td>1237665098459644444</td><td>0.8814697</td><td>0.000113710026</td><td>0</td><td>GALAXY</td><td>--</td><td>0.013058186</td><td>0</td><td>0</td><td>17592186044416</td><td>562949953421312</td></tr>\n",
-       "<tr><td>-7639190049580101632</td><td>1237665098459710264</td><td>0.29381153</td><td>5.269431e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>0.017101109</td><td>0</td><td>0</td><td>17592186044416</td><td>562949953421312</td></tr>\n",
-       "<tr><td>-7639188950068473856</td><td>1237665098459644427</td><td>0.9214788</td><td>0.00020183463</td><td>0</td><td>GALAXY</td><td>--</td><td>0.011347413</td><td>0</td><td>0</td><td>17592186044416</td><td>562949953421312</td></tr>\n",
-       "<tr><td>-7639187850556846080</td><td>1237664834855174988</td><td>0.7884503</td><td>7.470537e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>0.033761322</td><td>0</td><td>0</td><td>17592186044416</td><td>562949953421312</td></tr>\n",
-       "</table></div>"
-      ],
-      "text/plain": [
-       "<Table length=50>\n",
-       "     specobjid            bestobjid      ... eboss_target1   eboss_target2 \n",
-       "       int64                int64        ...     int64           int64     \n",
-       "-------------------- ------------------- ... -------------- ---------------\n",
-       "-7639230456632422400 1237665127987282622 ... 17592186044416 562949953421312\n",
-       "-7639227982731259904 1237665098459972441 ... 17592186044416 562949953421312\n",
-       "-7639227707853352960 1237665128524284395 ... 17592186044416 562949953421312\n",
-       "-7639227432975446016 1237665098459972179 ... 17592186044416 562949953421312\n",
-       "-7639226333463818240 1237665128524350020 ... 17592186044416 562949953421312\n",
-       "-7639225783708004352 1237665128524415517 ... 17592186044416 562949953421312\n",
-       "-7639225233952190464 1237665098460037767 ... 17592186044416 562949953421312\n",
-       "-7639224959074283520 1237665128524153288 ... 17592186044416 562949953421312\n",
-       "-7639224409318469632 1237665097923035567 ... 17592186044416 562949953421312\n",
-       "-7639224134440562688 1237665128524153695 ... 17592186044416 562949953421312\n",
-       "                 ...                 ... ...            ...             ...\n",
-       "-7639198021039403008 1237664834855306140 ... 17592186044416 562949953421312\n",
-       "-7639197196405682176 1237665097385771894 ... 17592186044416 562949953421312\n",
-       "-7639196371771961344 1237665097385772080 ... 17592186044416 562949953421312\n",
-       "-7639191698847543296 1237665098459644688 ... 17592186044416 562949953421312\n",
-       "-7639191423969636352 1237665128523891276 ... 17592186044416 562949953421312\n",
-       "-7639190874213822464 1237665098459644459 ... 17592186044416 562949953421312\n",
-       "-7639190599335915520 1237665098459644444 ... 17592186044416 562949953421312\n",
-       "-7639190049580101632 1237665098459710264 ... 17592186044416 562949953421312\n",
-       "-7639188950068473856 1237665098459644427 ... 17592186044416 562949953421312\n",
-       "-7639187850556846080 1237664834855174988 ... 17592186044416 562949953421312"
-      ]
-     },
-     "execution_count": 37,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "q = \"\"\"\n",
     "SELECT z.specobjid, z.bestobjid, z.z, z.zerr, z.zwarning, z.class, z.subclass,\n",
@@ -1972,16 +991,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2023-08-16T17:28:06.519498Z",
-     "iopub.status.busy": "2023-08-16T17:28:06.519061Z",
-     "iopub.status.idle": "2023-08-16T17:28:06.526113Z",
-     "shell.execute_reply": "2023-08-16T17:28:06.524849Z",
-     "shell.execute_reply.started": "2023-08-16T17:28:06.519452Z"
-    }
-   },
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": [
     "assert (np.unique(boss_ids['specobjid']) == boss_ids['specobjid']).all()"
@@ -1998,31 +1009,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
+   "execution_count": null,
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2023-08-16T17:28:06.527942Z",
-     "iopub.status.busy": "2023-08-16T17:28:06.527519Z",
-     "iopub.status.idle": "2023-08-16T17:28:08.640584Z",
-     "shell.execute_reply": "2023-08-16T17:28:08.639436Z",
-     "shell.execute_reply.started": "2023-08-16T17:28:06.527902Z"
-    },
     "tags": []
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'status': {'success': True,\n",
-       "  'info': [\"Successfully found 50 records in dr_list=['BOSS-DR16']\"],\n",
-       "  'warnings': []}}"
-      ]
-     },
-     "execution_count": 39,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "include = client.get_all_fields(dataset_list=['BOSS-DR16'])\n",
     "boss_spectra = client.retrieve_by_specid(specid_list=boss_ids['specobjid'].value.tolist(),\n",
@@ -2042,15 +1033,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 40,
+   "execution_count": null,
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2023-08-16T17:28:08.642475Z",
-     "iopub.status.busy": "2023-08-16T17:28:08.642140Z",
-     "iopub.status.idle": "2023-08-16T17:28:08.649719Z",
-     "shell.execute_reply": "2023-08-16T17:28:08.648831Z",
-     "shell.execute_reply.started": "2023-08-16T17:28:08.642439Z"
-    },
     "tags": []
    },
    "outputs": [],
@@ -2070,19 +1054,35 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 41,
+   "execution_count": null,
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2023-08-16T17:28:08.651118Z",
-     "iopub.status.busy": "2023-08-16T17:28:08.650831Z",
-     "iopub.status.idle": "2023-08-16T17:28:08.670708Z",
-     "shell.execute_reply": "2023-08-16T17:28:08.669793Z",
-     "shell.execute_reply.started": "2023-08-16T17:28:08.651089Z"
-    }
+    "tags": []
    },
    "outputs": [],
    "source": [
     "assert all([(r.wavelength == boss_spectra.records[0].wavelength).all() for r in boss_spectra.records])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**QA**: Are any of the spectra fully masked?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "for k in range(len(boss_spectra.records)):\n",
+    "    assert np.isfinite(boss_spectra.records[k].flux).all()\n",
+    "    assert np.isfinite(boss_spectra.records[k].ivar).all()\n",
+    "    if (boss_spectra.records[k].mask > 0).all():\n",
+    "        print(f\"WARNING: Spectrum record {k:d} is fully masked!\")"
    ]
   },
   {
@@ -2094,248 +1094,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 42,
+   "execution_count": null,
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2023-08-16T17:28:08.672073Z",
-     "iopub.status.busy": "2023-08-16T17:28:08.671794Z",
-     "iopub.status.idle": "2023-08-16T17:28:08.695646Z",
-     "shell.execute_reply": "2023-08-16T17:28:08.694794Z",
-     "shell.execute_reply.started": "2023-08-16T17:28:08.672045Z"
-    },
     "tags": []
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'specid': -7639227982731259904,\n",
-       " 'datasetgroup': 'SDSS_BOSS',\n",
-       " 'redshift_err': 0.000107904568722006,\n",
-       " 'telescope': 'sloan25m',\n",
-       " 'spectype': 'GALAXY',\n",
-       " 'instrument': 'BOSS',\n",
-       " 'targetid': 1237665098459972441,\n",
-       " 'wavemax': 10332.37109375,\n",
-       " 'redshift_warning': 0,\n",
-       " 'dec': 24.150201,\n",
-       " 'ra': 134.23291,\n",
-       " 'specprimary': True,\n",
-       " 'exptime': 3600.35,\n",
-       " 'site': 'apo',\n",
-       " 'redshift': 0.911027550697327,\n",
-       " 'data_release': 'BOSS-DR16',\n",
-       " 'wavemin': 3601.63745117188,\n",
-       " 'fiberid': 10,\n",
-       " 'class_noqso': 'GALAXY',\n",
-       " 'special_target1': 0,\n",
-       " 'elodie_filename': '',\n",
-       " 'platesn2': 5.494349956512451,\n",
-       " 'targetobjid': '',\n",
-       " 'specsegue': 0,\n",
-       " 'calibflux': [-0.2695178985595703,\n",
-       "  0.4001877009868622,\n",
-       "  1.0699976682662964,\n",
-       "  1.9848341941833496,\n",
-       "  1.4778335094451904],\n",
-       " 'subclass_noqso': '',\n",
-       " 'spec2_i': 16.17180061340332,\n",
-       " 'rchi2': 1.056380033493042,\n",
-       " 'survey': 'eboss',\n",
-       " 'segue1_target1': 0,\n",
-       " 'plate': 9599,\n",
-       " 'elodie_object': '',\n",
-       " 'mjd': 58131,\n",
-       " 'vdispz': 0.0,\n",
-       " 'spec1_i': 15.260899543762207,\n",
-       " 'eboss_target2': 562949953421312,\n",
-       " 'elodie_feh': 0.0,\n",
-       " 'fluxobjid': '1237665098459972441',\n",
-       " 'cx': -0.6365221042048994,\n",
-       " 'elodie_bv': 0.0,\n",
-       " 'platequality': 'good',\n",
-       " 'theta': [-0.00016797342686913908,\n",
-       "  -0.08542104810476303,\n",
-       "  0.47529876232147217,\n",
-       "  -0.05967295914888382,\n",
-       "  -1.2809841632843018,\n",
-       "  1.9083034992218018,\n",
-       "  0.6780674457550049,\n",
-       "  0.0,\n",
-       "  0.0,\n",
-       "  0.0],\n",
-       " 'chi68p': 0.9848752617835999,\n",
-       " 'specsegue1': 0,\n",
-       " 'designid': 10182,\n",
-       " 'targettype': 'SCIENCE',\n",
-       " 'tfile': 'spEigenGal-56436.fits',\n",
-       " 'firstrelease': 'dr16',\n",
-       " 'spec2_g': 6.322159767150879,\n",
-       " 'vdisp_err': 84.35669708251953,\n",
-       " 'specsdss': 0,\n",
-       " 'z_noqso': 0.9110275506973267,\n",
-       " 'elodie_dof': 0,\n",
-       " 'spectroflux': [1.435661792755127,\n",
-       "  0.6843998432159424,\n",
-       "  1.11798095703125,\n",
-       "  2.7152459621429443,\n",
-       "  4.8464884757995605],\n",
-       " 'rchi2diff_noqso': 0.01931917667388916,\n",
-       " 'elodie_rchi2': 0.0,\n",
-       " 'specboss': 1,\n",
-       " 'nspecobs': 1,\n",
-       " 'platerun': '2016.11.b.eboss',\n",
-       " 'wcoverage': 0.44369998574256897,\n",
-       " 'vdispdof': 977,\n",
-       " 'spectrosynflux': [0.23032288253307343,\n",
-       "  0.5758841633796692,\n",
-       "  1.1153984069824219,\n",
-       "  2.661834239959717,\n",
-       "  4.950334548950195],\n",
-       " 'rchi2diff': 0.0175018310546875,\n",
-       " 'ancillary_target2': 0,\n",
-       " 'elodie_logg': 0.0,\n",
-       " 'anyandmask': 96468992,\n",
-       " 'chunk': 'eboss23',\n",
-       " 'fracnsighi': [0.16384944319725037,\n",
-       "  0.026819923892617226,\n",
-       "  0.00428217276930809,\n",
-       "  0.0006761325057595968,\n",
-       "  0.0,\n",
-       "  0.0,\n",
-       "  0.0,\n",
-       "  0.0,\n",
-       "  0.0,\n",
-       "  0.0],\n",
-       " 'dof': 4430,\n",
-       " 'elodie_teff': 0.0,\n",
-       " 'run2d': 'v5_13_0',\n",
-       " 'calibflux_ivar': [5.1266865730285645,\n",
-       "  35.9057731628418,\n",
-       "  12.093795776367188,\n",
-       "  4.879647731781006,\n",
-       "  0.23459704220294952],\n",
-       " 'subclass': '',\n",
-       " 'eboss_target1': 17592186044416,\n",
-       " 'zwarning_noqso': 0,\n",
-       " 'class_person': 0,\n",
-       " 'elodie_z_err': 0.0,\n",
-       " 'xfocal': 250.6492462158203,\n",
-       " 'vdispz_err': 0.0,\n",
-       " 'segue2_target2': 0,\n",
-       " 'snturnoff': 0.0,\n",
-       " 'marvels_target2': 0,\n",
-       " 'thing_id': 322028114,\n",
-       " 'sn_median': [0.2970021367073059,\n",
-       "  0.4282677471637726,\n",
-       "  0.5722729563713074,\n",
-       "  1.0959781408309937,\n",
-       "  1.2025727033615112],\n",
-       " 'marvels_target1': 0,\n",
-       " 'z_person': 0.0,\n",
-       " 'primtarget': 0,\n",
-       " 'spec2_r': 15.675800323486328,\n",
-       " 'thing_id_targeting': 0,\n",
-       " 'tile': 17241,\n",
-       " 'fracnsigma': [0.3132747411727905,\n",
-       "  0.05296371504664421,\n",
-       "  0.008338967338204384,\n",
-       "  0.0009015100076794624,\n",
-       "  0.0,\n",
-       "  0.0,\n",
-       "  0.0,\n",
-       "  0.0,\n",
-       "  0.0,\n",
-       "  0.0],\n",
-       " 'tcolumn': [0, 1, 2, 3, -1, -1, -1, -1, -1, -1],\n",
-       " 'spectrographid': 1,\n",
-       " 'zoffset': 0.0,\n",
-       " 'objid': [0, 0, 0, 0, 0],\n",
-       " 'plateid': '10807513342203144192',\n",
-       " 'sourcetype': 'ELG',\n",
-       " 'spectrosynflux_ivar': [6.718648433685303,\n",
-       "  9.009385108947754,\n",
-       "  6.640621662139893,\n",
-       "  3.9203224182128906,\n",
-       "  1.8029663562774658],\n",
-       " 'segue2_target1': 0,\n",
-       " 'yfocal': -11.306900978088379,\n",
-       " 'specsegue2': 0,\n",
-       " 'comments_person': '',\n",
-       " 'sectarget': 0,\n",
-       " 'spec1_g': 5.494349956512451,\n",
-       " 'run1d': 0,\n",
-       " 'z_err_noqso': 0.00010790456872200593,\n",
-       " 'special_target2': 0,\n",
-       " 'vdispchi2': 1288.5028076171875,\n",
-       " 'anyormask': 265224192,\n",
-       " 'deredsn2': 5.494349956512451,\n",
-       " 'spectroskyflux': [9.471259117126465,\n",
-       "  12.944680213928223,\n",
-       "  28.706430435180664,\n",
-       "  63.788429260253906,\n",
-       "  177.5773468017578],\n",
-       " 'lambda_eff': 7500.0,\n",
-       " 'boss_specobj_id': 3485750,\n",
-       " 'z_conf_person': 0,\n",
-       " 'vdisp': 261.1448974609375,\n",
-       " 'cz': 0.40913010396598953,\n",
-       " 'sn_median_all': 0.6640755534172058,\n",
-       " 'legacy_target1': 0,\n",
-       " 'vdispnpix': 1186.0,\n",
-       " 'fracnsiglo': [0.14942528307437897,\n",
-       "  0.026143791154026985,\n",
-       "  0.004056795034557581,\n",
-       "  0.0002253775019198656,\n",
-       "  0.0,\n",
-       "  0.0,\n",
-       "  0.0,\n",
-       "  0.0,\n",
-       "  0.0,\n",
-       "  0.0],\n",
-       " 'eboss_target0': 0,\n",
-       " 'boss_target2': 0,\n",
-       " 'nturnoff': 0,\n",
-       " 'legacy_target2': 0,\n",
-       " 'spec1_r': 19.63450050354004,\n",
-       " 'ancillary_target1': 0,\n",
-       " 'speclegacy': 0,\n",
-       " 'elodie_z_modelerr': 0.0,\n",
-       " 'elodie_z': 0.0,\n",
-       " 'npoly': 3,\n",
-       " 'cy': 0.6537982631418852,\n",
-       " 'bluefiber': 1,\n",
-       " 'eboss_target_id': 2592008,\n",
-       " 'boss_target1': 0,\n",
-       " 'programname': 'ELG_NGC',\n",
-       " 'segue1_target2': 0,\n",
-       " 'elodie_sptype': '',\n",
-       " 'spectroflux_ivar': [2.2663114070892334,\n",
-       "  9.039624214172363,\n",
-       "  5.574249267578125,\n",
-       "  2.5262067317962646,\n",
-       "  0.08043096959590912],\n",
-       " 'wave_sigma': array([0., 0., 0., ..., 0., 0., 0.]),\n",
-       " 'ivar': array([0., 0., 0., ..., 0., 0., 0.]),\n",
-       " 'sky': array([0., 0., 0., ..., 0., 0., 0.]),\n",
-       " 'mask': array([88080384, 88080384, 88080384, ..., 83886080, 83886080, 83886080]),\n",
-       " 'model': array([0.27797607, 0.27003613, 0.26285109, ..., 0.93880498, 0.94388986,\n",
-       "        0.94133079]),\n",
-       " 'wavelength': array([ 3586.7408577 ,  3587.56683039,  3588.39299329, ...,\n",
-       "        10351.42166679, 10353.80544415, 10356.18977045]),\n",
-       " 'flux': array([ 3.74299359,  3.74153113,  3.7400713 , ..., -0.72711331,\n",
-       "        -0.72711992, -0.72712654]),\n",
-       " 'dateobs': '[\"2018-01-13 05:57:56+00\",\"2018-01-13 05:57:56+00\"]',\n",
-       " 'dateobs_center': '2018-01-13 05:57:56+00',\n",
-       " 'sparcl_id': '140d935e-7490-4351-b0e4-36085f1e75d1',\n",
-       " '_dr': 'BOSS-DR16'}"
-      ]
-     },
-     "execution_count": 42,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "boss_spectra.records[0]"
    ]
@@ -2361,15 +1124,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 43,
+   "execution_count": null,
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2023-08-16T17:28:08.696975Z",
-     "iopub.status.busy": "2023-08-16T17:28:08.696698Z",
-     "iopub.status.idle": "2023-08-16T17:28:08.719134Z",
-     "shell.execute_reply": "2023-08-16T17:28:08.718023Z",
-     "shell.execute_reply.started": "2023-08-16T17:28:08.696946Z"
-    },
     "tags": []
    },
    "outputs": [],
@@ -2404,15 +1160,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 44,
+   "execution_count": null,
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2023-08-16T17:28:08.720589Z",
-     "iopub.status.busy": "2023-08-16T17:28:08.720310Z",
-     "iopub.status.idle": "2023-08-16T17:28:08.852547Z",
-     "shell.execute_reply": "2023-08-16T17:28:08.851110Z",
-     "shell.execute_reply.started": "2023-08-16T17:28:08.720559Z"
-    },
     "tags": []
    },
    "outputs": [],
@@ -2430,16 +1179,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 45,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2023-08-16T17:28:08.854761Z",
-     "iopub.status.busy": "2023-08-16T17:28:08.854285Z",
-     "iopub.status.idle": "2023-08-16T17:28:08.867741Z",
-     "shell.execute_reply": "2023-08-16T17:28:08.866464Z",
-     "shell.execute_reply.started": "2023-08-16T17:28:08.854713Z"
-    }
-   },
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": [
     "for col in plugmap.colnames:\n",
@@ -2466,15 +1207,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 46,
+   "execution_count": null,
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2023-08-16T17:28:08.869696Z",
-     "iopub.status.busy": "2023-08-16T17:28:08.869262Z",
-     "iopub.status.idle": "2023-08-16T17:28:08.884191Z",
-     "shell.execute_reply": "2023-08-16T17:28:08.882974Z",
-     "shell.execute_reply.started": "2023-08-16T17:28:08.869653Z"
-    },
     "tags": []
    },
    "outputs": [],
@@ -2493,15 +1227,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 47,
+   "execution_count": null,
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2023-08-16T17:28:08.886081Z",
-     "iopub.status.busy": "2023-08-16T17:28:08.885681Z",
-     "iopub.status.idle": "2023-08-16T17:28:08.909812Z",
-     "shell.execute_reply": "2023-08-16T17:28:08.908675Z",
-     "shell.execute_reply.started": "2023-08-16T17:28:08.886041Z"
-    },
     "tags": []
    },
    "outputs": [],
@@ -2526,81 +1253,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 48,
+   "execution_count": null,
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2023-08-16T17:28:08.911491Z",
-     "iopub.status.busy": "2023-08-16T17:28:08.911137Z",
-     "iopub.status.idle": "2023-08-16T17:28:08.933322Z",
-     "shell.execute_reply": "2023-08-16T17:28:08.932453Z",
-     "shell.execute_reply.started": "2023-08-16T17:28:08.911454Z"
-    },
     "tags": []
    },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div><i>Table length=50</i>\n",
-       "<table id=\"table140010874717232\" class=\"table-striped table-bordered table-condensed\">\n",
-       "<thead><tr><th>SPECOBJID</th><th>BESTOBJID</th><th>Z</th><th>Z_ERR</th><th>ZWARNING</th><th>CLASS</th><th>SUBCLASS</th><th>RCHI2DIFF</th><th>BOSS_TARGET1</th><th>EBOSS_TARGET0</th><th>EBOSS_TARGET1</th><th>EBOSS_TARGET2</th></tr></thead>\n",
-       "<thead><tr><th>int64</th><th>int64</th><th>float64</th><th>float64</th><th>int64</th><th>str6</th><th>int64</th><th>float64</th><th>int64</th><th>int64</th><th>int64</th><th>int64</th></tr></thead>\n",
-       "<tr><td>-7639230456632422400</td><td>1237665127987282622</td><td>0.88640094</td><td>7.4862786e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>0.06782746</td><td>0</td><td>0</td><td>17592186044416</td><td>562949953421312</td></tr>\n",
-       "<tr><td>-7639227982731259904</td><td>1237665098459972441</td><td>0.91102755</td><td>0.00010790457</td><td>0</td><td>GALAXY</td><td>--</td><td>0.017501831</td><td>0</td><td>0</td><td>17592186044416</td><td>562949953421312</td></tr>\n",
-       "<tr><td>-7639227707853352960</td><td>1237665128524284395</td><td>0.38422388</td><td>3.725687e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>0.04291892</td><td>0</td><td>0</td><td>17592186044416</td><td>562949953421312</td></tr>\n",
-       "<tr><td>-7639227432975446016</td><td>1237665098459972179</td><td>0.80037284</td><td>7.310519e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>0.027097106</td><td>0</td><td>0</td><td>17592186044416</td><td>562949953421312</td></tr>\n",
-       "<tr><td>-7639226333463818240</td><td>1237665128524350020</td><td>0.7552472</td><td>0.00021918201</td><td>0</td><td>GALAXY</td><td>--</td><td>0.013135433</td><td>0</td><td>0</td><td>17592186044416</td><td>562949953421312</td></tr>\n",
-       "<tr><td>-7639225783708004352</td><td>1237665128524415517</td><td>0.821098</td><td>8.6746266e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>0.024078012</td><td>0</td><td>0</td><td>17592186044416</td><td>562949953421312</td></tr>\n",
-       "<tr><td>-7639225233952190464</td><td>1237665098460037767</td><td>1.4448227</td><td>0.28259814</td><td>0</td><td>GALAXY</td><td>--</td><td>0.011102319</td><td>0</td><td>0</td><td>17592186044416</td><td>562949953421312</td></tr>\n",
-       "<tr><td>-7639224959074283520</td><td>1237665128524153288</td><td>0.921071</td><td>0.00011867128</td><td>0</td><td>GALAXY</td><td>--</td><td>0.018088818</td><td>0</td><td>0</td><td>17592186044416</td><td>562949953421312</td></tr>\n",
-       "<tr><td>-7639224409318469632</td><td>1237665097923035567</td><td>0.9825296</td><td>0.00013494636</td><td>0</td><td>GALAXY</td><td>--</td><td>0.012501717</td><td>0</td><td>0</td><td>17592186044416</td><td>562949953421312</td></tr>\n",
-       "<tr><td>-7639224134440562688</td><td>1237665128524153695</td><td>0.72651744</td><td>0.00017377117</td><td>0</td><td>GALAXY</td><td>--</td><td>0.0122798085</td><td>0</td><td>0</td><td>17592186044416</td><td>562949953421312</td></tr>\n",
-       "<tr><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td></tr>\n",
-       "<tr><td>-7639198021039403008</td><td>1237664834855306140</td><td>0.84657186</td><td>0.00014326358</td><td>0</td><td>GALAXY</td><td>--</td><td>0.010893226</td><td>0</td><td>0</td><td>17592186044416</td><td>562949953421312</td></tr>\n",
-       "<tr><td>-7639197196405682176</td><td>1237665097385771894</td><td>0.956134</td><td>0.00012707015</td><td>0</td><td>GALAXY</td><td>--</td><td>0.014543593</td><td>0</td><td>0</td><td>17592186044416</td><td>562949953421312</td></tr>\n",
-       "<tr><td>-7639196371771961344</td><td>1237665097385772080</td><td>0.9289425</td><td>0.00012458111</td><td>0</td><td>GALAXY</td><td>--</td><td>0.020382047</td><td>0</td><td>0</td><td>17592186044416</td><td>562949953421312</td></tr>\n",
-       "<tr><td>-7639191698847543296</td><td>1237665098459644688</td><td>0.8261575</td><td>6.600007e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>0.044630587</td><td>0</td><td>0</td><td>17592186044416</td><td>562949953421312</td></tr>\n",
-       "<tr><td>-7639191423969636352</td><td>1237665128523891276</td><td>0.87418866</td><td>0.00013456396</td><td>0</td><td>GALAXY</td><td>--</td><td>0.012468994</td><td>0</td><td>0</td><td>17592186044416</td><td>562949953421312</td></tr>\n",
-       "<tr><td>-7639190874213822464</td><td>1237665098459644459</td><td>0.8458766</td><td>0.00012213441</td><td>0</td><td>GALAXY</td><td>--</td><td>0.019898295</td><td>0</td><td>0</td><td>17592186044416</td><td>562949953421312</td></tr>\n",
-       "<tr><td>-7639190599335915520</td><td>1237665098459644444</td><td>0.8814697</td><td>0.000113710026</td><td>0</td><td>GALAXY</td><td>--</td><td>0.013058186</td><td>0</td><td>0</td><td>17592186044416</td><td>562949953421312</td></tr>\n",
-       "<tr><td>-7639190049580101632</td><td>1237665098459710264</td><td>0.29381153</td><td>5.269431e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>0.017101109</td><td>0</td><td>0</td><td>17592186044416</td><td>562949953421312</td></tr>\n",
-       "<tr><td>-7639188950068473856</td><td>1237665098459644427</td><td>0.9214788</td><td>0.00020183463</td><td>0</td><td>GALAXY</td><td>--</td><td>0.011347413</td><td>0</td><td>0</td><td>17592186044416</td><td>562949953421312</td></tr>\n",
-       "<tr><td>-7639187850556846080</td><td>1237664834855174988</td><td>0.7884503</td><td>7.470537e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>0.033761322</td><td>0</td><td>0</td><td>17592186044416</td><td>562949953421312</td></tr>\n",
-       "</table></div>"
-      ],
-      "text/plain": [
-       "<Table length=50>\n",
-       "     SPECOBJID            BESTOBJID      ... EBOSS_TARGET1   EBOSS_TARGET2 \n",
-       "       int64                int64        ...     int64           int64     \n",
-       "-------------------- ------------------- ... -------------- ---------------\n",
-       "-7639230456632422400 1237665127987282622 ... 17592186044416 562949953421312\n",
-       "-7639227982731259904 1237665098459972441 ... 17592186044416 562949953421312\n",
-       "-7639227707853352960 1237665128524284395 ... 17592186044416 562949953421312\n",
-       "-7639227432975446016 1237665098459972179 ... 17592186044416 562949953421312\n",
-       "-7639226333463818240 1237665128524350020 ... 17592186044416 562949953421312\n",
-       "-7639225783708004352 1237665128524415517 ... 17592186044416 562949953421312\n",
-       "-7639225233952190464 1237665098460037767 ... 17592186044416 562949953421312\n",
-       "-7639224959074283520 1237665128524153288 ... 17592186044416 562949953421312\n",
-       "-7639224409318469632 1237665097923035567 ... 17592186044416 562949953421312\n",
-       "-7639224134440562688 1237665128524153695 ... 17592186044416 562949953421312\n",
-       "                 ...                 ... ...            ...             ...\n",
-       "-7639198021039403008 1237664834855306140 ... 17592186044416 562949953421312\n",
-       "-7639197196405682176 1237665097385771894 ... 17592186044416 562949953421312\n",
-       "-7639196371771961344 1237665097385772080 ... 17592186044416 562949953421312\n",
-       "-7639191698847543296 1237665098459644688 ... 17592186044416 562949953421312\n",
-       "-7639191423969636352 1237665128523891276 ... 17592186044416 562949953421312\n",
-       "-7639190874213822464 1237665098459644459 ... 17592186044416 562949953421312\n",
-       "-7639190599335915520 1237665098459644444 ... 17592186044416 562949953421312\n",
-       "-7639190049580101632 1237665098459710264 ... 17592186044416 562949953421312\n",
-       "-7639188950068473856 1237665098459644427 ... 17592186044416 562949953421312\n",
-       "-7639187850556846080 1237664834855174988 ... 17592186044416 562949953421312"
-      ]
-     },
-     "execution_count": 48,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "boss_zcatalog = boss_ids.copy()\n",
     "for col in boss_zcatalog.colnames:\n",
@@ -2622,15 +1279,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 49,
+   "execution_count": null,
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2023-08-16T17:28:08.934952Z",
-     "iopub.status.busy": "2023-08-16T17:28:08.934634Z",
-     "iopub.status.idle": "2023-08-16T17:28:08.959550Z",
-     "shell.execute_reply": "2023-08-16T17:28:08.958635Z",
-     "shell.execute_reply.started": "2023-08-16T17:28:08.934920Z"
-    },
     "tags": []
    },
    "outputs": [],
@@ -2672,6 +1322,13 @@
     "            model_from_zcat=False,\n",
     "            model=boss_model)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/04_HowTos/SPARCL/Plot_SPARCL_Spectra_with_Prospect.ipynb
+++ b/04_HowTos/SPARCL/Plot_SPARCL_Spectra_with_Prospect.ipynb
@@ -534,7 +534,7 @@
     "for k in range(len(desi_spectra.records)):\n",
     "        model_flux[k, :] = desi_spectra.records[k].model\n",
     "\n",
-    "desi_model = (desi_spectra.records[0].wavelength, model_flux[~desi_fully_masked])"
+    "desi_model = (desi_spectra.records[0].wavelength, model_flux[~desi_fully_masked, :])"
    ]
   },
   {
@@ -549,7 +549,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "plotspectra(desi_prospect,\n",

--- a/04_HowTos/SPARCL/Plot_SPARCL_Spectra_with_Prospect.ipynb
+++ b/04_HowTos/SPARCL/Plot_SPARCL_Spectra_with_Prospect.ipynb
@@ -8,7 +8,7 @@
    "source": [
     "__author__ = 'Eric Armengaud, Benjamin Weaver <benjamin.weaver@noirlab.edu>, Alice Jacques <alice.jacques@noirlab.edu>'\n",
     "__version__ = '20240124' # yyyymmdd\n",
-    "__datasets__ = ['sdss_dr16', 'boss_dr16', 'desi_edr']  \n",
+    "__datasets__ = ['sdss_dr16', 'boss_dr16', 'desi_edr']\n",
     "__keywords__ = ['sparcl', 'spectroscopy', 'sdss spectra', 'desi spectra', 'tutorial', 'prospect', 'specutils']"
    ]
   },
@@ -18,7 +18,7 @@
    "source": [
     "# Obtain and plot spectra data using SPARCL, prospect, and specutils\n",
     "\n",
-    "*Credit*: [Eric Armengaud](https://github.com/armengau), Saclay - CEA, is the primary author of prospect. See also the [prospect contributors](https://github.com/desihub/prospect/graphs/contributors)."
+    "*Credit*: [Eric Armengaud](https://github.com/armengau), Saclay - CEA, is the primary author of prospect. See also the [prospect contributors](https://github.com/desihub/prospect/graphs/contributors). [Benjamin Weaver](https://github.com/weaverba137) and [Alice Jacques](https://github.com/jacquesalice) contributed to the development of this notebook."
    ]
   },
   {
@@ -275,11 +275,14 @@
    },
    "outputs": [],
    "source": [
+    "desi_fully_masked = np.zeros((len(desi_spectra.records), ), dtype=bool)\n",
+    "\n",
     "for k in range(len(desi_spectra.records)):\n",
     "    assert np.isfinite(desi_spectra.records[k].flux).all()\n",
     "    assert np.isfinite(desi_spectra.records[k].ivar).all()\n",
     "    if (desi_spectra.records[k].mask > 0).all():\n",
-    "        print(f\"WARNING: Spectrum record {k:d} is fully masked!\")"
+    "        print(f\"WARNING: Spectrum record {k:d} is fully masked!\")\n",
+    "        desi_fully_masked[k] = True"
    ]
   },
   {
@@ -479,10 +482,10 @@
    "source": [
     "desi_prospect = Spectra(bands=['coadd'],\n",
     "                        wave={'coadd': desi_spectra.records[0].wavelength},\n",
-    "                        flux={'coadd': flux},\n",
-    "                        ivar={'coadd': uncertainty},\n",
-    "                        mask={'coadd': mask},\n",
-    "                        fibermap=fibermap,\n",
+    "                        flux={'coadd': flux[~desi_fully_masked, :]},\n",
+    "                        ivar={'coadd': uncertainty[~desi_fully_masked, :]},\n",
+    "                        mask={'coadd': mask[~desi_fully_masked, :]},\n",
+    "                        fibermap=fibermap[~desi_fully_masked],\n",
     "                        meta={'coadd': meta})"
    ]
   },
@@ -530,8 +533,8 @@
     "\n",
     "for k in range(len(desi_spectra.records)):\n",
     "        model_flux[k, :] = desi_spectra.records[k].model\n",
-    "        \n",
-    "desi_model = (desi_spectra.records[0].wavelength, model_flux)"
+    "\n",
+    "desi_model = (desi_spectra.records[0].wavelength, model_flux[~desi_fully_masked])"
    ]
   },
   {
@@ -550,7 +553,7 @@
    "outputs": [],
    "source": [
     "plotspectra(desi_prospect,\n",
-    "            zcatalog=desi_zcatalog,\n",
+    "            zcatalog=desi_zcatalog[~desi_fully_masked],\n",
     "            redrock_cat=None,\n",
     "            notebook=True,\n",
     "            with_thumb_tab=False,\n",
@@ -697,11 +700,14 @@
    },
    "outputs": [],
    "source": [
+    "sdss_fully_masked = np.zeros((len(sdss_spectra.records), ), dtype=bool)\n",
+    "\n",
     "for k in range(len(sdss_spectra.records)):\n",
     "    assert np.isfinite(sdss_spectra.records[k].flux).all()\n",
     "    assert np.isfinite(sdss_spectra.records[k].ivar).all()\n",
     "    if (sdss_spectra.records[k].mask > 0).all():\n",
-    "        print(f\"WARNING: Spectrum record {k:d} is fully masked!\")"
+    "        print(f\"WARNING: Spectrum record {k:d} is fully masked!\")\n",
+    "        sdss_fully_masked[k] = True"
    ]
   },
   {
@@ -817,7 +823,7 @@
     "plugmap.add_column(mag, name='MAG')\n",
     "plugmap.add_column(sdss_ids['primtarget'], name='PRIMTARGET')\n",
     "plugmap.add_column(sdss_ids['sectarget'], name='SECTARGET')\n",
-    "meta['plugmap'] = plugmap[1:]"
+    "meta['plugmap'] = plugmap[~sdss_fully_masked]"
    ]
   },
   {
@@ -853,10 +859,10 @@
    },
    "outputs": [],
    "source": [
-    "sdss_prospect = Spectrum1D(flux=flux[1:, :] * u.Unit('1e-17 erg / (Angstrom cm2 s)'),\n",
+    "sdss_prospect = Spectrum1D(flux=flux[~sdss_fully_masked, :] * u.Unit('1e-17 erg / (Angstrom cm2 s)'),\n",
     "                           spectral_axis=sdss_spectra.records[0].wavelength * u.Unit('Angstrom'),\n",
-    "                           uncertainty=InverseVariance(uncertainty[1:, :]),\n",
-    "                           mask=mask[1:, :] != 0,\n",
+    "                           uncertainty=InverseVariance(uncertainty[~sdss_fully_masked, :]),\n",
+    "                           mask=mask[~sdss_fully_masked, :] != 0,\n",
     "                           meta=meta)"
    ]
   },
@@ -908,8 +914,8 @@
     "\n",
     "for k in range(len(sdss_spectra.records)):\n",
     "        model_flux[k, :] = sdss_spectra.records[k].model\n",
-    "        \n",
-    "sdss_model = (sdss_spectra.records[0].wavelength, model_flux[1:, :])"
+    "\n",
+    "sdss_model = (sdss_spectra.records[0].wavelength, model_flux[~sdss_fully_masked, :])"
    ]
   },
   {
@@ -930,7 +936,7 @@
    "outputs": [],
    "source": [
     "plotspectra(sdss_prospect,\n",
-    "            zcatalog=sdss_zcatalog[1:],\n",
+    "            zcatalog=sdss_zcatalog[~sdss_fully_masked],\n",
     "            redrock_cat=None,\n",
     "            notebook=True,\n",
     "            with_thumb_tab=False,\n",
@@ -975,7 +981,7 @@
     "    AND z.mjd = 58131\n",
     "    AND z.class = 'GALAXY'\n",
     "    AND z.zwarning = 0\n",
-    "ORDER BY z.specobjid \n",
+    "ORDER BY z.specobjid\n",
     "LIMIT 50\n",
     "\"\"\"\n",
     "boss_ids = qc.query(sql=q, fmt='table')\n",
@@ -1078,11 +1084,14 @@
    },
    "outputs": [],
    "source": [
+    "boss_fully_masked = np.zeros((len(boss_spectra.records), ), dtype=bool)\n",
+    "\n",
     "for k in range(len(boss_spectra.records)):\n",
     "    assert np.isfinite(boss_spectra.records[k].flux).all()\n",
     "    assert np.isfinite(boss_spectra.records[k].ivar).all()\n",
     "    if (boss_spectra.records[k].mask > 0).all():\n",
-    "        print(f\"WARNING: Spectrum record {k:d} is fully masked!\")"
+    "        print(f\"WARNING: Spectrum record {k:d} is fully masked!\")\n",
+    "        boss_fully_masked[k] = True"
    ]
   },
   {
@@ -1193,7 +1202,7 @@
     "plugmap.add_column(boss_ids['eboss_target0'], name='EBOSS_TARGET0')\n",
     "plugmap.add_column(boss_ids['eboss_target1'], name='EBOSS_TARGET1')\n",
     "plugmap.add_column(boss_ids['eboss_target2'], name='EBOSS_TARGET2')\n",
-    "meta['plugmap'] = plugmap"
+    "meta['plugmap'] = plugmap[~boss_fully_masked]"
    ]
   },
   {
@@ -1233,10 +1242,10 @@
    },
    "outputs": [],
    "source": [
-    "boss_prospect = Spectrum1D(flux=flux * u.Unit('1e-17 erg / (Angstrom cm2 s)'),\n",
+    "boss_prospect = Spectrum1D(flux=flux[~boss_fully_masked, :] * u.Unit('1e-17 erg / (Angstrom cm2 s)'),\n",
     "                           spectral_axis=boss_spectra.records[0].wavelength * u.Unit('Angstrom'),\n",
-    "                           uncertainty=InverseVariance(uncertainty),\n",
-    "                           mask=mask != 0,\n",
+    "                           uncertainty=InverseVariance(uncertainty[~boss_fully_masked, :]),\n",
+    "                           mask=mask[~boss_fully_masked, :] != 0,\n",
     "                           meta=meta)"
    ]
   },
@@ -1290,8 +1299,8 @@
     "\n",
     "for k in range(len(boss_spectra.records)):\n",
     "        model_flux[k, :] = boss_spectra.records[k].model\n",
-    "        \n",
-    "boss_model = (boss_spectra.records[0].wavelength, model_flux)"
+    "\n",
+    "boss_model = (boss_spectra.records[0].wavelength, model_flux[~boss_fully_masked, :])"
    ]
   },
   {
@@ -1312,7 +1321,7 @@
    "outputs": [],
    "source": [
     "plotspectra(boss_prospect,\n",
-    "            zcatalog=boss_zcatalog,\n",
+    "            zcatalog=boss_zcatalog[~boss_fully_masked],\n",
     "            redrock_cat=None,\n",
     "            notebook=True,\n",
     "            with_thumb_tab=False,\n",


### PR DESCRIPTION
This PR adds a test for fully-masked spectra, which cause problems for current versions of Prospect. The test is added to DESI and BOSS spectra as well, for completeness.

This notebook also demonstrates how to hide only a particular class of warning that we don't care about.

Please test, then we'll update the HTML file, and add the cell outputs back into the notebook.