### PR TITLE
Updated metadata to automatically select DRAGONS-3.2.2 (DL,Py3.10.14)…

### DIFF
--- a/04_HowTos/DataReduction/DRAGONS_reduction_examples/Flamingos2_Imaging_BrownDwarf/Flamingos2_Imaging_BrownDwarf.html
+++ b/04_HowTos/DataReduction/DRAGONS_reduction_examples/Flamingos2_Imaging_BrownDwarf/Flamingos2_Imaging_BrownDwarf.html
@@ -7519,7 +7519,7 @@ a.anchor-link {
 <div class="cm-editor cm-s-jupyter">
 <div class="highlight hl-ipython3"><pre><span></span><span class="n">__nbid__</span> <span class="o">=</span> <span class="s1">'0038'</span>
 <span class="n">__author__</span> <span class="o">=</span> <span class="s1">'Brian Merino &lt;brian.merino@noirlab.edu&gt;, Vinicius Placco &lt;vinicius.placco@noirlab.edu&gt;'</span>
-<span class="n">__version__</span> <span class="o">=</span> <span class="s1">'20240606'</span> <span class="c1"># yyyymmdd; version datestamp of this notebook</span>
+<span class="n">__version__</span> <span class="o">=</span> <span class="s1">'20241209'</span> <span class="c1"># yyyymmdd; version datestamp of this notebook</span>
 <span class="n">__keywords__</span> <span class="o">=</span> <span class="p">[</span><span class="s1">'flamingos-2'</span><span class="p">,</span><span class="s1">'gemini'</span><span class="p">,</span><span class="s1">'browndwarf'</span><span class="p">,</span><span class="s1">'dwarf'</span><span class="p">,</span><span class="s1">'dragons'</span><span class="p">]</span>
 </pre></div>
 </div>

--- a/04_HowTos/DataReduction/DRAGONS_reduction_examples/Flamingos2_Imaging_BrownDwarf/Flamingos2_Imaging_BrownDwarf.ipynb
+++ b/04_HowTos/DataReduction/DRAGONS_reduction_examples/Flamingos2_Imaging_BrownDwarf/Flamingos2_Imaging_BrownDwarf.ipynb
@@ -8,7 +8,7 @@
    "source": [
     "__nbid__ = '0038'\n",
     "__author__ = 'Brian Merino <brian.merino@noirlab.edu>, Vinicius Placco <vinicius.placco@noirlab.edu>'\n",
-    "__version__ = '20240606' # yyyymmdd; version datestamp of this notebook\n",
+    "__version__ = '20241209' # yyyymmdd; version datestamp of this notebook\n",
     "__keywords__ = ['flamingos-2','gemini','browndwarf','dwarf','dragons']"
    ]
   },
@@ -603,9 +603,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "DRAGONS-3.2.1 (Py3.10)",
+   "display_name": "DRAGONS-3.2.2 (DL,Py3.10.14)",
    "language": "python",
-   "name": "dragons-3.2.1"
+   "name": "dragons-3.2.2"
   },
   "language_info": {
    "codemirror_mode": {

--- a/04_HowTos/DataReduction/DRAGONS_reduction_examples/GMOS_Imaging_Galaxy/GMOS_Imaging_Galaxy.html
+++ b/04_HowTos/DataReduction/DRAGONS_reduction_examples/GMOS_Imaging_Galaxy/GMOS_Imaging_Galaxy.html
@@ -7519,7 +7519,7 @@ a.anchor-link {
 <div class="cm-editor cm-s-jupyter">
 <div class="highlight hl-ipython3"><pre><span></span><span class="n">__nbid__</span> <span class="o">=</span> <span class="s1">'0039'</span>
 <span class="n">__author__</span> <span class="o">=</span> <span class="s1">'Brian Merino &lt;brian.merino@noirlab.edu&gt;, Susan Ridgway &lt;susan.ridgway@noirlab.edu&gt;, Vinicius Placco &lt;vinicius.placco@noirlab.edu&gt;'</span>
-<span class="n">__version__</span> <span class="o">=</span> <span class="s1">'20240606'</span> <span class="c1"># yyyymmdd; version datestamp of this notebook</span>
+<span class="n">__version__</span> <span class="o">=</span> <span class="s1">'20241209'</span> <span class="c1"># yyyymmdd; version datestamp of this notebook</span>
 <span class="n">__keywords__</span> <span class="o">=</span> <span class="p">[</span><span class="s1">'gmos'</span><span class="p">,</span><span class="s1">'gemini'</span><span class="p">,</span><span class="s1">'galaxy'</span><span class="p">,</span><span class="s1">'dragons'</span><span class="p">]</span>
 </pre></div>
 </div>

--- a/04_HowTos/DataReduction/DRAGONS_reduction_examples/GMOS_Imaging_Galaxy/GMOS_Imaging_Galaxy.ipynb
+++ b/04_HowTos/DataReduction/DRAGONS_reduction_examples/GMOS_Imaging_Galaxy/GMOS_Imaging_Galaxy.ipynb
@@ -8,7 +8,7 @@
    "source": [
     "__nbid__ = '0039'\n",
     "__author__ = 'Brian Merino <brian.merino@noirlab.edu>, Susan Ridgway <susan.ridgway@noirlab.edu>, Vinicius Placco <vinicius.placco@noirlab.edu>'\n",
-    "__version__ = '20240606' # yyyymmdd; version datestamp of this notebook\n",
+    "__version__ = '20241209' # yyyymmdd; version datestamp of this notebook\n",
     "__keywords__ = ['gmos','gemini','galaxy','dragons']"
    ]
   },
@@ -485,9 +485,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "DRAGONS-3.2.1 (Py3.10)",
+   "display_name": "DRAGONS-3.2.2 (DL,Py3.10.14)",
    "language": "python",
-   "name": "dragons-3.2.1"
+   "name": "dragons-3.2.2"
   },
   "language_info": {
    "codemirror_mode": {

--- a/04_HowTos/DataReduction/DRAGONS_reduction_examples/GMOS_Imaging_StarryField/GMOS_Imaging_StarryField.html
+++ b/04_HowTos/DataReduction/DRAGONS_reduction_examples/GMOS_Imaging_StarryField/GMOS_Imaging_StarryField.html
@@ -7519,7 +7519,7 @@ a.anchor-link {
 <div class="cm-editor cm-s-jupyter">
 <div class="highlight hl-ipython3"><pre><span></span><span class="n">__nbid__</span> <span class="o">=</span> <span class="s1">'0040'</span>
 <span class="n">__author__</span> <span class="o">=</span> <span class="s1">'Brian Merino &lt;brian.merino@noirlab.edu&gt;, Vinicius Placco &lt;vinicius.placco@noirlab.edu&gt;'</span>
-<span class="n">__version__</span> <span class="o">=</span> <span class="s1">'20240606'</span> <span class="c1"># yyyymmdd; version datestamp of this notebook</span>
+<span class="n">__version__</span> <span class="o">=</span> <span class="s1">'20241209'</span> <span class="c1"># yyyymmdd; version datestamp of this notebook</span>
 <span class="n">__keywords__</span> <span class="o">=</span> <span class="p">[</span><span class="s1">'gmos'</span><span class="p">,</span><span class="s1">'gemini'</span><span class="p">,</span><span class="s1">'stars'</span><span class="p">,</span><span class="s1">'dragons'</span><span class="p">]</span>
 </pre></div>
 </div>

--- a/04_HowTos/DataReduction/DRAGONS_reduction_examples/GMOS_Imaging_StarryField/GMOS_Imaging_StarryField.ipynb
+++ b/04_HowTos/DataReduction/DRAGONS_reduction_examples/GMOS_Imaging_StarryField/GMOS_Imaging_StarryField.ipynb
@@ -8,7 +8,7 @@
    "source": [
     "__nbid__ = '0040'\n",
     "__author__ = 'Brian Merino <brian.merino@noirlab.edu>, Vinicius Placco <vinicius.placco@noirlab.edu>'\n",
-    "__version__ = '20240606' # yyyymmdd; version datestamp of this notebook\n",
+    "__version__ = '20241209' # yyyymmdd; version datestamp of this notebook\n",
     "__keywords__ = ['gmos','gemini','stars','dragons']"
    ]
   },
@@ -528,9 +528,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "DRAGONS-3.2.1 (Py3.10)",
+   "display_name": "DRAGONS-3.2.2 (DL,Py3.10.14)",
    "language": "python",
-   "name": "dragons-3.2.1"
+   "name": "dragons-3.2.2"
   },
   "language_info": {
    "codemirror_mode": {

--- a/04_HowTos/DataReduction/DRAGONS_reduction_examples/GMOS_longslit_WhiteDwarf/GMOS_longslit_WhiteDwarf.html
+++ b/04_HowTos/DataReduction/DRAGONS_reduction_examples/GMOS_longslit_WhiteDwarf/GMOS_longslit_WhiteDwarf.html
@@ -7519,7 +7519,7 @@ a.anchor-link {
 <div class="cm-editor cm-s-jupyter">
 <div class="highlight hl-ipython3"><pre><span></span><span class="n">__nbid__</span> <span class="o">=</span> <span class="s1">'0041'</span>
 <span class="n">__author__</span> <span class="o">=</span> <span class="s1">'Brian Merino &lt;brian.merino@noirlab.edu&gt;, Vinicius Placco &lt;vinicius.placco@noirlab.edu&gt;'</span>
-<span class="n">__version__</span> <span class="o">=</span> <span class="s1">'20240606'</span> <span class="c1"># yyyymmdd; version datestamp of this notebook</span>
+<span class="n">__version__</span> <span class="o">=</span> <span class="s1">'20241209'</span> <span class="c1"># yyyymmdd; version datestamp of this notebook</span>
 <span class="n">__keywords__</span> <span class="o">=</span> <span class="p">[</span><span class="s1">'gmos'</span><span class="p">,</span><span class="s1">'gemini'</span><span class="p">,</span><span class="s1">'longslit'</span><span class="p">,</span><span class="s1">'whitedwarf'</span><span class="p">,</span><span class="s1">'dragons'</span><span class="p">]</span>
 </pre></div>
 </div>

--- a/04_HowTos/DataReduction/DRAGONS_reduction_examples/GMOS_longslit_WhiteDwarf/GMOS_longslit_WhiteDwarf.ipynb
+++ b/04_HowTos/DataReduction/DRAGONS_reduction_examples/GMOS_longslit_WhiteDwarf/GMOS_longslit_WhiteDwarf.ipynb
@@ -9,7 +9,7 @@
    "source": [
     "__nbid__ = '0041'\n",
     "__author__ = 'Brian Merino <brian.merino@noirlab.edu>, Vinicius Placco <vinicius.placco@noirlab.edu>'\n",
-    "__version__ = '20240606' # yyyymmdd; version datestamp of this notebook\n",
+    "__version__ = '20241209' # yyyymmdd; version datestamp of this notebook\n",
     "__keywords__ = ['gmos','gemini','longslit','whitedwarf','dragons']"
    ]
   },
@@ -777,9 +777,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "DRAGONS-3.2.1 (Py3.10)",
+   "display_name": "DRAGONS-3.2.2 (DL,Py3.10.14)",
    "language": "python",
-   "name": "dragons-3.2.1"
+   "name": "dragons-3.2.2"
   },
   "language_info": {
    "codemirror_mode": {

--- a/04_HowTos/DataReduction/DRAGONS_reduction_examples/GNIRS_Imaging_GammaRayBurst/GNIRS_Imaging_GammaRayBurst.html
+++ b/04_HowTos/DataReduction/DRAGONS_reduction_examples/GNIRS_Imaging_GammaRayBurst/GNIRS_Imaging_GammaRayBurst.html
@@ -7519,7 +7519,7 @@ a.anchor-link {
 <div class="cm-editor cm-s-jupyter">
 <div class="highlight hl-ipython3"><pre><span></span><span class="n">__nbid__</span> <span class="o">=</span> <span class="s1">'0042'</span>
 <span class="n">__author__</span> <span class="o">=</span> <span class="s1">'Brian Merino &lt;brian.merino@noirlab.edu&gt;, Vinicius Placco &lt;vinicius.placco@noirlab.edu&gt;'</span>
-<span class="n">__version__</span> <span class="o">=</span> <span class="s1">'20240606'</span> <span class="c1"># yyyymmdd; version datestamp of this notebook</span>
+<span class="n">__version__</span> <span class="o">=</span> <span class="s1">'20241209'</span> <span class="c1"># yyyymmdd; version datestamp of this notebook</span>
 <span class="n">__keywords__</span> <span class="o">=</span> <span class="p">[</span><span class="s1">'gnirs'</span><span class="p">,</span><span class="s1">'gemini'</span><span class="p">,</span><span class="s1">'GRB'</span><span class="p">,</span><span class="s1">'dragons'</span><span class="p">]</span>
 </pre></div>
 </div>

--- a/04_HowTos/DataReduction/DRAGONS_reduction_examples/GNIRS_Imaging_GammaRayBurst/GNIRS_Imaging_GammaRayBurst.ipynb
+++ b/04_HowTos/DataReduction/DRAGONS_reduction_examples/GNIRS_Imaging_GammaRayBurst/GNIRS_Imaging_GammaRayBurst.ipynb
@@ -8,7 +8,7 @@
    "source": [
     "__nbid__ = '0042'\n",
     "__author__ = 'Brian Merino <brian.merino@noirlab.edu>, Vinicius Placco <vinicius.placco@noirlab.edu>'\n",
-    "__version__ = '20240606' # yyyymmdd; version datestamp of this notebook\n",
+    "__version__ = '20241209' # yyyymmdd; version datestamp of this notebook\n",
     "__keywords__ = ['gnirs','gemini','GRB','dragons']"
    ]
   },
@@ -534,9 +534,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "DRAGONS-3.2.1 (Py3.10)",
+   "display_name": "DRAGONS-3.2.2 (DL,Py3.10.14)",
    "language": "python",
-   "name": "dragons-3.2.1"
+   "name": "dragons-3.2.2"
   },
   "language_info": {
    "codemirror_mode": {

--- a/04_HowTos/DataReduction/DRAGONS_reduction_examples/GSAOI_Imaging_EllipticalGalaxy/GSAOI_Imaging_EllipticalGalaxy.html
+++ b/04_HowTos/DataReduction/DRAGONS_reduction_examples/GSAOI_Imaging_EllipticalGalaxy/GSAOI_Imaging_EllipticalGalaxy.html
@@ -7519,7 +7519,7 @@ a.anchor-link {
 <div class="cm-editor cm-s-jupyter">
 <div class="highlight hl-ipython3"><pre><span></span><span class="n">__nbid__</span> <span class="o">=</span> <span class="s1">'0043'</span>
 <span class="n">__author__</span> <span class="o">=</span> <span class="s1">'Brian Merino &lt;brian.merino@noirlab.edu&gt;, Vinicius Placco &lt;vinicius.placco@noirlab.edu&gt;'</span>
-<span class="n">__version__</span> <span class="o">=</span> <span class="s1">'20240606'</span> <span class="c1"># yyyymmdd; version datestamp of this notebook</span>
+<span class="n">__version__</span> <span class="o">=</span> <span class="s1">'20241209'</span> <span class="c1"># yyyymmdd; version datestamp of this notebook</span>
 <span class="n">__keywords__</span> <span class="o">=</span> <span class="p">[</span><span class="s1">'gsaoi'</span><span class="p">,</span><span class="s1">'gemini'</span><span class="p">,</span><span class="s1">'galaxy'</span><span class="p">,</span><span class="s1">'dragons'</span><span class="p">]</span>
 </pre></div>
 </div>

--- a/04_HowTos/DataReduction/DRAGONS_reduction_examples/GSAOI_Imaging_EllipticalGalaxy/GSAOI_Imaging_EllipticalGalaxy.ipynb
+++ b/04_HowTos/DataReduction/DRAGONS_reduction_examples/GSAOI_Imaging_EllipticalGalaxy/GSAOI_Imaging_EllipticalGalaxy.ipynb
@@ -8,7 +8,7 @@
    "source": [
     "__nbid__ = '0043'\n",
     "__author__ = 'Brian Merino <brian.merino@noirlab.edu>, Vinicius Placco <vinicius.placco@noirlab.edu>'\n",
-    "__version__ = '20240606' # yyyymmdd; version datestamp of this notebook\n",
+    "__version__ = '20241209' # yyyymmdd; version datestamp of this notebook\n",
     "__keywords__ = ['gsaoi','gemini','galaxy','dragons']"
    ]
   },
@@ -547,9 +547,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "DRAGONS-3.2.1 (Py3.10)",
+   "display_name": "DRAGONS-3.2.2 (DL,Py3.10.14)",
    "language": "python",
-   "name": "dragons-3.2.1"
+   "name": "dragons-3.2.2"
   },
   "language_info": {
    "codemirror_mode": {

--- a/04_HowTos/DataReduction/DRAGONS_reduction_examples/NIRI_Imaging_Supernova/NIRI_Imaging_Supernova.html
+++ b/04_HowTos/DataReduction/DRAGONS_reduction_examples/NIRI_Imaging_Supernova/NIRI_Imaging_Supernova.html
@@ -7519,7 +7519,7 @@ a.anchor-link {
 <div class="cm-editor cm-s-jupyter">
 <div class="highlight hl-ipython3"><pre><span></span><span class="n">__nbid__</span> <span class="o">=</span> <span class="s1">'0044'</span>
 <span class="n">__author__</span> <span class="o">=</span> <span class="s1">'Brian Merino &lt;brian.merino@noirlab.edu&gt;, Vinicius Placco &lt;vinicius.placco@noirlab.edu&gt;'</span>
-<span class="n">__version__</span> <span class="o">=</span> <span class="s1">'20240606'</span> <span class="c1"># yyyymmdd; version datestamp of this notebook</span>
+<span class="n">__version__</span> <span class="o">=</span> <span class="s1">'20241209'</span> <span class="c1"># yyyymmdd; version datestamp of this notebook</span>
 <span class="n">__keywords__</span> <span class="o">=</span> <span class="p">[</span><span class="s1">'niri'</span><span class="p">,</span><span class="s1">'gemini'</span><span class="p">,</span><span class="s1">'supernova'</span><span class="p">,</span><span class="s1">'dragons'</span><span class="p">]</span>
 </pre></div>
 </div>

--- a/04_HowTos/DataReduction/DRAGONS_reduction_examples/NIRI_Imaging_Supernova/NIRI_Imaging_Supernova.ipynb
+++ b/04_HowTos/DataReduction/DRAGONS_reduction_examples/NIRI_Imaging_Supernova/NIRI_Imaging_Supernova.ipynb
@@ -8,7 +8,7 @@
    "source": [
     "__nbid__ = '0044'\n",
     "__author__ = 'Brian Merino <brian.merino@noirlab.edu>, Vinicius Placco <vinicius.placco@noirlab.edu>'\n",
-    "__version__ = '20240606' # yyyymmdd; version datestamp of this notebook\n",
+    "__version__ = '20241209' # yyyymmdd; version datestamp of this notebook\n",
     "__keywords__ = ['niri','gemini','supernova','dragons']"
    ]
   },
@@ -633,9 +633,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "DRAGONS-3.2.1 (Py3.10)",
+   "display_name": "DRAGONS-3.2.2 (DL,Py3.10.14)",
    "language": "python",
-   "name": "dragons-3.2.1"
+   "name": "dragons-3.2.2"
   },
   "language_info": {
    "codemirror_mode": {


### PR DESCRIPTION
Hello! The DataLab's DRAGONS kernel has been updated, so I updated the DRAGONS notebook's metadata to select the correct kernel automatically. 

The DRAGONS update was minor and should only have affected how it handles GHOST data, so these notebooks shouldn't be affected. Although these notebooks aren't affected, the metadata caused the notebooks to prompt the user to select what kernel they want to use. So, I updated the metadata to avoid any confusion.

Can you open the notebooks in GP13 to ensure the correct kernel (DRAGONS-3.2.2 (DL,Py3.10.14)) is selected by default?