### PR TITLE
Break up long-running query in DR1 notebook

### DIFF
--- a/04_HowTos/QueryClient/How_to_query_DESI_DR1_Data.html
+++ b/04_HowTos/QueryClient/How_to_query_DESI_DR1_Data.html
@@ -7520,7 +7520,7 @@ a.anchor-link {
 <div class="cm-editor cm-s-jupyter">
 <div class="highlight hl-ipython3"><pre><span></span><span class="n">__nbid__</span> <span class="o">=</span> <span class="s1">'0073'</span>
 <span class="n">__author__</span> <span class="o">=</span> <span class="s1">'Benjamin Weaver &lt;benjamin.weaver@noirlab.edu&gt;, Alice Jacques &lt;alice.jacques@noirlab.edu&gt;, Astro Data Lab Team &lt;datalab@noirlab.edu&gt;'</span>
-<span class="n">__version__</span> <span class="o">=</span> <span class="s1">'20250317'</span> <span class="c1"># yyyymmdd</span>
+<span class="n">__version__</span> <span class="o">=</span> <span class="s1">'20250424'</span> <span class="c1"># yyyymmdd</span>
 <span class="n">__datasets__</span> <span class="o">=</span> <span class="p">[</span><span class="s1">'desi_dr1'</span><span class="p">]</span>
 <span class="n">__keywords__</span> <span class="o">=</span> <span class="p">[</span><span class="s1">'query'</span><span class="p">,</span> <span class="s1">'DESI'</span><span class="p">]</span>
 </pre></div>
@@ -7720,8 +7720,9 @@ Usually, but not always, the unique identifier will also have a <code>UNIQUE</co
 <div class="jp-InputPrompt jp-InputArea-prompt">In [ ]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
 <div class="cm-editor cm-s-jupyter">
-<div class="highlight hl-ipython3"><pre><span></span><span class="c1">#token = ac.login(input("Enter user name: (+ENTER) "),getpass("Enter password: (+ENTER) "))</span>
-<span class="n">ac</span><span class="o">.</span><span class="n">whoAmI</span><span class="p">()</span>
+<div class="highlight hl-ipython3"><pre><span></span><span class="c1"># from getpass import getpass</span>
+<span class="c1"># token = ac.login(input("Enter user name: (+ENTER) "), getpass("Enter password: (+ENTER) "))</span>
+<span class="c1"># ac.whoAmI()</span>
 </pre></div>
 </div>
 </div>
@@ -8255,7 +8256,7 @@ Usually, but not always, the unique identifier will also have a <code>UNIQUE</co
 <span class="w">              </span><span class="k">JOIN</span><span class="w"> </span><span class="n">desi_dr1</span><span class="p">.</span><span class="n">exposure</span><span class="w"> </span><span class="k">AS</span><span class="w"> </span><span class="n">ee</span><span class="w"> </span><span class="k">ON</span><span class="w"> </span><span class="n">ff</span><span class="p">.</span><span class="n">tileid</span><span class="w"> </span><span class="o">=</span><span class="w"> </span><span class="n">ee</span><span class="p">.</span><span class="n">tileid</span><span class="w"> </span><span class="k">GROUP</span><span class="w"> </span><span class="k">BY</span><span class="w"> </span><span class="n">tt</span><span class="p">.</span><span class="n">targetid</span><span class="p">)</span><span class="w"> </span><span class="k">AS</span><span class="w"> </span><span class="n">q1</span><span class="w"> </span><span class="k">ON</span><span class="w"> </span><span class="n">f</span><span class="p">.</span><span class="n">targetid</span><span class="w"> </span><span class="o">=</span><span class="w"> </span><span class="n">q1</span><span class="p">.</span><span class="n">targetid</span>
 <span class="w">    </span><span class="k">JOIN</span><span class="w"> </span><span class="n">desi_dr1</span><span class="p">.</span><span class="n">exposure</span><span class="w"> </span><span class="k">AS</span><span class="w"> </span><span class="n">e</span><span class="w"> </span><span class="k">ON</span><span class="w"> </span><span class="n">f</span><span class="p">.</span><span class="n">tileid</span><span class="w"> </span><span class="o">=</span><span class="w"> </span><span class="n">e</span><span class="p">.</span><span class="n">tileid</span><span class="w"> </span><span class="k">ORDER</span><span class="w"> </span><span class="k">BY</span><span class="w"> </span><span class="n">q1</span><span class="p">.</span><span class="n">targetid</span><span class="p">,</span><span class="w"> </span><span class="n">e</span><span class="p">.</span><span class="n">expid</span><span class="p">;</span>
 </pre></div>
-<p><em>WARNING</em>: This query will take several minutes, please be patient.</p>
+<p>Note that this consists of an inner query, <code>(SELECT tt.targetid FROM desi_dr1.target AS tt ...) AS q1</code> and an outer query that treats <code>q1</code> as if it were a table. In some cases we can run this query exactly as written above, but due to time limitations, we'll split this query apart and run them asynchronously, saving the intermediate results in a MyDB table.</p>
 </div>
 </div>
 </div>
@@ -8267,17 +8268,30 @@ Usually, but not always, the unique identifier will also have a <code>UNIQUE</co
 <div class="jp-InputPrompt jp-InputArea-prompt">In [ ]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
 <div class="cm-editor cm-s-jupyter">
-<div class="highlight hl-ipython3"><pre><span></span><span class="c1"># Find all targetids that have observations.</span>
+<div class="highlight hl-ipython3"><pre><span></span><span class="c1">#</span>
+<span class="c1"># Clean up any existing intermediate table.</span>
 <span class="c1">#</span>
-<span class="n">q1</span> <span class="o">=</span> <span class="s2">"""SELECT tt.targetid FROM desi_dr1.target AS tt JOIN desi_dr1.fiberassign AS ff ON tt.targetid = ff.targetid</span>
-<span class="s2">    JOIN desi_dr1.exposure AS ee ON ff.tileid = ee.tileid GROUP BY tt.targetid"""</span>
+<span class="n">overwrite_q1_table</span> <span class="o">=</span> <span class="kc">False</span>
+<span class="n">q1_table</span> <span class="o">=</span> <span class="s1">'desi_dr1_survey_progress_q1'</span>
+<span class="n">mydb_tables</span> <span class="o">=</span> <span class="n">qc</span><span class="o">.</span><span class="n">mydb_list</span><span class="p">()</span><span class="o">.</span><span class="n">split</span><span class="p">(</span><span class="s1">'</span><span class="se">\n</span><span class="s1">'</span><span class="p">)</span>
+<span class="k">if</span> <span class="n">q1_table</span> <span class="ow">in</span> <span class="n">mydb_tables</span> <span class="ow">and</span> <span class="ow">not</span> <span class="n">overwrite_q1_table</span><span class="p">:</span>
+    <span class="nb">print</span><span class="p">(</span><span class="sa">f</span><span class="s2">"Using existing survey progress table </span><span class="si">{</span><span class="n">q1_table</span><span class="si">}</span><span class="s2">."</span><span class="p">)</span>
+<span class="k">else</span><span class="p">:</span>
+    <span class="n">qc</span><span class="o">.</span><span class="n">mydb_drop</span><span class="p">(</span><span class="s1">'desi_dr1_survey_progress_q1'</span><span class="p">)</span>
+    <span class="c1">#</span>
+    <span class="c1"># Find all targetids that have observations.</span>
+    <span class="c1">#</span>
+    <span class="n">q1</span> <span class="o">=</span> <span class="s2">"""SELECT tt.targetid FROM desi_dr1.target AS tt JOIN desi_dr1.fiberassign AS ff ON tt.targetid = ff.targetid</span>
+<span class="s2">        JOIN desi_dr1.exposure AS ee ON ff.tileid = ee.tileid GROUP BY tt.targetid;"""</span>
+    <span class="n">response</span> <span class="o">=</span> <span class="n">qc</span><span class="o">.</span><span class="n">query</span><span class="p">(</span><span class="n">sql</span><span class="o">=</span><span class="n">q1</span><span class="p">,</span> <span class="n">out</span><span class="o">=</span><span class="sa">f</span><span class="s1">'mydb://</span><span class="si">{</span><span class="n">q1_table</span><span class="si">}</span><span class="s1">'</span><span class="p">,</span> <span class="n">async_</span><span class="o">=</span><span class="kc">True</span><span class="p">,</span> <span class="n">wait</span><span class="o">=</span><span class="kc">True</span><span class="p">,</span> <span class="n">poll</span><span class="o">=</span><span class="mi">60</span><span class="p">,</span> <span class="n">verbose</span><span class="o">=</span><span class="kc">True</span><span class="p">,</span> <span class="n">timeout</span><span class="o">=</span><span class="mi">6000</span><span class="p">)</span>
+    <span class="nb">print</span><span class="p">(</span><span class="n">response</span><span class="p">)</span>
 <span class="c1">#</span>
-<span class="c1"># Find the exposure times for the targetids that have been observed</span>
+<span class="c1"># Find the exposure dates (MJD) for the targetids that have been observed</span>
 <span class="c1">#</span>
 <span class="n">q2</span> <span class="o">=</span> <span class="sa">f</span><span class="s2">"""SELECT f.targetid, e.expid, e.mjd FROM desi_dr1.fiberassign AS f</span>
-<span class="s2">    JOIN (</span><span class="si">{</span><span class="n">q1</span><span class="si">}</span><span class="s2">) AS q1 ON f.targetid = q1.targetid</span>
+<span class="s2">    JOIN mydb://</span><span class="si">{</span><span class="n">q1_table</span><span class="si">}</span><span class="s2"> AS q1 ON f.targetid = q1.targetid</span>
 <span class="s2">    JOIN desi_dr1.exposure AS e ON f.tileid = e.tileid ORDER BY q1.targetid, e.expid;"""</span>
-<span class="n">response</span> <span class="o">=</span> <span class="n">qc</span><span class="o">.</span><span class="n">query</span><span class="p">(</span><span class="n">sql</span><span class="o">=</span><span class="n">q2</span><span class="p">,</span> <span class="n">fmt</span><span class="o">=</span><span class="s1">'pandas'</span><span class="p">,</span> <span class="n">timeout</span><span class="o">=</span><span class="mi">600</span><span class="p">)</span>
+<span class="n">response</span> <span class="o">=</span> <span class="n">qc</span><span class="o">.</span><span class="n">query</span><span class="p">(</span><span class="n">sql</span><span class="o">=</span><span class="n">q2</span><span class="p">,</span> <span class="n">fmt</span><span class="o">=</span><span class="s1">'pandas'</span><span class="p">,</span> <span class="n">async_</span><span class="o">=</span><span class="kc">True</span><span class="p">,</span> <span class="n">wait</span><span class="o">=</span><span class="kc">True</span><span class="p">,</span> <span class="n">poll</span><span class="o">=</span><span class="mi">60</span><span class="p">,</span> <span class="n">verbose</span><span class="o">=</span><span class="kc">True</span><span class="p">,</span> <span class="n">timeout</span><span class="o">=</span><span class="mi">6000</span><span class="p">)</span>
 <span class="n">targetid</span> <span class="o">=</span> <span class="n">response</span><span class="o">.</span><span class="n">targetid</span><span class="o">.</span><span class="n">values</span>
 <span class="n">expid</span> <span class="o">=</span> <span class="n">response</span><span class="o">.</span><span class="n">expid</span><span class="o">.</span><span class="n">values</span>
 <span class="n">mjd</span> <span class="o">=</span> <span class="n">response</span><span class="o">.</span><span class="n">mjd</span><span class="o">.</span><span class="n">values</span>

--- a/04_HowTos/QueryClient/How_to_query_DESI_DR1_Data.ipynb
+++ b/04_HowTos/QueryClient/How_to_query_DESI_DR1_Data.ipynb
@@ -8,7 +8,7 @@
    "source": [
     "__nbid__ = '0073'\n",
     "__author__ = 'Benjamin Weaver <benjamin.weaver@noirlab.edu>, Alice Jacques <alice.jacques@noirlab.edu>, Astro Data Lab Team <datalab@noirlab.edu>'\n",
-    "__version__ = '20250317' # yyyymmdd\n",
+    "__version__ = '20250424' # yyyymmdd\n",
     "__datasets__ = ['desi_dr1']\n",
     "__keywords__ = ['query', 'DESI']"
    ]
@@ -89,15 +89,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2025-03-05T23:41:20.279487Z",
-     "iopub.status.busy": "2025-03-05T23:41:20.279106Z",
-     "iopub.status.idle": "2025-03-05T23:41:21.532244Z",
-     "shell.execute_reply": "2025-03-05T23:41:21.531595Z",
-     "shell.execute_reply.started": "2025-03-05T23:41:20.279466Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import pandas as pd\n",
@@ -206,19 +198,12 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2025-03-06T00:22:12.833643Z",
-     "iopub.status.busy": "2025-03-06T00:22:12.833375Z",
-     "iopub.status.idle": "2025-03-06T00:22:12.869860Z",
-     "shell.execute_reply": "2025-03-06T00:22:12.869466Z",
-     "shell.execute_reply.started": "2025-03-06T00:22:12.833630Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
-    "#token = ac.login(input(\"Enter user name: (+ENTER) \"),getpass(\"Enter password: (+ENTER) \"))\n",
-    "ac.whoAmI()"
+    "# from getpass import getpass\n",
+    "# token = ac.login(input(\"Enter user name: (+ENTER) \"), getpass(\"Enter password: (+ENTER) \"))\n",
+    "# ac.whoAmI()"
    ]
   },
   {
@@ -248,15 +233,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2025-03-06T00:22:58.417472Z",
-     "iopub.status.busy": "2025-03-06T00:22:58.417213Z",
-     "iopub.status.idle": "2025-03-06T00:22:58.507305Z",
-     "shell.execute_reply": "2025-03-06T00:22:58.506888Z",
-     "shell.execute_reply.started": "2025-03-06T00:22:58.417458Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "response = qc.query(sql='SELECT COUNT(tileid) FROM desi_dr1.tile;', fmt='pandas', timeout=600)\n",
@@ -277,15 +254,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2025-03-06T00:23:22.335531Z",
-     "iopub.status.busy": "2025-03-06T00:23:22.335280Z",
-     "iopub.status.idle": "2025-03-06T00:23:22.427382Z",
-     "shell.execute_reply": "2025-03-06T00:23:22.426964Z",
-     "shell.execute_reply.started": "2025-03-06T00:23:22.335516Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "response = qc.query(sql='SELECT night, expid FROM desi_dr1.exposure WHERE tileid = 100;', fmt='pandas', timeout=600)\n",
@@ -307,15 +276,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2025-03-06T00:23:41.453338Z",
-     "iopub.status.busy": "2025-03-06T00:23:41.452905Z",
-     "iopub.status.idle": "2025-03-06T00:23:41.538423Z",
-     "shell.execute_reply": "2025-03-06T00:23:41.537556Z",
-     "shell.execute_reply.started": "2025-03-06T00:23:41.453323Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "response = qc.query(sql='SELECT tileid, survey, program FROM desi_dr1.exposure WHERE night = 20210115;', fmt='pandas', timeout=600)\n",
@@ -338,15 +299,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2025-03-06T00:24:33.816208Z",
-     "iopub.status.busy": "2025-03-06T00:24:33.815814Z",
-     "iopub.status.idle": "2025-03-06T00:24:33.913618Z",
-     "shell.execute_reply": "2025-03-06T00:24:33.913076Z",
-     "shell.execute_reply.started": "2025-03-06T00:24:33.816189Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "q = f\"SELECT * FROM desi_dr1.target WHERE (desi_target & {desi_mask.ELG:d}) != 0 LIMIT 10;\"\n",
@@ -379,15 +332,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2025-03-06T00:24:53.491579Z",
-     "iopub.status.busy": "2025-03-06T00:24:53.491349Z",
-     "iopub.status.idle": "2025-03-06T00:24:53.581317Z",
-     "shell.execute_reply": "2025-03-06T00:24:53.580827Z",
-     "shell.execute_reply.started": "2025-03-06T00:24:53.491565Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "response = qc.query(sql=\"SELECT spectype, subtype, z FROM desi_dr1.zpix WHERE spectype = 'STAR' AND subtype != '' LIMIT 20;\", fmt='pandas', timeout=600)\n",
@@ -412,15 +357,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2025-03-06T00:25:25.003331Z",
-     "iopub.status.busy": "2025-03-06T00:25:25.003077Z",
-     "iopub.status.idle": "2025-03-06T00:25:25.095212Z",
-     "shell.execute_reply": "2025-03-06T00:25:25.094791Z",
-     "shell.execute_reply.started": "2025-03-06T00:25:25.003317Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "q = \"\"\"SELECT f.tileid, e.expid, e.night\n",
@@ -447,15 +384,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2025-03-06T00:25:57.209163Z",
-     "iopub.status.busy": "2025-03-06T00:25:57.208915Z",
-     "iopub.status.idle": "2025-03-06T00:25:57.347234Z",
-     "shell.execute_reply": "2025-03-06T00:25:57.346748Z",
-     "shell.execute_reply.started": "2025-03-06T00:25:57.209149Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "q = \"\"\"SELECT p.*, z.*\n",
@@ -470,13 +399,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2025-03-06T00:26:04.084888Z",
-     "iopub.status.busy": "2025-03-06T00:26:04.084609Z",
-     "iopub.status.idle": "2025-03-06T00:26:04.216292Z",
-     "shell.execute_reply": "2025-03-06T00:26:04.215784Z",
-     "shell.execute_reply.started": "2025-03-06T00:26:04.084874Z"
-    },
     "tags": []
    },
    "outputs": [],
@@ -524,15 +446,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2025-03-06T00:26:35.407566Z",
-     "iopub.status.busy": "2025-03-06T00:26:35.407277Z",
-     "iopub.status.idle": "2025-03-06T00:26:46.686046Z",
-     "shell.execute_reply": "2025-03-06T00:26:46.685497Z",
-     "shell.execute_reply.started": "2025-03-06T00:26:35.407552Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "q = \"\"\"SELECT t.nexp, f.tileid, q1.targetid, q1.n_assign\n",
@@ -558,15 +472,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2025-03-06T00:27:28.676947Z",
-     "iopub.status.busy": "2025-03-06T00:27:28.676440Z",
-     "iopub.status.idle": "2025-03-06T00:27:28.784284Z",
-     "shell.execute_reply": "2025-03-06T00:27:28.783477Z",
-     "shell.execute_reply.started": "2025-03-06T00:27:28.676932Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "q3 = \"\"\"SELECT z.* FROM desi_dr1.zpix AS z\n",
@@ -613,15 +519,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2025-03-06T00:28:10.814326Z",
-     "iopub.status.busy": "2025-03-06T00:28:10.813922Z",
-     "iopub.status.idle": "2025-03-06T00:28:10.917639Z",
-     "shell.execute_reply": "2025-03-06T00:28:10.917017Z",
-     "shell.execute_reply.started": "2025-03-06T00:28:10.814307Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "q = \"\"\"SELECT z.targetid, z.spgrp, z.spgrpval, z.tileid, z.z, z.zwarn, z.spectype,\n",
@@ -655,15 +553,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2025-03-06T00:29:10.684351Z",
-     "iopub.status.busy": "2025-03-06T00:29:10.683765Z",
-     "iopub.status.idle": "2025-03-06T00:29:10.808924Z",
-     "shell.execute_reply": "2025-03-06T00:29:10.808257Z",
-     "shell.execute_reply.started": "2025-03-06T00:29:10.684331Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "q = \"\"\"SELECT z.targetid, z.survey, z.program, z.healpix, z.z, z.zwarn, z.spectype,\n",
@@ -692,15 +582,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2025-03-06T00:29:33.969953Z",
-     "iopub.status.busy": "2025-03-06T00:29:33.969699Z",
-     "iopub.status.idle": "2025-03-06T00:29:34.062050Z",
-     "shell.execute_reply": "2025-03-06T00:29:34.061637Z",
-     "shell.execute_reply.started": "2025-03-06T00:29:33.969940Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "q = \"SELECT e.night, COUNT(e.expid) AS n_exp FROM desi_dr1.exposure AS e GROUP BY e.night ORDER BY e.night;\"\n",
@@ -722,15 +604,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2025-03-06T00:29:56.763633Z",
-     "iopub.status.busy": "2025-03-06T00:29:56.763397Z",
-     "iopub.status.idle": "2025-03-06T00:29:56.859416Z",
-     "shell.execute_reply": "2025-03-06T00:29:56.859058Z",
-     "shell.execute_reply.started": "2025-03-06T00:29:56.763619Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "q = \"SELECT e.expid, e.mjd, e.date_obs FROM desi_dr1.exposure AS e WHERE e.night = 20210428 ORDER BY e.expid;\"\n",
@@ -752,15 +626,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2025-03-06T00:30:17.883616Z",
-     "iopub.status.busy": "2025-03-06T00:30:17.883369Z",
-     "iopub.status.idle": "2025-03-06T00:30:20.746185Z",
-     "shell.execute_reply": "2025-03-06T00:30:20.745773Z",
-     "shell.execute_reply.started": "2025-03-06T00:30:17.883603Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "q = \"SELECT COUNT(*) AS n_targets FROM desi_dr1.target;\"\n",
@@ -781,34 +647,39 @@
     "    JOIN desi_dr1.exposure AS e ON f.tileid = e.tileid ORDER BY q1.targetid, e.expid;\n",
     "```\n",
     "\n",
-    "*WARNING*: This query will take several minutes, please be patient."
+    "Note that this consists of an inner query, `(SELECT tt.targetid FROM desi_dr1.target AS tt ...) AS q1` and an outer query that treats `q1` as if it were a table. In some cases we can run this query exactly as written above, but due to time limitations, we'll split this query apart and run them asynchronously, saving the intermediate results in a MyDB table."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2025-03-06T00:31:55.658621Z",
-     "iopub.status.busy": "2025-03-06T00:31:55.658276Z",
-     "iopub.status.idle": "2025-03-06T00:36:18.038746Z",
-     "shell.execute_reply": "2025-03-06T00:36:18.037833Z",
-     "shell.execute_reply.started": "2025-03-06T00:31:55.658607Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
-    "# Find all targetids that have observations.\n",
     "#\n",
-    "q1 = \"\"\"SELECT tt.targetid FROM desi_dr1.target AS tt JOIN desi_dr1.fiberassign AS ff ON tt.targetid = ff.targetid\n",
-    "    JOIN desi_dr1.exposure AS ee ON ff.tileid = ee.tileid GROUP BY tt.targetid\"\"\"\n",
+    "# Clean up any existing intermediate table.\n",
     "#\n",
-    "# Find the exposure times for the targetids that have been observed\n",
+    "overwrite_q1_table = False\n",
+    "q1_table = 'desi_dr1_survey_progress_q1'\n",
+    "mydb_tables = qc.mydb_list().split('\\n')\n",
+    "if q1_table in mydb_tables and not overwrite_q1_table:\n",
+    "    print(f\"Using existing survey progress table {q1_table}.\")\n",
+    "else:\n",
+    "    qc.mydb_drop('desi_dr1_survey_progress_q1')\n",
+    "    #\n",
+    "    # Find all targetids that have observations.\n",
+    "    #\n",
+    "    q1 = \"\"\"SELECT tt.targetid FROM desi_dr1.target AS tt JOIN desi_dr1.fiberassign AS ff ON tt.targetid = ff.targetid\n",
+    "        JOIN desi_dr1.exposure AS ee ON ff.tileid = ee.tileid GROUP BY tt.targetid;\"\"\"\n",
+    "    response = qc.query(sql=q1, out=f'mydb://{q1_table}', async_=True, wait=True, poll=60, verbose=True, timeout=6000)\n",
+    "    print(response)\n",
+    "#\n",
+    "# Find the exposure dates (MJD) for the targetids that have been observed\n",
     "#\n",
     "q2 = f\"\"\"SELECT f.targetid, e.expid, e.mjd FROM desi_dr1.fiberassign AS f\n",
-    "    JOIN ({q1}) AS q1 ON f.targetid = q1.targetid\n",
+    "    JOIN mydb://{q1_table} AS q1 ON f.targetid = q1.targetid\n",
     "    JOIN desi_dr1.exposure AS e ON f.tileid = e.tileid ORDER BY q1.targetid, e.expid;\"\"\"\n",
-    "response = qc.query(sql=q2, fmt='pandas', timeout=600)\n",
+    "response = qc.query(sql=q2, fmt='pandas', async_=True, wait=True, poll=60, verbose=True, timeout=6000)\n",
     "targetid = response.targetid.values\n",
     "expid = response.expid.values\n",
     "mjd = response.mjd.values\n",
@@ -830,15 +701,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2025-03-06T00:37:09.305661Z",
-     "iopub.status.busy": "2025-03-06T00:37:09.305264Z",
-     "iopub.status.idle": "2025-03-06T00:37:10.601412Z",
-     "shell.execute_reply": "2025-03-06T00:37:10.600719Z",
-     "shell.execute_reply.started": "2025-03-06T00:37:09.305645Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "ii = unique_expid.argsort()\n",
@@ -856,15 +719,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2025-03-06T00:37:12.735311Z",
-     "iopub.status.busy": "2025-03-06T00:37:12.735046Z",
-     "iopub.status.idle": "2025-03-06T00:37:13.372639Z",
-     "shell.execute_reply": "2025-03-06T00:37:13.372111Z",
-     "shell.execute_reply.started": "2025-03-06T00:37:12.735298Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "min_mjd = 10*(int(mjd.min())//10)\n",
@@ -905,15 +760,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2025-03-06T00:38:00.080998Z",
-     "iopub.status.busy": "2025-03-06T00:38:00.080740Z",
-     "iopub.status.idle": "2025-03-06T00:38:00.206016Z",
-     "shell.execute_reply": "2025-03-06T00:38:00.205540Z",
-     "shell.execute_reply.started": "2025-03-06T00:38:00.080984Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "q = \"\"\"SELECT p.*, z.*, q3c_dist(p.ra, p.dec, 180.0, 0.0) AS radial_distance\n",
@@ -946,9 +793,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "DESI 23.1 (DL,Py3.10.13)",
+   "display_name": "DESI 25.3 (DL,Py3.10.13)",
    "language": "python",
-   "name": "desi_23.1"
+   "name": "desi_25.3"
   },
   "language_info": {
    "codemirror_mode": {


### PR DESCRIPTION
This PR fixes #270.

The compound query is split up into an inner query which can run asynchronously with the intermediate results stored in MyDB.

Although a solution involving `lastnight` from `desi_dr1.ztile` would be possible in principle, the *plots* resulting from this query expect MJD, and I didn't feel like doing a lot of extra math to convert `lastnight` (YYYYMMDD) into a day number like MJD.