### PR TITLE
GSAOI DRAGONS update

### DIFF
--- a/04_HowTos/DataReduction/DRAGONS_reduction_examples/GSAOI_Imaging_EllipticalGalaxy/GSAOI_Imaging_EllipticalGalaxy.html
+++ b/04_HowTos/DataReduction/DRAGONS_reduction_examples/GSAOI_Imaging_EllipticalGalaxy/GSAOI_Imaging_EllipticalGalaxy.html
@@ -7312,6 +7312,7 @@ a.anchor-link {
                     processEnvironments: true
                 },
                 displayAlign: 'center',
+                messageStyle: 'none',
                 CommonHTML: {
                     linebreaks: {
                     automatic: true
@@ -7519,7 +7520,7 @@ a.anchor-link {
 <div class="cm-editor cm-s-jupyter">
 <div class="highlight hl-ipython3"><pre><span></span><span class="n">__nbid__</span> <span class="o">=</span> <span class="s1">'0043'</span>
 <span class="n">__author__</span> <span class="o">=</span> <span class="s1">'Brian Merino &lt;brian.merino@noirlab.edu&gt;, Vinicius Placco &lt;vinicius.placco@noirlab.edu&gt;'</span>
-<span class="n">__version__</span> <span class="o">=</span> <span class="s1">'20241209'</span> <span class="c1"># yyyymmdd; version datestamp of this notebook</span>
+<span class="n">__version__</span> <span class="o">=</span> <span class="s1">'20250709'</span> <span class="c1"># yyyymmdd; version datestamp of this notebook</span>
 <span class="n">__keywords__</span> <span class="o">=</span> <span class="p">[</span><span class="s1">'gsaoi'</span><span class="p">,</span><span class="s1">'gemini'</span><span class="p">,</span><span class="s1">'galaxy'</span><span class="p">,</span><span class="s1">'dragons'</span><span class="p">]</span>
 </pre></div>
 </div>
@@ -7622,21 +7623,21 @@ a.anchor-link {
 <div class="jp-InputPrompt jp-InputArea-prompt">In [ ]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
 <div class="cm-editor cm-s-jupyter">
-<div class="highlight hl-ipython3"><pre><span></span><span class="kn">import</span> <span class="nn">glob</span>
-<span class="kn">import</span> <span class="nn">os</span> 
-<span class="kn">import</span> <span class="nn">shutil</span>
+<div class="highlight hl-ipython3"><pre><span></span><span class="kn">import</span><span class="w"> </span><span class="nn">glob</span>
+<span class="kn">import</span><span class="w"> </span><span class="nn">os</span> 
+<span class="kn">import</span><span class="w"> </span><span class="nn">shutil</span>
 
-<span class="kn">from</span> <span class="nn">recipe_system</span> <span class="kn">import</span> <span class="n">cal_service</span>
-<span class="kn">from</span> <span class="nn">recipe_system.reduction.coreReduce</span> <span class="kn">import</span> <span class="n">Reduce</span>
+<span class="kn">from</span><span class="w"> </span><span class="nn">recipe_system</span><span class="w"> </span><span class="kn">import</span> <span class="n">cal_service</span>
+<span class="kn">from</span><span class="w"> </span><span class="nn">recipe_system.reduction.coreReduce</span><span class="w"> </span><span class="kn">import</span> <span class="n">Reduce</span>
 
-<span class="kn">from</span> <span class="nn">gempy.adlibrary</span> <span class="kn">import</span> <span class="n">dataselect</span>
-<span class="kn">from</span> <span class="nn">gempy.utils</span> <span class="kn">import</span> <span class="n">logutils</span>
+<span class="kn">from</span><span class="w"> </span><span class="nn">gempy.adlibrary</span><span class="w"> </span><span class="kn">import</span> <span class="n">dataselect</span>
+<span class="kn">from</span><span class="w"> </span><span class="nn">gempy.utils</span><span class="w"> </span><span class="kn">import</span> <span class="n">logutils</span>
 
-<span class="kn">from</span> <span class="nn">astropy.io</span> <span class="kn">import</span> <span class="n">fits</span>
-<span class="kn">from</span> <span class="nn">astropy.wcs</span> <span class="kn">import</span> <span class="n">WCS</span>
+<span class="kn">from</span><span class="w"> </span><span class="nn">astropy.io</span><span class="w"> </span><span class="kn">import</span> <span class="n">fits</span>
+<span class="kn">from</span><span class="w"> </span><span class="nn">astropy.wcs</span><span class="w"> </span><span class="kn">import</span> <span class="n">WCS</span>
 
-<span class="kn">import</span> <span class="nn">matplotlib.pyplot</span> <span class="k">as</span> <span class="nn">plt</span>
-<span class="kn">from</span> <span class="nn">matplotlib.colors</span> <span class="kn">import</span> <span class="n">Normalize</span>
+<span class="kn">import</span><span class="w"> </span><span class="nn">matplotlib.pyplot</span><span class="w"> </span><span class="k">as</span><span class="w"> </span><span class="nn">plt</span>
+<span class="kn">from</span><span class="w"> </span><span class="nn">matplotlib.colors</span><span class="w"> </span><span class="kn">import</span> <span class="n">Normalize</span>
 </pre></div>
 </div>
 </div>
@@ -7662,7 +7663,7 @@ a.anchor-link {
 <div class="jp-InputPrompt jp-InputArea-prompt">In [ ]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
 <div class="cm-editor cm-s-jupyter">
-<div class="highlight hl-ipython3"><pre><span></span><span class="k">def</span> <span class="nf">clean_up</span><span class="p">(</span><span class="n">save_reduced</span><span class="o">=</span><span class="mi">0</span><span class="p">):</span>
+<div class="highlight hl-ipython3"><pre><span></span><span class="k">def</span><span class="w"> </span><span class="nf">clean_up</span><span class="p">(</span><span class="n">save_reduced</span><span class="o">=</span><span class="mi">0</span><span class="p">):</span>
     <span class="c1">#Does the calibrations directory already exist?</span>
     <span class="n">caldb_Exist</span> <span class="o">=</span> <span class="n">os</span><span class="o">.</span><span class="n">path</span><span class="o">.</span><span class="n">exists</span><span class="p">(</span><span class="s1">'./calibrations'</span><span class="p">)</span> 
     
@@ -8072,7 +8073,7 @@ Unlike the other near-IR instruments, the additive offset_sky parameter is used 
 <div class="cm-editor cm-s-jupyter">
 <div class="highlight hl-ipython3"><pre><span></span><span class="n">reduce_target</span> <span class="o">=</span> <span class="n">Reduce</span><span class="p">()</span>
 <span class="n">reduce_target</span><span class="o">.</span><span class="n">files</span><span class="o">.</span><span class="n">extend</span><span class="p">(</span><span class="n">list_of_science_images</span><span class="p">)</span>
-<span class="n">reduce_target</span><span class="o">.</span><span class="n">uparms</span><span class="o">.</span><span class="n">append</span><span class="p">((</span><span class="s1">'skyCorrect:offset_sky'</span><span class="p">,</span> <span class="kc">False</span><span class="p">))</span>
+<span class="n">reduce_target</span><span class="o">.</span><span class="n">uparms</span><span class="p">[</span><span class="s1">'skyCorrect:offset_sky'</span><span class="p">]</span> <span class="o">=</span> <span class="kc">False</span>
 <span class="n">reduce_target</span><span class="o">.</span><span class="n">runr</span><span class="p">()</span>
 </pre></div>
 </div>
@@ -8162,7 +8163,21 @@ Unlike the other near-IR instruments, the additive offset_sky parameter is used 
 <div class="jp-InputPrompt jp-InputArea-prompt">In [ ]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
 <div class="cm-editor cm-s-jupyter">
-<div class="highlight hl-ipython3"><pre><span></span><span class="c1">#clean_up(save_reduced=1)</span>
+<div class="highlight hl-ipython3"><pre><span></span><span class="c1">#clean_up(save_reduced=0)</span>
+</pre></div>
+</div>
+</div>
+</div>
+</div>
+</div><div class="jp-Cell jp-CodeCell jp-Notebook-cell jp-mod-noOutputs">
+<div class="jp-Cell-inputWrapper" tabindex="0">
+<div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
+</div>
+<div class="jp-InputArea jp-Cell-inputArea">
+<div class="jp-InputPrompt jp-InputArea-prompt">In [ ]:</div>
+<div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
+<div class="cm-editor cm-s-jupyter">
+<div class="highlight hl-ipython3"><pre><span></span> 
 </pre></div>
 </div>
 </div>

--- a/04_HowTos/DataReduction/DRAGONS_reduction_examples/GSAOI_Imaging_EllipticalGalaxy/GSAOI_Imaging_EllipticalGalaxy.ipynb
+++ b/04_HowTos/DataReduction/DRAGONS_reduction_examples/GSAOI_Imaging_EllipticalGalaxy/GSAOI_Imaging_EllipticalGalaxy.ipynb
@@ -8,7 +8,7 @@
    "source": [
     "__nbid__ = '0043'\n",
     "__author__ = 'Brian Merino <brian.merino@noirlab.edu>, Vinicius Placco <vinicius.placco@noirlab.edu>'\n",
-    "__version__ = '20241209' # yyyymmdd; version datestamp of this notebook\n",
+    "__version__ = '20250709' # yyyymmdd; version datestamp of this notebook\n",
     "__keywords__ = ['gsaoi','gemini','galaxy','dragons']"
    ]
   },
@@ -410,6 +410,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
+    "scrolled": true,
     "tags": []
    },
    "outputs": [],
@@ -436,7 +437,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [],
    "source": [
     "reduce_std = Reduce()\n",
@@ -475,7 +478,7 @@
    "source": [
     "reduce_target = Reduce()\n",
     "reduce_target.files.extend(list_of_science_images)\n",
-    "reduce_target.uparms.append(('skyCorrect:offset_sky', False))\n",
+    "reduce_target.uparms['skyCorrect:offset_sky'] = False\n",
     "reduce_target.runr()"
    ]
   },
@@ -541,15 +544,22 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "#clean_up(save_reduced=1)"
+    "#clean_up(save_reduced=0)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "DRAGONS-3.2.2 (DL,Py3.10.14)",
+   "display_name": "DRAGONS-4.0.0 (DL,Py3.12)",
    "language": "python",
-   "name": "dragons-3.2.2"
+   "name": "dragons-4.0.0"
   },
   "language_info": {
    "codemirror_mode": {
@@ -561,7 +571,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.14"
+   "version": "3.12.10"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
The current GSAOI notebook fails to reduce the list of science images when using the new DRAGONS v4.0.0 kernel. The fix involved replacing the following line 

`reduce_target.uparms.append(('skyCorrect:offset_sky', False))`

with

`reduce_target.uparms['skyCorrect:offset_sky'] = False`

I have verified that the new line of code works on GP13 with the new kernel. I will note, however, that the fix does not work with the current DRAGONS kernel. Until the new kernel is published, this PR will remain as a draft. 