### PR TITLE
Use to_specutils to simplify Prospect inputs

### DIFF
--- a/04_HowTos/SPARCL/Plot_SPARCL_Spectra_with_Jdaviz.html
+++ b/04_HowTos/SPARCL/Plot_SPARCL_Spectra_with_Jdaviz.html
@@ -7643,33 +7643,60 @@ a.anchor-link {
 </div>
 </div>
 </div>
-</div><div class="jp-Cell jp-CodeCell jp-Notebook-cell jp-mod-noOutputs" id="cell-id=1b12bf2e">
+</div><div class="jp-Cell jp-CodeCell jp-Notebook-cell" id="cell-id=1b12bf2e">
 <div class="jp-Cell-inputWrapper" tabindex="0">
 <div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
 </div>
 <div class="jp-InputArea jp-Cell-inputArea">
-<div class="jp-InputPrompt jp-InputArea-prompt">In [ ]:</div>
+<div class="jp-InputPrompt jp-InputArea-prompt">In [1]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
 <div class="cm-editor cm-s-jupyter">
-<div class="highlight hl-ipython3"><pre><span></span><span class="c1"># Handle warnings below</span>
+<div class="highlight hl-ipython3"><pre><span></span><span class="kn">import</span><span class="w"> </span><span class="nn">os</span>
+<span class="kn">import</span><span class="w"> </span><span class="nn">sys</span>
+<span class="n">sys</span><span class="o">.</span><span class="n">path</span><span class="o">.</span><span class="n">insert</span><span class="p">(</span><span class="mi">1</span><span class="p">,</span> <span class="n">os</span><span class="o">.</span><span class="n">path</span><span class="o">.</span><span class="n">join</span><span class="p">(</span><span class="n">os</span><span class="o">.</span><span class="n">environ</span><span class="p">[</span><span class="s1">'HOME'</span><span class="p">],</span> <span class="s1">'Documents'</span><span class="p">,</span> <span class="s1">'Code'</span><span class="p">,</span> <span class="s1">'git'</span><span class="p">,</span> <span class="s1">'nsf-noirlab'</span><span class="p">,</span> <span class="s1">'csdc'</span><span class="p">,</span> <span class="s1">'datalab'</span><span class="p">,</span> <span class="s1">'sparcl'</span><span class="p">,</span> <span class="s1">'sparclclient'</span><span class="p">))</span>
+<span class="c1"># Handle warnings below</span>
 <span class="kn">import</span><span class="w"> </span><span class="nn">warnings</span>
 <span class="c1"># Numpy import</span>
 <span class="kn">import</span><span class="w"> </span><span class="nn">numpy</span><span class="w"> </span><span class="k">as</span><span class="w"> </span><span class="nn">np</span>
 <span class="c1"># SPARCL import</span>
+<span class="kn">from</span><span class="w"> </span><span class="nn">sparcl</span><span class="w"> </span><span class="kn">import</span> <span class="n">__version__</span> <span class="k">as</span> <span class="n">sparcl_version</span>
 <span class="kn">from</span><span class="w"> </span><span class="nn">sparcl.client</span><span class="w"> </span><span class="kn">import</span> <span class="n">SparclClient</span>
 <span class="c1"># Jdaviz import</span>
+<span class="kn">from</span><span class="w"> </span><span class="nn">jdaviz</span><span class="w"> </span><span class="kn">import</span> <span class="n">__version__</span> <span class="k">as</span> <span class="n">jdaviz_version</span>
 <span class="kn">from</span><span class="w"> </span><span class="nn">jdaviz</span><span class="w"> </span><span class="kn">import</span> <span class="n">Specviz</span>
 <span class="c1"># Jupyter</span>
 <span class="kn">import</span><span class="w"> </span><span class="nn">ipywidgets</span><span class="w"> </span><span class="k">as</span><span class="w"> </span><span class="nn">widgets</span>
 <span class="kn">from</span><span class="w"> </span><span class="nn">IPython.display</span><span class="w"> </span><span class="kn">import</span> <span class="n">display</span>
 <span class="c1"># Specutils import</span>
-<span class="kn">from</span><span class="w"> </span><span class="nn">specutils</span><span class="w"> </span><span class="kn">import</span> <span class="n">Spectrum1D</span>
+<span class="kn">from</span><span class="w"> </span><span class="nn">specutils</span><span class="w"> </span><span class="kn">import</span> <span class="n">__version__</span> <span class="k">as</span> <span class="n">specutils_version</span>
+<span class="k">try</span><span class="p">:</span>
+    <span class="kn">from</span><span class="w"> </span><span class="nn">specutils</span><span class="w"> </span><span class="kn">import</span> <span class="n">Spectrum</span>
+<span class="k">except</span><span class="p">:</span>
+    <span class="kn">from</span><span class="w"> </span><span class="nn">specutils</span><span class="w"> </span><span class="kn">import</span> <span class="n">Spectrum1D</span> <span class="k">as</span> <span class="n">Spectrum</span>
 <span class="c1"># Astropy import</span>
 <span class="kn">import</span><span class="w"> </span><span class="nn">astropy.units</span><span class="w"> </span><span class="k">as</span><span class="w"> </span><span class="nn">u</span>
 <span class="kn">from</span><span class="w"> </span><span class="nn">astropy.nddata</span><span class="w"> </span><span class="kn">import</span> <span class="n">InverseVariance</span><span class="p">,</span> <span class="n">StdDevUncertainty</span>
 <span class="c1"># Jdaviz can emit warnings about Angstrom which we will ignore.</span>
 <span class="n">warnings</span><span class="o">.</span><span class="n">filterwarnings</span><span class="p">(</span><span class="s1">'ignore'</span><span class="p">,</span> <span class="n">category</span><span class="o">=</span><span class="n">u</span><span class="o">.</span><span class="n">UnitsWarning</span><span class="p">,</span> <span class="n">message</span><span class="o">=</span><span class="sa">r</span><span class="s1">'.*VOUnit standard.*'</span><span class="p">)</span>
+<span class="nb">print</span><span class="p">(</span><span class="sa">f</span><span class="s2">"sparcl_version==</span><span class="si">{</span><span class="n">sparcl_version</span><span class="si">}</span><span class="s2">"</span><span class="p">)</span>
+<span class="nb">print</span><span class="p">(</span><span class="sa">f</span><span class="s2">"jdaviz_version==</span><span class="si">{</span><span class="n">jdaviz_version</span><span class="si">}</span><span class="s2">"</span><span class="p">)</span>
+<span class="nb">print</span><span class="p">(</span><span class="sa">f</span><span class="s2">"specutils_version==</span><span class="si">{</span><span class="n">specutils_version</span><span class="si">}</span><span class="s2">"</span><span class="p">)</span>
 </pre></div>
+</div>
+</div>
+</div>
+</div>
+<div class="jp-Cell-outputWrapper">
+<div class="jp-Collapser jp-OutputCollapser jp-Cell-outputCollapser">
+</div>
+<div class="jp-OutputArea jp-Cell-outputArea">
+<div class="jp-OutputArea-child">
+<div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
+<div class="jp-RenderedText jp-OutputArea-output" data-mime-type="text/plain" tabindex="0">
+<pre>sparcl_version==1.2.8
+jdaviz_version==3.8.2
+specutils_version==1.13.0
+</pre>
 </div>
 </div>
 </div>
@@ -7685,17 +7712,36 @@ a.anchor-link {
 </div>
 </div>
 </div>
-</div><div class="jp-Cell jp-CodeCell jp-Notebook-cell jp-mod-noOutputs" id="cell-id=482c5e93">
+</div><div class="jp-Cell jp-CodeCell jp-Notebook-cell" id="cell-id=482c5e93">
 <div class="jp-Cell-inputWrapper" tabindex="0">
 <div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
 </div>
 <div class="jp-InputArea jp-Cell-inputArea">
-<div class="jp-InputPrompt jp-InputArea-prompt">In [ ]:</div>
+<div class="jp-InputPrompt jp-InputArea-prompt">In [2]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
 <div class="cm-editor cm-s-jupyter">
 <div class="highlight hl-ipython3"><pre><span></span><span class="n">client</span> <span class="o">=</span> <span class="n">SparclClient</span><span class="p">()</span>
 <span class="n">client</span>
 </pre></div>
+</div>
+</div>
+</div>
+</div>
+<div class="jp-Cell-outputWrapper">
+<div class="jp-Collapser jp-OutputCollapser jp-Cell-outputCollapser">
+</div>
+<div class="jp-OutputArea jp-Cell-outputArea">
+<div class="jp-OutputArea-child">
+<div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
+<div class="jp-RenderedText jp-OutputArea-output" data-mime-type="text/plain" tabindex="0">
+<pre>announcement=Data set deprecation notice: on November 19, 2025 the SDSS/BOSS DR16 data sets were deprecated. Please use the new SDSS/BOSS DR17 data sets instead.
+</pre>
+</div>
+</div>
+<div class="jp-OutputArea-child jp-OutputArea-executeResult">
+<div class="jp-OutputPrompt jp-OutputArea-prompt">Out[2]:</div>
+<div class="jp-RenderedText jp-OutputArea-output jp-OutputArea-executeResult" data-mime-type="text/plain" tabindex="0">
+<pre>(sparclclient:1.2.8, api:13.0, https://astrosparcl.datalab.noirlab.edu/api, client_hash=829f72b02e216275c9f079aeea2a162e2cf6e795, verbose=False, connect_timeout=1.1, read_timeout=5400.0, announcement=True)</pre>
 </div>
 </div>
 </div>
@@ -7711,17 +7757,30 @@ a.anchor-link {
 </div>
 </div>
 </div>
-</div><div class="jp-Cell jp-CodeCell jp-Notebook-cell jp-mod-noOutputs" id="cell-id=9e288542-73aa-45cf-9f69-668bd3208d70">
+</div><div class="jp-Cell jp-CodeCell jp-Notebook-cell" id="cell-id=9e288542-73aa-45cf-9f69-668bd3208d70">
 <div class="jp-Cell-inputWrapper" tabindex="0">
 <div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
 </div>
 <div class="jp-InputArea jp-Cell-inputArea">
-<div class="jp-InputPrompt jp-InputArea-prompt">In [ ]:</div>
+<div class="jp-InputPrompt jp-InputArea-prompt">In [3]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
 <div class="cm-editor cm-s-jupyter">
 <div class="highlight hl-ipython3"><pre><span></span><span class="n">desi_fields</span> <span class="o">=</span> <span class="n">client</span><span class="o">.</span><span class="n">get_all_fields</span><span class="p">(</span><span class="n">dataset_list</span><span class="o">=</span><span class="p">[</span><span class="s1">'DESI-DR1'</span><span class="p">])</span>
 <span class="nb">print</span><span class="p">(</span><span class="n">desi_fields</span><span class="p">)</span>
 </pre></div>
+</div>
+</div>
+</div>
+</div>
+<div class="jp-Cell-outputWrapper">
+<div class="jp-Collapser jp-OutputCollapser jp-Cell-outputCollapser">
+</div>
+<div class="jp-OutputArea jp-Cell-outputArea">
+<div class="jp-OutputArea-child">
+<div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
+<div class="jp-RenderedText jp-OutputArea-output" data-mime-type="text/plain" tabindex="0">
+<pre>['bgs_target', 'chi2', 'cmx_target', 'coadd_fiberstatus', 'coadd_numexp', 'coadd_numnight', 'coadd_numtile', 'coeff', 'data_release', 'datasetgroup', 'dateobs', 'dateobs_center', 'dec', 'deltachi2', 'desi_target', 'desiname', 'exptime', 'fa_target', 'fa_type', 'flux', 'healpix', 'instrument', 'ivar', 'main_nspec', 'main_primary', 'mask', 'mean_delta_x', 'mean_delta_y', 'mean_fiber_dec', 'mean_fiber_ra', 'mean_mjd', 'mean_psf_to_fiber_specflux', 'model', 'mws_target', 'ncoeff', 'npixels', 'numobs_init', 'objtype', 'obsconditions', 'plate_dec', 'plate_ra', 'pmdec', 'pmra', 'priority_init', 'program', 'ra', 'redshift', 'redshift_err', 'redshift_warning', 'ref_epoch', 'rms_delta_x', 'rms_delta_y', 'scnd_target', 'site', 'sparcl_id', 'specid', 'specprimary', 'spectype', 'spgrpval', 'std_fiber_dec', 'std_fiber_ra', 'subpriority', 'subtype', 'survey', 'sv1_bgs_target', 'sv1_desi_target', 'sv1_mws_target', 'sv1_scnd_target', 'sv2_bgs_target', 'sv2_desi_target', 'sv2_mws_target', 'sv2_scnd_target', 'sv3_bgs_target', 'sv3_desi_target', 'sv3_mws_target', 'sv3_scnd_target', 'sv_nspec', 'sv_primary', 'targetid', 'telescope', 'tsnr2_bgs', 'tsnr2_elg', 'tsnr2_gpbbackup', 'tsnr2_gpbbright', 'tsnr2_gpbdark', 'tsnr2_lrg', 'tsnr2_lya', 'tsnr2_qso', 'wave_sigma', 'wavelength', 'wavemax', 'wavemin', 'zcat_nspec']
+</pre>
 </div>
 </div>
 </div>
@@ -7761,7 +7820,7 @@ a.anchor-link {
 <div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
 </div>
 <div class="jp-InputArea jp-Cell-inputArea">
-<div class="jp-InputPrompt jp-InputArea-prompt">In [ ]:</div>
+<div class="jp-InputPrompt jp-InputArea-prompt">In [4]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
 <div class="cm-editor cm-s-jupyter">
 <div class="highlight hl-ipython3"><pre><span></span><span class="n">outfields</span> <span class="o">=</span> <span class="p">[</span><span class="s1">'sparcl_id'</span><span class="p">,</span> <span class="s1">'ra'</span><span class="p">,</span> <span class="s1">'dec'</span><span class="p">,</span> <span class="s1">'spectype'</span><span class="p">,</span> <span class="s1">'subtype'</span><span class="p">,</span> <span class="s1">'specid'</span><span class="p">,</span>
@@ -7782,7 +7841,7 @@ a.anchor-link {
 <div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
 </div>
 <div class="jp-InputArea jp-Cell-inputArea">
-<div class="jp-InputPrompt jp-InputArea-prompt">In [ ]:</div>
+<div class="jp-InputPrompt jp-InputArea-prompt">In [5]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
 <div class="cm-editor cm-s-jupyter">
 <div class="highlight hl-ipython3"><pre><span></span><span class="n">found</span> <span class="o">=</span> <span class="n">client</span><span class="o">.</span><span class="n">find</span><span class="p">(</span><span class="n">outfields</span><span class="o">=</span><span class="n">outfields</span><span class="p">,</span>
@@ -7810,7 +7869,7 @@ a.anchor-link {
 <div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
 </div>
 <div class="jp-InputArea jp-Cell-inputArea">
-<div class="jp-InputPrompt jp-InputArea-prompt">In [ ]:</div>
+<div class="jp-InputPrompt jp-InputArea-prompt">In [6]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
 <div class="cm-editor cm-s-jupyter">
 <div class="highlight hl-ipython3"><pre><span></span><span class="k">def</span><span class="w"> </span><span class="nf">radec_to_desiname</span><span class="p">(</span><span class="n">target_ra</span><span class="p">,</span> <span class="n">target_dec</span><span class="p">):</span>
@@ -7885,7 +7944,7 @@ a.anchor-link {
 <div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
 </div>
 <div class="jp-InputArea jp-Cell-inputArea">
-<div class="jp-InputPrompt jp-InputArea-prompt">In [ ]:</div>
+<div class="jp-InputPrompt jp-InputArea-prompt">In [7]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
 <div class="cm-editor cm-s-jupyter">
 <div class="highlight hl-ipython3"><pre><span></span><span class="k">for</span> <span class="n">record</span> <span class="ow">in</span> <span class="n">found</span><span class="o">.</span><span class="n">records</span><span class="p">:</span>
@@ -7921,7 +7980,7 @@ a.anchor-link {
 <div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
 </div>
 <div class="jp-InputArea jp-Cell-inputArea">
-<div class="jp-InputPrompt jp-InputArea-prompt">In [ ]:</div>
+<div class="jp-InputPrompt jp-InputArea-prompt">In [14]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
 <div class="cm-editor cm-s-jupyter">
 <div class="highlight hl-ipython3"><pre><span></span><span class="k">def</span><span class="w"> </span><span class="nf">on_selected</span><span class="p">(</span><span class="n">b</span><span class="p">):</span>
@@ -7935,7 +7994,8 @@ a.anchor-link {
     <span class="n">specunit</span> <span class="o">=</span> <span class="n">u</span><span class="o">.</span><span class="n">Unit</span><span class="p">(</span><span class="s1">'10-17 erg cm-2 s-1 AA-1'</span><span class="p">)</span>
     <span class="n">key</span> <span class="o">=</span> <span class="n">entries</span><span class="p">[</span><span class="n">b</span><span class="p">[</span><span class="s1">'new'</span><span class="p">]][</span><span class="mi">0</span><span class="p">]</span>
     <span class="n">result</span> <span class="o">=</span> <span class="n">client</span><span class="o">.</span><span class="n">retrieve</span><span class="p">(</span><span class="n">uuid_list</span><span class="o">=</span><span class="p">[</span><span class="n">ids</span><span class="p">[</span><span class="n">b</span><span class="p">[</span><span class="s1">'new'</span><span class="p">]]],</span>
-                             <span class="n">include</span><span class="o">=</span><span class="p">[</span><span class="s1">'specid'</span><span class="p">,</span>
+                             <span class="n">include</span><span class="o">=</span><span class="p">[</span><span class="s1">'data_release'</span><span class="p">,</span>
+                                      <span class="s1">'specid'</span><span class="p">,</span>
                                       <span class="s1">'survey'</span><span class="p">,</span>
                                       <span class="s1">'ra'</span><span class="p">,</span>
                                       <span class="s1">'dec'</span><span class="p">,</span>
@@ -7950,13 +8010,21 @@ a.anchor-link {
         <span class="c1">#</span>
         <span class="c1"># Note how the data and the model are prepared as two separate objects.</span>
         <span class="c1">#</span>
-        <span class="n">spectra</span><span class="p">[</span><span class="n">key</span><span class="p">]</span> <span class="o">=</span> <span class="p">(</span><span class="n">Spectrum1D</span><span class="p">(</span><span class="n">spectral_axis</span><span class="o">=</span><span class="n">result</span><span class="o">.</span><span class="n">records</span><span class="p">[</span><span class="mi">0</span><span class="p">][</span><span class="s1">'wavelength'</span><span class="p">]</span><span class="o">*</span><span class="n">u</span><span class="o">.</span><span class="n">AA</span><span class="p">,</span>
-                                   <span class="n">flux</span><span class="o">=</span><span class="n">result</span><span class="o">.</span><span class="n">records</span><span class="p">[</span><span class="mi">0</span><span class="p">][</span><span class="s1">'flux'</span><span class="p">]</span><span class="o">*</span><span class="n">specunit</span><span class="p">,</span>
-                                   <span class="n">uncertainty</span><span class="o">=</span><span class="n">InverseVariance</span><span class="p">(</span><span class="n">result</span><span class="o">.</span><span class="n">records</span><span class="p">[</span><span class="mi">0</span><span class="p">][</span><span class="s1">'ivar'</span><span class="p">]</span><span class="o">*</span><span class="p">(</span><span class="n">specunit</span><span class="o">**-</span><span class="mi">2</span><span class="p">))</span><span class="o">.</span><span class="n">represent_as</span><span class="p">(</span><span class="n">StdDevUncertainty</span><span class="p">),</span>
-                                   <span class="n">mask</span><span class="o">=</span><span class="n">result</span><span class="o">.</span><span class="n">records</span><span class="p">[</span><span class="mi">0</span><span class="p">][</span><span class="s1">'mask'</span><span class="p">],</span>
-                                   <span class="n">redshift</span><span class="o">=</span><span class="n">result</span><span class="o">.</span><span class="n">records</span><span class="p">[</span><span class="mi">0</span><span class="p">][</span><span class="s1">'redshift'</span><span class="p">]),</span>
-                        <span class="n">Spectrum1D</span><span class="p">(</span><span class="n">spectral_axis</span><span class="o">=</span><span class="n">result</span><span class="o">.</span><span class="n">records</span><span class="p">[</span><span class="mi">0</span><span class="p">][</span><span class="s1">'wavelength'</span><span class="p">]</span><span class="o">*</span><span class="n">u</span><span class="o">.</span><span class="n">AA</span><span class="p">,</span>
-                                   <span class="n">flux</span><span class="o">=</span><span class="n">result</span><span class="o">.</span><span class="n">records</span><span class="p">[</span><span class="mi">0</span><span class="p">][</span><span class="s1">'model'</span><span class="p">]</span><span class="o">*</span><span class="n">specunit</span><span class="p">))</span>
+        <span class="c1"># result_specutils = result.to_specutils()</span>
+        <span class="c1">#</span>
+        <span class="c1"># result_specutils.flux = result_specutils.flux[0, :]</span>
+        <span class="c1"># result_specutils.uncertainty = result_specutils.uncertainty.represent_as(StdDevUncertainty)[0, :]</span>
+        <span class="c1"># result_specutils.mask = result_specutils.mask[0, :]</span>
+        <span class="c1"># print(result_specutils.flux.shape)</span>
+        <span class="n">spectra</span><span class="p">[</span><span class="n">key</span><span class="p">]</span> <span class="o">=</span> <span class="p">(</span><span class="n">Spectrum</span><span class="p">(</span><span class="n">spectral_axis</span><span class="o">=</span><span class="n">result</span><span class="o">.</span><span class="n">records</span><span class="p">[</span><span class="mi">0</span><span class="p">][</span><span class="s1">'wavelength'</span><span class="p">]</span><span class="o">*</span><span class="n">u</span><span class="o">.</span><span class="n">AA</span><span class="p">,</span>
+                                 <span class="n">flux</span><span class="o">=</span><span class="n">result</span><span class="o">.</span><span class="n">records</span><span class="p">[</span><span class="mi">0</span><span class="p">][</span><span class="s1">'flux'</span><span class="p">]</span><span class="o">*</span><span class="n">specunit</span><span class="p">,</span>
+                                 <span class="n">uncertainty</span><span class="o">=</span><span class="n">InverseVariance</span><span class="p">(</span><span class="n">result</span><span class="o">.</span><span class="n">records</span><span class="p">[</span><span class="mi">0</span><span class="p">][</span><span class="s1">'ivar'</span><span class="p">]</span><span class="o">*</span><span class="p">(</span><span class="n">specunit</span><span class="o">**-</span><span class="mi">2</span><span class="p">))</span><span class="o">.</span><span class="n">represent_as</span><span class="p">(</span><span class="n">StdDevUncertainty</span><span class="p">),</span>
+                                 <span class="n">mask</span><span class="o">=</span><span class="n">result</span><span class="o">.</span><span class="n">records</span><span class="p">[</span><span class="mi">0</span><span class="p">][</span><span class="s1">'mask'</span><span class="p">],</span>
+                                 <span class="n">redshift</span><span class="o">=</span><span class="n">result</span><span class="o">.</span><span class="n">records</span><span class="p">[</span><span class="mi">0</span><span class="p">][</span><span class="s1">'redshift'</span><span class="p">]),</span>
+                        <span class="n">Spectrum</span><span class="p">(</span><span class="n">spectral_axis</span><span class="o">=</span><span class="n">result</span><span class="o">.</span><span class="n">records</span><span class="p">[</span><span class="mi">0</span><span class="p">][</span><span class="s1">'wavelength'</span><span class="p">]</span><span class="o">*</span><span class="n">u</span><span class="o">.</span><span class="n">AA</span><span class="p">,</span>
+                                 <span class="n">flux</span><span class="o">=</span><span class="n">result</span><span class="o">.</span><span class="n">records</span><span class="p">[</span><span class="mi">0</span><span class="p">][</span><span class="s1">'model'</span><span class="p">]</span><span class="o">*</span><span class="n">specunit</span><span class="p">))</span>
+        <span class="c1"># print(spectra[key][0].flux.shape)</span>
+        <span class="c1"># spectra[key] = (result_specutils, Spectrum(spectral_axis=result_specutils.spectral_axis, flux=result_specutils.meta['model'][0, :]*specunit))</span>
     <span class="k">if</span> <span class="s1">'old'</span> <span class="ow">in</span> <span class="n">b</span><span class="p">:</span>
         <span class="c1">#</span>
         <span class="c1"># Remove the previous spectrum.</span>
@@ -8014,12 +8082,12 @@ a.anchor-link {
 </div>
 </div>
 </div>
-</div><div class="jp-Cell jp-CodeCell jp-Notebook-cell jp-mod-noOutputs" id="cell-id=e6867ab3-b29c-46f1-94b8-7b5665c8bed5">
+</div><div class="jp-Cell jp-CodeCell jp-Notebook-cell" id="cell-id=e6867ab3-b29c-46f1-94b8-7b5665c8bed5">
 <div class="jp-Cell-inputWrapper" tabindex="0">
 <div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
 </div>
 <div class="jp-InputArea jp-Cell-inputArea">
-<div class="jp-InputPrompt jp-InputArea-prompt">In [ ]:</div>
+<div class="jp-InputPrompt jp-InputArea-prompt">In [15]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
 <div class="cm-editor cm-s-jupyter">
 <div class="highlight hl-ipython3"><pre><span></span><span class="c1">#</span>
@@ -8047,6 +8115,39 @@ a.anchor-link {
 <span class="c1">#</span>
 <span class="n">display</span><span class="p">(</span><span class="n">select</span><span class="p">,</span> <span class="n">output</span><span class="p">)</span>
 </pre></div>
+</div>
+</div>
+</div>
+</div>
+<div class="jp-Cell-outputWrapper">
+<div class="jp-Collapser jp-OutputCollapser jp-Cell-outputCollapser">
+</div>
+<div class="jp-OutputArea jp-Cell-outputArea">
+<div class="jp-OutputArea-child">
+<div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
+<div class="jp-RenderedText jp-OutputArea-output" data-mime-type="application/vnd.jupyter.stderr" tabindex="0">
+<pre>
+<span class="ansi-red-fg">---------------------------------------------------------------------------</span>
+<span class="ansi-red-fg">AttributeError</span>                            Traceback (most recent call last)
+Cell <span class="ansi-green-fg">In[15], line 12</span>
+<span class="ansi-green-intense-fg ansi-bold">      8</span> specviz <span style="color: rgb(98,98,98)">=</span> Specviz()
+<span class="ansi-green-intense-fg ansi-bold">      9</span> <span style="color: rgb(95,135,135)">#</span>
+<span class="ansi-green-intense-fg ansi-bold">     10</span> <span style="color: rgb(95,135,135)"># Trigger the download if this is the very first spectrum.</span>
+<span class="ansi-green-intense-fg ansi-bold">     11</span> <span style="color: rgb(95,135,135)">#</span>
+<span class="ansi-green-fg">---&gt; 12</span> <span class="ansi-yellow-bg">on_selected</span><span class="ansi-yellow-bg">(</span><span class="ansi-yellow-bg">{</span><span class="ansi-yellow-bg" style="color: rgb(175,0,0)">'</span><span class="ansi-yellow-bg" style="color: rgb(175,0,0)">new</span><span class="ansi-yellow-bg" style="color: rgb(175,0,0)">'</span><span class="ansi-yellow-bg">:</span><span class="ansi-yellow-bg"> </span><span class="ansi-yellow-bg" style="color: rgb(98,98,98)">0</span><span class="ansi-yellow-bg">}</span><span class="ansi-yellow-bg">)</span>
+<span class="ansi-green-intense-fg ansi-bold">     13</span> <span style="color: rgb(95,135,135)">#</span>
+<span class="ansi-green-intense-fg ansi-bold">     14</span> <span style="color: rgb(95,135,135)"># Connect the function action to the dropdown menu.</span>
+<span class="ansi-green-intense-fg ansi-bold">     15</span> <span style="color: rgb(95,135,135)">#</span>
+<span class="ansi-green-intense-fg ansi-bold">     16</span> select<span style="color: rgb(98,98,98)">.</span>observe(on_selected, names<span style="color: rgb(98,98,98)">=</span><span style="color: rgb(175,0,0)">'</span><span style="color: rgb(175,0,0)">value</span><span style="color: rgb(175,0,0)">'</span>)
+
+Cell <span class="ansi-green-fg">In[14], line 30</span>, in <span class="ansi-cyan-fg">on_selected</span><span class="ansi-blue-fg">(b)</span>
+<span class="ansi-green-intense-fg ansi-bold">     28</span> result_specutils <span style="color: rgb(98,98,98)">=</span> result<span style="color: rgb(98,98,98)">.</span>to_specutils()
+<span class="ansi-green-intense-fg ansi-bold">     29</span> <span style="color: rgb(95,135,135)">#</span>
+<span class="ansi-green-fg">---&gt; 30</span> <span class="ansi-yellow-bg">result_specutils</span><span class="ansi-yellow-bg" style="color: rgb(98,98,98)">.</span><span class="ansi-yellow-bg">flux</span> <span style="color: rgb(98,98,98)">=</span> result_specutils<span style="color: rgb(98,98,98)">.</span>flux[<span style="color: rgb(98,98,98)">0</span>, :]
+<span class="ansi-green-intense-fg ansi-bold">     31</span> result_specutils<span style="color: rgb(98,98,98)">.</span>uncertainty <span style="color: rgb(98,98,98)">=</span> result_specutils<span style="color: rgb(98,98,98)">.</span>uncertainty<span style="color: rgb(98,98,98)">.</span>represent_as(StdDevUncertainty)[<span style="color: rgb(98,98,98)">0</span>, :]
+<span class="ansi-green-intense-fg ansi-bold">     32</span> result_specutils<span style="color: rgb(98,98,98)">.</span>mask <span style="color: rgb(98,98,98)">=</span> result_specutils<span style="color: rgb(98,98,98)">.</span>mask[<span style="color: rgb(98,98,98)">0</span>, :]
+
+<span class="ansi-red-fg">AttributeError</span>: can't set attribute 'flux'</pre>
 </div>
 </div>
 </div>

--- a/04_HowTos/SPARCL/Plot_SPARCL_Spectra_with_Jdaviz.html
+++ b/04_HowTos/SPARCL/Plot_SPARCL_Spectra_with_Jdaviz.html
@@ -7515,7 +7515,7 @@ a.anchor-link {
 <div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
 </div>
 <div class="jp-InputArea jp-Cell-inputArea">
-<div class="jp-InputPrompt jp-InputArea-prompt">In [ ]:</div>
+<div class="jp-InputPrompt jp-InputArea-prompt">In [1]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
 <div class="cm-editor cm-s-jupyter">
 <div class="highlight hl-ipython3"><pre><span></span><span class="n">__nbid__</span> <span class="o">=</span> <span class="s1">'0052'</span>
@@ -7648,7 +7648,7 @@ a.anchor-link {
 <div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
 </div>
 <div class="jp-InputArea jp-Cell-inputArea">
-<div class="jp-InputPrompt jp-InputArea-prompt">In [1]:</div>
+<div class="jp-InputPrompt jp-InputArea-prompt">In [2]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
 <div class="cm-editor cm-s-jupyter">
 <div class="highlight hl-ipython3"><pre><span></span><span class="kn">import</span><span class="w"> </span><span class="nn">os</span>
@@ -7694,8 +7694,8 @@ a.anchor-link {
 <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
 <div class="jp-RenderedText jp-OutputArea-output" data-mime-type="text/plain" tabindex="0">
 <pre>sparcl_version==1.2.8
-jdaviz_version==3.8.2
-specutils_version==1.13.0
+jdaviz_version==4.2.3
+specutils_version==1.20.3
 </pre>
 </div>
 </div>
@@ -7717,7 +7717,7 @@ specutils_version==1.13.0
 <div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
 </div>
 <div class="jp-InputArea jp-Cell-inputArea">
-<div class="jp-InputPrompt jp-InputArea-prompt">In [2]:</div>
+<div class="jp-InputPrompt jp-InputArea-prompt">In [3]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
 <div class="cm-editor cm-s-jupyter">
 <div class="highlight hl-ipython3"><pre><span></span><span class="n">client</span> <span class="o">=</span> <span class="n">SparclClient</span><span class="p">()</span>
@@ -7739,9 +7739,9 @@ specutils_version==1.13.0
 </div>
 </div>
 <div class="jp-OutputArea-child jp-OutputArea-executeResult">
-<div class="jp-OutputPrompt jp-OutputArea-prompt">Out[2]:</div>
+<div class="jp-OutputPrompt jp-OutputArea-prompt">Out[3]:</div>
 <div class="jp-RenderedText jp-OutputArea-output jp-OutputArea-executeResult" data-mime-type="text/plain" tabindex="0">
-<pre>(sparclclient:1.2.8, api:13.0, https://astrosparcl.datalab.noirlab.edu/api, client_hash=829f72b02e216275c9f079aeea2a162e2cf6e795, verbose=False, connect_timeout=1.1, read_timeout=5400.0, announcement=True)</pre>
+<pre>(sparclclient:1.2.8, api:13.0, https://astrosparcl.datalab.noirlab.edu/api, client_hash=16e04212a9a27f648c0f43dcb99d9b5ae9ec37e0, verbose=False, connect_timeout=1.1, read_timeout=5400.0, announcement=True)</pre>
 </div>
 </div>
 </div>
@@ -7762,7 +7762,7 @@ specutils_version==1.13.0
 <div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
 </div>
 <div class="jp-InputArea jp-Cell-inputArea">
-<div class="jp-InputPrompt jp-InputArea-prompt">In [3]:</div>
+<div class="jp-InputPrompt jp-InputArea-prompt">In [4]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
 <div class="cm-editor cm-s-jupyter">
 <div class="highlight hl-ipython3"><pre><span></span><span class="n">desi_fields</span> <span class="o">=</span> <span class="n">client</span><span class="o">.</span><span class="n">get_all_fields</span><span class="p">(</span><span class="n">dataset_list</span><span class="o">=</span><span class="p">[</span><span class="s1">'DESI-DR1'</span><span class="p">])</span>
@@ -7820,7 +7820,7 @@ specutils_version==1.13.0
 <div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
 </div>
 <div class="jp-InputArea jp-Cell-inputArea">
-<div class="jp-InputPrompt jp-InputArea-prompt">In [4]:</div>
+<div class="jp-InputPrompt jp-InputArea-prompt">In [5]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
 <div class="cm-editor cm-s-jupyter">
 <div class="highlight hl-ipython3"><pre><span></span><span class="n">outfields</span> <span class="o">=</span> <span class="p">[</span><span class="s1">'sparcl_id'</span><span class="p">,</span> <span class="s1">'ra'</span><span class="p">,</span> <span class="s1">'dec'</span><span class="p">,</span> <span class="s1">'spectype'</span><span class="p">,</span> <span class="s1">'subtype'</span><span class="p">,</span> <span class="s1">'specid'</span><span class="p">,</span>
@@ -7841,7 +7841,7 @@ specutils_version==1.13.0
 <div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
 </div>
 <div class="jp-InputArea jp-Cell-inputArea">
-<div class="jp-InputPrompt jp-InputArea-prompt">In [5]:</div>
+<div class="jp-InputPrompt jp-InputArea-prompt">In [6]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
 <div class="cm-editor cm-s-jupyter">
 <div class="highlight hl-ipython3"><pre><span></span><span class="n">found</span> <span class="o">=</span> <span class="n">client</span><span class="o">.</span><span class="n">find</span><span class="p">(</span><span class="n">outfields</span><span class="o">=</span><span class="n">outfields</span><span class="p">,</span>
@@ -7869,7 +7869,7 @@ specutils_version==1.13.0
 <div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
 </div>
 <div class="jp-InputArea jp-Cell-inputArea">
-<div class="jp-InputPrompt jp-InputArea-prompt">In [6]:</div>
+<div class="jp-InputPrompt jp-InputArea-prompt">In [7]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
 <div class="cm-editor cm-s-jupyter">
 <div class="highlight hl-ipython3"><pre><span></span><span class="k">def</span><span class="w"> </span><span class="nf">radec_to_desiname</span><span class="p">(</span><span class="n">target_ra</span><span class="p">,</span> <span class="n">target_dec</span><span class="p">):</span>
@@ -7944,7 +7944,7 @@ specutils_version==1.13.0
 <div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
 </div>
 <div class="jp-InputArea jp-Cell-inputArea">
-<div class="jp-InputPrompt jp-InputArea-prompt">In [7]:</div>
+<div class="jp-InputPrompt jp-InputArea-prompt">In [8]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
 <div class="cm-editor cm-s-jupyter">
 <div class="highlight hl-ipython3"><pre><span></span><span class="k">for</span> <span class="n">record</span> <span class="ow">in</span> <span class="n">found</span><span class="o">.</span><span class="n">records</span><span class="p">:</span>
@@ -7980,7 +7980,7 @@ specutils_version==1.13.0
 <div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
 </div>
 <div class="jp-InputArea jp-Cell-inputArea">
-<div class="jp-InputPrompt jp-InputArea-prompt">In [14]:</div>
+<div class="jp-InputPrompt jp-InputArea-prompt">In [12]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
 <div class="cm-editor cm-s-jupyter">
 <div class="highlight hl-ipython3"><pre><span></span><span class="k">def</span><span class="w"> </span><span class="nf">on_selected</span><span class="p">(</span><span class="n">b</span><span class="p">):</span>
@@ -8015,7 +8015,6 @@ specutils_version==1.13.0
         <span class="c1"># result_specutils.flux = result_specutils.flux[0, :]</span>
         <span class="c1"># result_specutils.uncertainty = result_specutils.uncertainty.represent_as(StdDevUncertainty)[0, :]</span>
         <span class="c1"># result_specutils.mask = result_specutils.mask[0, :]</span>
-        <span class="c1"># print(result_specutils.flux.shape)</span>
         <span class="n">spectra</span><span class="p">[</span><span class="n">key</span><span class="p">]</span> <span class="o">=</span> <span class="p">(</span><span class="n">Spectrum</span><span class="p">(</span><span class="n">spectral_axis</span><span class="o">=</span><span class="n">result</span><span class="o">.</span><span class="n">records</span><span class="p">[</span><span class="mi">0</span><span class="p">][</span><span class="s1">'wavelength'</span><span class="p">]</span><span class="o">*</span><span class="n">u</span><span class="o">.</span><span class="n">AA</span><span class="p">,</span>
                                  <span class="n">flux</span><span class="o">=</span><span class="n">result</span><span class="o">.</span><span class="n">records</span><span class="p">[</span><span class="mi">0</span><span class="p">][</span><span class="s1">'flux'</span><span class="p">]</span><span class="o">*</span><span class="n">specunit</span><span class="p">,</span>
                                  <span class="n">uncertainty</span><span class="o">=</span><span class="n">InverseVariance</span><span class="p">(</span><span class="n">result</span><span class="o">.</span><span class="n">records</span><span class="p">[</span><span class="mi">0</span><span class="p">][</span><span class="s1">'ivar'</span><span class="p">]</span><span class="o">*</span><span class="p">(</span><span class="n">specunit</span><span class="o">**-</span><span class="mi">2</span><span class="p">))</span><span class="o">.</span><span class="n">represent_as</span><span class="p">(</span><span class="n">StdDevUncertainty</span><span class="p">),</span>
@@ -8023,8 +8022,8 @@ specutils_version==1.13.0
                                  <span class="n">redshift</span><span class="o">=</span><span class="n">result</span><span class="o">.</span><span class="n">records</span><span class="p">[</span><span class="mi">0</span><span class="p">][</span><span class="s1">'redshift'</span><span class="p">]),</span>
                         <span class="n">Spectrum</span><span class="p">(</span><span class="n">spectral_axis</span><span class="o">=</span><span class="n">result</span><span class="o">.</span><span class="n">records</span><span class="p">[</span><span class="mi">0</span><span class="p">][</span><span class="s1">'wavelength'</span><span class="p">]</span><span class="o">*</span><span class="n">u</span><span class="o">.</span><span class="n">AA</span><span class="p">,</span>
                                  <span class="n">flux</span><span class="o">=</span><span class="n">result</span><span class="o">.</span><span class="n">records</span><span class="p">[</span><span class="mi">0</span><span class="p">][</span><span class="s1">'model'</span><span class="p">]</span><span class="o">*</span><span class="n">specunit</span><span class="p">))</span>
-        <span class="c1"># print(spectra[key][0].flux.shape)</span>
-        <span class="c1"># spectra[key] = (result_specutils, Spectrum(spectral_axis=result_specutils.spectral_axis, flux=result_specutils.meta['model'][0, :]*specunit))</span>
+        <span class="c1"># spectra[key] = (result_specutils, Spectrum(spectral_axis=result_specutils.spectral_axis, flux=result_specutils.meta['model']*specunit))</span>
+        <span class="nb">print</span><span class="p">(</span><span class="n">spectra</span><span class="p">[</span><span class="n">key</span><span class="p">][</span><span class="mi">0</span><span class="p">]</span><span class="o">.</span><span class="n">flux</span><span class="o">.</span><span class="n">shape</span><span class="p">)</span>
     <span class="k">if</span> <span class="s1">'old'</span> <span class="ow">in</span> <span class="n">b</span><span class="p">:</span>
         <span class="c1">#</span>
         <span class="c1"># Remove the previous spectrum.</span>
@@ -8038,7 +8037,7 @@ specutils_version==1.13.0
     <span class="c1">#</span>
     <span class="n">specviz</span><span class="o">.</span><span class="n">load_data</span><span class="p">(</span><span class="n">spectra</span><span class="p">[</span><span class="n">key</span><span class="p">][</span><span class="mi">0</span><span class="p">],</span> <span class="n">data_label</span><span class="o">=</span><span class="n">key</span> <span class="o">+</span> <span class="s1">' Data'</span><span class="p">)</span>
     <span class="n">opt</span> <span class="o">=</span> <span class="n">specviz</span><span class="o">.</span><span class="n">plugins</span><span class="p">[</span><span class="s1">'Plot Options'</span><span class="p">]</span>
-    <span class="n">opt</span><span class="o">.</span><span class="n">layer</span> <span class="o">=</span> <span class="n">key</span> <span class="o">+</span> <span class="s1">' Data'</span>
+    <span class="n">opt</span><span class="o">.</span><span class="n">layer</span> <span class="o">=</span> <span class="n">key</span> <span class="o">+</span> <span class="s1">' Data [0]'</span>
     <span class="n">opt</span><span class="o">.</span><span class="n">line_color</span><span class="o">.</span><span class="n">value</span> <span class="o">=</span> <span class="s1">'#000000'</span>  <span class="c1"># Black</span>
     <span class="n">opt</span><span class="o">.</span><span class="n">line_as_steps</span> <span class="o">=</span> <span class="kc">True</span>
     <span class="n">opt</span><span class="o">.</span><span class="n">uncertainty_visible</span> <span class="o">=</span> <span class="kc">True</span>
@@ -8055,15 +8054,15 @@ specutils_version==1.13.0
     <span class="c1">#</span>
     <span class="n">specviz</span><span class="o">.</span><span class="n">load_data</span><span class="p">(</span><span class="n">spectra</span><span class="p">[</span><span class="n">key</span><span class="p">][</span><span class="mi">1</span><span class="p">],</span> <span class="n">data_label</span><span class="o">=</span><span class="n">key</span> <span class="o">+</span> <span class="s1">' Model'</span><span class="p">)</span>
     <span class="n">opt</span> <span class="o">=</span> <span class="n">specviz</span><span class="o">.</span><span class="n">plugins</span><span class="p">[</span><span class="s1">'Plot Options'</span><span class="p">]</span>
-    <span class="n">opt</span><span class="o">.</span><span class="n">layer</span> <span class="o">=</span> <span class="n">key</span> <span class="o">+</span> <span class="s1">' Model'</span>
+    <span class="n">opt</span><span class="o">.</span><span class="n">layer</span> <span class="o">=</span> <span class="n">key</span> <span class="o">+</span> <span class="s1">' Model [0]'</span>
     <span class="n">opt</span><span class="o">.</span><span class="n">line_color</span><span class="o">.</span><span class="n">value</span> <span class="o">=</span> <span class="s1">'#FF0000'</span>  <span class="c1"># Red</span>
     <span class="n">opt</span><span class="o">.</span><span class="n">line_as_steps</span> <span class="o">=</span> <span class="kc">True</span>
     <span class="c1">#</span>
     <span class="c1"># This is a workaround for a bug where metadata is not initially displayed.</span>
     <span class="c1">#</span>
     <span class="n">m</span> <span class="o">=</span> <span class="n">specviz</span><span class="o">.</span><span class="n">plugins</span><span class="p">[</span><span class="s1">'Metadata'</span><span class="p">]</span>
-    <span class="n">m</span><span class="o">.</span><span class="n">dataset</span> <span class="o">=</span> <span class="n">key</span> <span class="o">+</span> <span class="s1">' Model'</span>
-    <span class="n">m</span><span class="o">.</span><span class="n">dataset</span> <span class="o">=</span> <span class="n">key</span> <span class="o">+</span> <span class="s1">' Data'</span>
+    <span class="n">m</span><span class="o">.</span><span class="n">dataset</span> <span class="o">=</span> <span class="n">key</span> <span class="o">+</span> <span class="s1">' Model [0]'</span>
+    <span class="n">m</span><span class="o">.</span><span class="n">dataset</span> <span class="o">=</span> <span class="n">key</span> <span class="o">+</span> <span class="s1">' Data [0]'</span>
 </pre></div>
 </div>
 </div>
@@ -8087,7 +8086,7 @@ specutils_version==1.13.0
 <div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
 </div>
 <div class="jp-InputArea jp-Cell-inputArea">
-<div class="jp-InputPrompt jp-InputArea-prompt">In [15]:</div>
+<div class="jp-InputPrompt jp-InputArea-prompt">In [13]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
 <div class="cm-editor cm-s-jupyter">
 <div class="highlight hl-ipython3"><pre><span></span><span class="c1">#</span>
@@ -8125,11 +8124,18 @@ specutils_version==1.13.0
 <div class="jp-OutputArea jp-Cell-outputArea">
 <div class="jp-OutputArea-child">
 <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
+<div class="jp-RenderedText jp-OutputArea-output" data-mime-type="text/plain" tabindex="0">
+<pre>(7781,)
+</pre>
+</div>
+</div>
+<div class="jp-OutputArea-child">
+<div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
 <div class="jp-RenderedText jp-OutputArea-output" data-mime-type="application/vnd.jupyter.stderr" tabindex="0">
 <pre>
 <span class="ansi-red-fg">---------------------------------------------------------------------------</span>
-<span class="ansi-red-fg">AttributeError</span>                            Traceback (most recent call last)
-Cell <span class="ansi-green-fg">In[15], line 12</span>
+<span class="ansi-red-fg">ValueError</span>                                Traceback (most recent call last)
+Cell <span class="ansi-green-fg">In[13], line 12</span>
 <span class="ansi-green-intense-fg ansi-bold">      8</span> specviz <span style="color: rgb(98,98,98)">=</span> Specviz()
 <span class="ansi-green-intense-fg ansi-bold">      9</span> <span style="color: rgb(95,135,135)">#</span>
 <span class="ansi-green-intense-fg ansi-bold">     10</span> <span style="color: rgb(95,135,135)"># Trigger the download if this is the very first spectrum.</span>
@@ -8140,14 +8146,71 @@ Cell <span class="ansi-green-fg">In[15], line 12</span>
 <span class="ansi-green-intense-fg ansi-bold">     15</span> <span style="color: rgb(95,135,135)">#</span>
 <span class="ansi-green-intense-fg ansi-bold">     16</span> select<span style="color: rgb(98,98,98)">.</span>observe(on_selected, names<span style="color: rgb(98,98,98)">=</span><span style="color: rgb(175,0,0)">'</span><span style="color: rgb(175,0,0)">value</span><span style="color: rgb(175,0,0)">'</span>)
 
-Cell <span class="ansi-green-fg">In[14], line 30</span>, in <span class="ansi-cyan-fg">on_selected</span><span class="ansi-blue-fg">(b)</span>
-<span class="ansi-green-intense-fg ansi-bold">     28</span> result_specutils <span style="color: rgb(98,98,98)">=</span> result<span style="color: rgb(98,98,98)">.</span>to_specutils()
-<span class="ansi-green-intense-fg ansi-bold">     29</span> <span style="color: rgb(95,135,135)">#</span>
-<span class="ansi-green-fg">---&gt; 30</span> <span class="ansi-yellow-bg">result_specutils</span><span class="ansi-yellow-bg" style="color: rgb(98,98,98)">.</span><span class="ansi-yellow-bg">flux</span> <span style="color: rgb(98,98,98)">=</span> result_specutils<span style="color: rgb(98,98,98)">.</span>flux[<span style="color: rgb(98,98,98)">0</span>, :]
-<span class="ansi-green-intense-fg ansi-bold">     31</span> result_specutils<span style="color: rgb(98,98,98)">.</span>uncertainty <span style="color: rgb(98,98,98)">=</span> result_specutils<span style="color: rgb(98,98,98)">.</span>uncertainty<span style="color: rgb(98,98,98)">.</span>represent_as(StdDevUncertainty)[<span style="color: rgb(98,98,98)">0</span>, :]
-<span class="ansi-green-intense-fg ansi-bold">     32</span> result_specutils<span style="color: rgb(98,98,98)">.</span>mask <span style="color: rgb(98,98,98)">=</span> result_specutils<span style="color: rgb(98,98,98)">.</span>mask[<span style="color: rgb(98,98,98)">0</span>, :]
+Cell <span class="ansi-green-fg">In[12], line 55</span>, in <span class="ansi-cyan-fg">on_selected</span><span class="ansi-blue-fg">(b)</span>
+<span class="ansi-green-intense-fg ansi-bold">     53</span> specviz<span style="color: rgb(98,98,98)">.</span>load_data(spectra[key][<span style="color: rgb(98,98,98)">0</span>], data_label<span style="color: rgb(98,98,98)">=</span>key <span style="color: rgb(98,98,98)">+</span> <span style="color: rgb(175,0,0)">'</span><span style="color: rgb(175,0,0)"> Data</span><span style="color: rgb(175,0,0)">'</span>)
+<span class="ansi-green-intense-fg ansi-bold">     54</span> opt <span style="color: rgb(98,98,98)">=</span> specviz<span style="color: rgb(98,98,98)">.</span>plugins[<span style="color: rgb(175,0,0)">'</span><span style="color: rgb(175,0,0)">Plot Options</span><span style="color: rgb(175,0,0)">'</span>]
+<span class="ansi-green-fg">---&gt; 55</span> <span class="ansi-yellow-bg">opt</span><span class="ansi-yellow-bg" style="color: rgb(98,98,98)">.</span><span class="ansi-yellow-bg">layer</span> <span style="color: rgb(98,98,98)">=</span> key <span style="color: rgb(98,98,98)">+</span> <span style="color: rgb(175,0,0)">'</span><span style="color: rgb(175,0,0)"> Data [0]</span><span style="color: rgb(175,0,0)">'</span>
+<span class="ansi-green-intense-fg ansi-bold">     56</span> opt<span style="color: rgb(98,98,98)">.</span>line_color<span style="color: rgb(98,98,98)">.</span>value <span style="color: rgb(98,98,98)">=</span> <span style="color: rgb(175,0,0)">'</span><span style="color: rgb(175,0,0)">#000000</span><span style="color: rgb(175,0,0)">'</span>  <span style="color: rgb(95,135,135)"># Black</span>
+<span class="ansi-green-intense-fg ansi-bold">     57</span> opt<span style="color: rgb(98,98,98)">.</span>line_as_steps <span style="color: rgb(98,98,98)">=</span> <span class="ansi-bold" style="color: rgb(0,135,0)">True</span>
 
-<span class="ansi-red-fg">AttributeError</span>: can't set attribute 'flux'</pre>
+File <span class="ansi-green-fg">~/Documents/local/products/venv/kitchen_sink/lib/python3.10/site-packages/jdaviz/core/user_api.py:69</span>, in <span class="ansi-cyan-fg">UserApiWrapper.__setattr__</span><span class="ansi-blue-fg">(self, attr, value)</span>
+<span class="ansi-green-intense-fg ansi-bold">     67</span>     <span class="ansi-bold" style="color: rgb(0,135,0)">if</span> <span style="color: rgb(0,135,0)">isinstance</span>(exp_obj, UnitSelectPluginComponent) <span class="ansi-bold" style="color: rgb(175,0,255)">and</span> <span style="color: rgb(0,135,0)">isinstance</span>(value, u<span style="color: rgb(98,98,98)">.</span>Unit):
+<span class="ansi-green-intense-fg ansi-bold">     68</span>         value <span style="color: rgb(98,98,98)">=</span> value<span style="color: rgb(98,98,98)">.</span>to_string()
+<span class="ansi-green-fg">---&gt; 69</span>     <span class="ansi-yellow-bg">exp_obj</span><span class="ansi-yellow-bg" style="color: rgb(98,98,98)">.</span><span class="ansi-yellow-bg">selected</span> <span style="color: rgb(98,98,98)">=</span> value
+<span class="ansi-green-intense-fg ansi-bold">     70</span>     <span class="ansi-bold" style="color: rgb(0,135,0)">return</span>
+<span class="ansi-green-intense-fg ansi-bold">     71</span> <span class="ansi-bold" style="color: rgb(0,135,0)">elif</span> <span style="color: rgb(0,135,0)">isinstance</span>(exp_obj, AddResults):
+
+File <span class="ansi-green-fg">~/Documents/local/products/venv/kitchen_sink/lib/python3.10/site-packages/jdaviz/core/template_mixin.py:767</span>, in <span class="ansi-cyan-fg">BasePluginComponent.__setattr__</span><span class="ansi-blue-fg">(self, attr, value, force_super)</span>
+<span class="ansi-green-intense-fg ansi-bold">    764</span> <span class="ansi-bold" style="color: rgb(0,135,0)">if</span> attr[<span style="color: rgb(98,98,98)">0</span>] <span style="color: rgb(98,98,98)">==</span> <span style="color: rgb(175,0,0)">'</span><span style="color: rgb(175,0,0)">_</span><span style="color: rgb(175,0,0)">'</span> <span class="ansi-bold" style="color: rgb(175,0,255)">or</span> force_super <span class="ansi-bold" style="color: rgb(175,0,255)">or</span> attr <span class="ansi-bold" style="color: rgb(175,0,255)">not</span> <span class="ansi-bold" style="color: rgb(175,0,255)">in</span> <span style="color: rgb(0,135,0)">self</span><span style="color: rgb(98,98,98)">.</span>_plugin_traitlets<span style="color: rgb(98,98,98)">.</span>keys():
+<span class="ansi-green-intense-fg ansi-bold">    765</span>     <span class="ansi-bold" style="color: rgb(0,135,0)">return</span> <span style="color: rgb(0,135,0)">super</span>()<span style="color: rgb(98,98,98)">.</span><span style="color: rgb(0,0,255)">__setattr__</span>(attr, value)
+<span class="ansi-green-fg">--&gt; 767</span> <span class="ansi-bold" style="color: rgb(0,135,0)">return</span> <span class="ansi-yellow-bg" style="color: rgb(0,135,0)">setattr</span><span class="ansi-yellow-bg">(</span><span class="ansi-yellow-bg" style="color: rgb(0,135,0)">self</span><span class="ansi-yellow-bg" style="color: rgb(98,98,98)">.</span><span class="ansi-yellow-bg">_plugin</span><span class="ansi-yellow-bg">,</span><span class="ansi-yellow-bg"> </span><span class="ansi-yellow-bg" style="color: rgb(0,135,0)">self</span><span class="ansi-yellow-bg" style="color: rgb(98,98,98)">.</span><span class="ansi-yellow-bg">_plugin_traitlets</span><span class="ansi-yellow-bg" style="color: rgb(98,98,98)">.</span><span class="ansi-yellow-bg">get</span><span class="ansi-yellow-bg">(</span><span class="ansi-yellow-bg">attr</span><span class="ansi-yellow-bg">)</span><span class="ansi-yellow-bg">,</span><span class="ansi-yellow-bg"> </span><span class="ansi-yellow-bg">value</span><span class="ansi-yellow-bg">)</span>
+
+File <span class="ansi-green-fg">~/Documents/local/products/venv/kitchen_sink/lib/python3.10/site-packages/traitlets/traitlets.py:716</span>, in <span class="ansi-cyan-fg">TraitType.__set__</span><span class="ansi-blue-fg">(self, obj, value)</span>
+<span class="ansi-green-intense-fg ansi-bold">    714</span> <span class="ansi-bold" style="color: rgb(0,135,0)">if</span> <span style="color: rgb(0,135,0)">self</span><span style="color: rgb(98,98,98)">.</span>read_only:
+<span class="ansi-green-intense-fg ansi-bold">    715</span>     <span class="ansi-bold" style="color: rgb(0,135,0)">raise</span> TraitError(<span style="color: rgb(175,0,0)">'</span><span style="color: rgb(175,0,0)">The </span><span style="color: rgb(175,0,0)">"</span><span class="ansi-bold" style="color: rgb(175,95,135)">%s</span><span style="color: rgb(175,0,0)">"</span><span style="color: rgb(175,0,0)"> trait is read-only.</span><span style="color: rgb(175,0,0)">'</span> <span style="color: rgb(98,98,98)">%</span> <span style="color: rgb(0,135,0)">self</span><span style="color: rgb(98,98,98)">.</span>name)
+<span class="ansi-green-fg">--&gt; 716</span> <span class="ansi-yellow-bg" style="color: rgb(0,135,0)">self</span><span class="ansi-yellow-bg" style="color: rgb(98,98,98)">.</span><span class="ansi-yellow-bg">set</span><span class="ansi-yellow-bg">(</span><span class="ansi-yellow-bg">obj</span><span class="ansi-yellow-bg">,</span><span class="ansi-yellow-bg"> </span><span class="ansi-yellow-bg">value</span><span class="ansi-yellow-bg">)</span>
+
+File <span class="ansi-green-fg">~/Documents/local/products/venv/kitchen_sink/lib/python3.10/site-packages/traitlets/traitlets.py:706</span>, in <span class="ansi-cyan-fg">TraitType.set</span><span class="ansi-blue-fg">(self, obj, value)</span>
+<span class="ansi-green-intense-fg ansi-bold">    702</span>     silent <span style="color: rgb(98,98,98)">=</span> <span class="ansi-bold" style="color: rgb(0,135,0)">False</span>
+<span class="ansi-green-intense-fg ansi-bold">    703</span> <span class="ansi-bold" style="color: rgb(0,135,0)">if</span> silent <span class="ansi-bold" style="color: rgb(175,0,255)">is</span> <span class="ansi-bold" style="color: rgb(175,0,255)">not</span> <span class="ansi-bold" style="color: rgb(0,135,0)">True</span>:
+<span class="ansi-green-intense-fg ansi-bold">    704</span>     <span style="color: rgb(95,135,135)"># we explicitly compare silent to True just in case the equality</span>
+<span class="ansi-green-intense-fg ansi-bold">    705</span>     <span style="color: rgb(95,135,135)"># comparison above returns something other than True/False</span>
+<span class="ansi-green-fg">--&gt; 706</span>     <span class="ansi-yellow-bg">obj</span><span class="ansi-yellow-bg" style="color: rgb(98,98,98)">.</span><span class="ansi-yellow-bg">_notify_trait</span><span class="ansi-yellow-bg">(</span><span class="ansi-yellow-bg" style="color: rgb(0,135,0)">self</span><span class="ansi-yellow-bg" style="color: rgb(98,98,98)">.</span><span class="ansi-yellow-bg">name</span><span class="ansi-yellow-bg">,</span><span class="ansi-yellow-bg"> </span><span class="ansi-yellow-bg">old_value</span><span class="ansi-yellow-bg">,</span><span class="ansi-yellow-bg"> </span><span class="ansi-yellow-bg">new_value</span><span class="ansi-yellow-bg">)</span>
+
+File <span class="ansi-green-fg">~/Documents/local/products/venv/kitchen_sink/lib/python3.10/site-packages/traitlets/traitlets.py:1513</span>, in <span class="ansi-cyan-fg">HasTraits._notify_trait</span><span class="ansi-blue-fg">(self, name, old_value, new_value)</span>
+<span class="ansi-green-intense-fg ansi-bold">   1512</span> <span class="ansi-bold" style="color: rgb(0,135,0)">def</span><span style="color: rgb(188,188,188)"> </span><span style="color: rgb(0,0,255)">_notify_trait</span>(<span style="color: rgb(0,135,0)">self</span>, name: <span style="color: rgb(0,135,0)">str</span>, old_value: t<span style="color: rgb(98,98,98)">.</span>Any, new_value: t<span style="color: rgb(98,98,98)">.</span>Any) <span style="color: rgb(98,98,98)">-</span><span style="color: rgb(98,98,98)">&gt;</span> <span class="ansi-bold" style="color: rgb(0,135,0)">None</span>:
+<span class="ansi-green-fg">-&gt; 1513</span>     <span class="ansi-yellow-bg" style="color: rgb(0,135,0)">self</span><span class="ansi-yellow-bg" style="color: rgb(98,98,98)">.</span><span class="ansi-yellow-bg">notify_change</span><span class="ansi-yellow-bg">(</span>
+<span class="ansi-green-intense-fg ansi-bold">   1514</span> <span class="ansi-yellow-bg">        </span><span class="ansi-yellow-bg">Bunch</span><span class="ansi-yellow-bg">(</span>
+<span class="ansi-green-intense-fg ansi-bold">   1515</span> <span class="ansi-yellow-bg">            </span><span class="ansi-yellow-bg">name</span><span class="ansi-yellow-bg" style="color: rgb(98,98,98)">=</span><span class="ansi-yellow-bg">name</span><span class="ansi-yellow-bg">,</span>
+<span class="ansi-green-intense-fg ansi-bold">   1516</span> <span class="ansi-yellow-bg">            </span><span class="ansi-yellow-bg">old</span><span class="ansi-yellow-bg" style="color: rgb(98,98,98)">=</span><span class="ansi-yellow-bg">old_value</span><span class="ansi-yellow-bg">,</span>
+<span class="ansi-green-intense-fg ansi-bold">   1517</span> <span class="ansi-yellow-bg">            </span><span class="ansi-yellow-bg">new</span><span class="ansi-yellow-bg" style="color: rgb(98,98,98)">=</span><span class="ansi-yellow-bg">new_value</span><span class="ansi-yellow-bg">,</span>
+<span class="ansi-green-intense-fg ansi-bold">   1518</span> <span class="ansi-yellow-bg">            </span><span class="ansi-yellow-bg">owner</span><span class="ansi-yellow-bg" style="color: rgb(98,98,98)">=</span><span class="ansi-yellow-bg" style="color: rgb(0,135,0)">self</span><span class="ansi-yellow-bg">,</span>
+<span class="ansi-green-intense-fg ansi-bold">   1519</span> <span class="ansi-yellow-bg">            </span><span class="ansi-yellow-bg" style="color: rgb(0,135,0)">type</span><span class="ansi-yellow-bg" style="color: rgb(98,98,98)">=</span><span class="ansi-yellow-bg" style="color: rgb(175,0,0)">"</span><span class="ansi-yellow-bg" style="color: rgb(175,0,0)">change</span><span class="ansi-yellow-bg" style="color: rgb(175,0,0)">"</span><span class="ansi-yellow-bg">,</span>
+<span class="ansi-green-intense-fg ansi-bold">   1520</span> <span class="ansi-yellow-bg">        </span><span class="ansi-yellow-bg">)</span>
+<span class="ansi-green-intense-fg ansi-bold">   1521</span> <span class="ansi-yellow-bg">    </span><span class="ansi-yellow-bg">)</span>
+
+File <span class="ansi-green-fg">~/Documents/local/products/venv/kitchen_sink/lib/python3.10/site-packages/ipywidgets/widgets/widget.py:701</span>, in <span class="ansi-cyan-fg">Widget.notify_change</span><span class="ansi-blue-fg">(self, change)</span>
+<span class="ansi-green-intense-fg ansi-bold">    698</span>     <span class="ansi-bold" style="color: rgb(0,135,0)">if</span> name <span class="ansi-bold" style="color: rgb(175,0,255)">in</span> <span style="color: rgb(0,135,0)">self</span><span style="color: rgb(98,98,98)">.</span>keys <span class="ansi-bold" style="color: rgb(175,0,255)">and</span> <span style="color: rgb(0,135,0)">self</span><span style="color: rgb(98,98,98)">.</span>_should_send_property(name, <span style="color: rgb(0,135,0)">getattr</span>(<span style="color: rgb(0,135,0)">self</span>, name)):
+<span class="ansi-green-intense-fg ansi-bold">    699</span>         <span style="color: rgb(95,135,135)"># Send new state to front-end</span>
+<span class="ansi-green-intense-fg ansi-bold">    700</span>         <span style="color: rgb(0,135,0)">self</span><span style="color: rgb(98,98,98)">.</span>send_state(key<span style="color: rgb(98,98,98)">=</span>name)
+<span class="ansi-green-fg">--&gt; 701</span> <span class="ansi-yellow-bg" style="color: rgb(0,135,0)">super</span><span class="ansi-yellow-bg">(</span><span class="ansi-yellow-bg">)</span><span class="ansi-yellow-bg" style="color: rgb(98,98,98)">.</span><span class="ansi-yellow-bg">notify_change</span><span class="ansi-yellow-bg">(</span><span class="ansi-yellow-bg">change</span><span class="ansi-yellow-bg">)</span>
+
+File <span class="ansi-green-fg">~/Documents/local/products/venv/kitchen_sink/lib/python3.10/site-packages/traitlets/traitlets.py:1525</span>, in <span class="ansi-cyan-fg">HasTraits.notify_change</span><span class="ansi-blue-fg">(self, change)</span>
+<span class="ansi-green-intense-fg ansi-bold">   1523</span> <span class="ansi-bold" style="color: rgb(0,135,0)">def</span><span style="color: rgb(188,188,188)"> </span><span style="color: rgb(0,0,255)">notify_change</span>(<span style="color: rgb(0,135,0)">self</span>, change: Bunch) <span style="color: rgb(98,98,98)">-</span><span style="color: rgb(98,98,98)">&gt;</span> <span class="ansi-bold" style="color: rgb(0,135,0)">None</span>:
+<span class="ansi-green-intense-fg ansi-bold">   1524</span> <span style="color: rgb(188,188,188)">    </span><span style="color: rgb(175,0,0)">"""Notify observers of a change event"""</span>
+<span class="ansi-green-fg">-&gt; 1525</span>     <span class="ansi-bold" style="color: rgb(0,135,0)">return</span> <span class="ansi-yellow-bg" style="color: rgb(0,135,0)">self</span><span class="ansi-yellow-bg" style="color: rgb(98,98,98)">.</span><span class="ansi-yellow-bg">_notify_observers</span><span class="ansi-yellow-bg">(</span><span class="ansi-yellow-bg">change</span><span class="ansi-yellow-bg">)</span>
+
+File <span class="ansi-green-fg">~/Documents/local/products/venv/kitchen_sink/lib/python3.10/site-packages/traitlets/traitlets.py:1568</span>, in <span class="ansi-cyan-fg">HasTraits._notify_observers</span><span class="ansi-blue-fg">(self, event)</span>
+<span class="ansi-green-intense-fg ansi-bold">   1565</span> <span class="ansi-bold" style="color: rgb(0,135,0)">elif</span> <span style="color: rgb(0,135,0)">isinstance</span>(c, EventHandler) <span class="ansi-bold" style="color: rgb(175,0,255)">and</span> c<span style="color: rgb(98,98,98)">.</span>name <span class="ansi-bold" style="color: rgb(175,0,255)">is</span> <span class="ansi-bold" style="color: rgb(175,0,255)">not</span> <span class="ansi-bold" style="color: rgb(0,135,0)">None</span>:
+<span class="ansi-green-intense-fg ansi-bold">   1566</span>     c <span style="color: rgb(98,98,98)">=</span> <span style="color: rgb(0,135,0)">getattr</span>(<span style="color: rgb(0,135,0)">self</span>, c<span style="color: rgb(98,98,98)">.</span>name)
+<span class="ansi-green-fg">-&gt; 1568</span> <span class="ansi-yellow-bg">c</span><span class="ansi-yellow-bg">(</span><span class="ansi-yellow-bg">event</span><span class="ansi-yellow-bg">)</span>
+
+File <span class="ansi-green-fg">~/Documents/local/products/venv/kitchen_sink/lib/python3.10/site-packages/jdaviz/core/template_mixin.py:1141</span>, in <span class="ansi-cyan-fg">SelectPluginComponent._selected_changed</span><span class="ansi-blue-fg">(self, event)</span>
+<span class="ansi-green-intense-fg ansi-bold">   1139</span> <span class="ansi-bold" style="color: rgb(0,135,0)">if</span> event[<span style="color: rgb(175,0,0)">'</span><span style="color: rgb(175,0,0)">new</span><span style="color: rgb(175,0,0)">'</span>] <span class="ansi-bold" style="color: rgb(175,0,255)">not</span> <span class="ansi-bold" style="color: rgb(175,0,255)">in</span> valid <span style="color: rgb(98,98,98)">+</span> [<span style="color: rgb(175,0,0)">'</span><span style="color: rgb(175,0,0)">'</span>]:
+<span class="ansi-green-intense-fg ansi-bold">   1140</span>     <span style="color: rgb(0,135,0)">self</span><span style="color: rgb(98,98,98)">.</span>selected <span style="color: rgb(98,98,98)">=</span> event[<span style="color: rgb(175,0,0)">'</span><span style="color: rgb(175,0,0)">old</span><span style="color: rgb(175,0,0)">'</span>]
+<span class="ansi-green-fg">-&gt; 1141</span>     <span class="ansi-bold" style="color: rgb(0,135,0)">raise</span> <span class="ansi-bold" style="color: rgb(215,95,95)">ValueError</span>(<span style="color: rgb(175,0,0)">f</span><span style="color: rgb(175,0,0)">"</span><span class="ansi-bold" style="color: rgb(175,95,0)">\'</span><span class="ansi-bold" style="color: rgb(175,95,135)">{</span>event[<span style="color: rgb(175,0,0)">'</span><span style="color: rgb(175,0,0)">new</span><span style="color: rgb(175,0,0)">'</span>]<span class="ansi-bold" style="color: rgb(175,95,135)">}</span><span class="ansi-bold" style="color: rgb(175,95,0)">\'</span><span style="color: rgb(175,0,0)"> not one of </span><span class="ansi-bold" style="color: rgb(175,95,135)">{</span>valid<span class="ansi-bold" style="color: rgb(175,95,135)">}</span><span style="color: rgb(175,0,0)">, reverting selection to </span><span class="ansi-bold" style="color: rgb(175,95,0)">\'</span><span class="ansi-bold" style="color: rgb(175,95,135)">{</span>event[<span style="color: rgb(175,0,0)">'</span><span style="color: rgb(175,0,0)">old</span><span style="color: rgb(175,0,0)">'</span>]<span class="ansi-bold" style="color: rgb(175,95,135)">}</span><span class="ansi-bold" style="color: rgb(175,95,0)">\'</span><span style="color: rgb(175,0,0)">"</span>)
+
+<span class="ansi-red-fg">ValueError</span>: 'DESI J003.7111+07.9541 Data [0]' not one of ['DESI J003.7111+07.9541 Data'], reverting selection to 'DESI J003.7111+07.9541 Data'</pre>
 </div>
 </div>
 </div>

--- a/04_HowTos/SPARCL/Plot_SPARCL_Spectra_with_Jdaviz.html
+++ b/04_HowTos/SPARCL/Plot_SPARCL_Spectra_with_Jdaviz.html
@@ -7805,7 +7805,7 @@ a.anchor-link {
 <div class="cm-editor cm-s-jupyter">
 <div class="highlight hl-ipython3"><pre><span></span><span class="n">__nbid__</span> <span class="o">=</span> <span class="s1">'0052'</span>
 <span class="n">__author__</span> <span class="o">=</span> <span class="s1">'Camilla Pacifici, Brett Morris, Benjamin Weaver &lt;benjamin.weaver@noirlab.edu&gt;, Alice Jacques &lt;alice.jacques@noirlab.edu&gt;'</span>
-<span class="n">__version__</span> <span class="o">=</span> <span class="s1">'20250317'</span> <span class="c1"># yyyymmdd</span>
+<span class="n">__version__</span> <span class="o">=</span> <span class="s1">'20260505'</span> <span class="c1"># yyyymmdd</span>
 <span class="n">__datasets__</span> <span class="o">=</span> <span class="p">[</span><span class="s1">'desi_dr1'</span><span class="p">]</span>
 <span class="n">__keywords__</span> <span class="o">=</span> <span class="p">[</span><span class="s1">'sparcl'</span><span class="p">,</span> <span class="s1">'jdaviz'</span><span class="p">,</span> <span class="s1">'specutils'</span><span class="p">,</span> <span class="s1">'spectroscopy'</span><span class="p">,</span> <span class="s1">'desi spectra'</span><span class="p">,</span> <span class="s1">'tutorial'</span><span class="p">]</span>
 </pre></div>

--- a/04_HowTos/SPARCL/Plot_SPARCL_Spectra_with_Jdaviz.html
+++ b/04_HowTos/SPARCL/Plot_SPARCL_Spectra_with_Jdaviz.html
@@ -7332,7 +7332,12 @@ a.anchor-link {
     if (!diagrams.length) {
       return;
     }
-    const mermaid = (await import("https://cdnjs.cloudflare.com/ajax/libs/mermaid/10.7.0/mermaid.esm.min.mjs")).default;
+    const mermaid = (await import("https://cdnjs.cloudflare.com/ajax/libs/mermaid/11.10.0/mermaid.esm.min.mjs")).default;
+    const elkUrl = "https://cdnjs.cloudflare.com/ajax/libs/mermaid-layout-elk/0.1.9/mermaid-layout-elk.esm.min.mjs";
+    if(elkUrl) {
+      const elkLayouts = (await import(elkUrl)).default;
+      mermaid.registerLayoutLoaders(elkLayouts);
+    }
     const parser = new DOMParser();
 
     mermaid.initialize({
@@ -7429,7 +7434,8 @@ a.anchor-link {
      * Post-process to ensure mermaid diagrams contain only valid SVG and XHTML.
      */
     function cleanMermaidSvg(svg) {
-      return svg.replace(RE_VOID_ELEMENT, replaceVoidElement);
+      svg = svg.replace(RE_VOID_ELEMENT, replaceVoidElement);
+      return `${SVG_XML_HEADER}${svg}`;
     }
 
 
@@ -7455,6 +7461,285 @@ a.anchor-link {
       }
       return `<${tag} ${rest}>`;
     }
+
+
+  /**
+   * Named HTML entities with their decimal equivalent codes.
+   *
+   * @see https://www.w3.org/TR/WD-html40-970708/sgml/entities.html
+   * */
+  const HTML_ENTITIES = `<!ENTITY Aacute "&#193;">
+<!ENTITY aacute "&#225;">
+<!ENTITY Acirc "&#194;">
+<!ENTITY acirc "&#226;">
+<!ENTITY acute "&#180;">
+<!ENTITY AElig "&#198;">
+<!ENTITY aelig "&#230;">
+<!ENTITY Agrave "&#192;">
+<!ENTITY agrave "&#224;">
+<!ENTITY alefsym "&#8501;">
+<!ENTITY Alpha "&#913;">
+<!ENTITY alpha "&#945;">
+<!ENTITY amp "&#38;">
+<!ENTITY and "&#8869;">
+<!ENTITY ang "&#8736;">
+<!ENTITY Aring "&#197;">
+<!ENTITY aring "&#229;">
+<!ENTITY asymp "&#8776;">
+<!ENTITY Atilde "&#195;">
+<!ENTITY atilde "&#227;">
+<!ENTITY Auml "&#196;">
+<!ENTITY auml "&#228;">
+<!ENTITY bdquo "&#8222;">
+<!ENTITY Beta "&#914;">
+<!ENTITY beta "&#946;">
+<!ENTITY brvbar "&#166;">
+<!ENTITY bull "&#8226;">
+<!ENTITY cap "&#8745;">
+<!ENTITY Ccedil "&#199;">
+<!ENTITY ccedil "&#231;">
+<!ENTITY cedil "&#184;">
+<!ENTITY cent "&#162;">
+<!ENTITY Chi "&#935;">
+<!ENTITY chi "&#967;">
+<!ENTITY circ "&#710;">
+<!ENTITY clubs "&#9827;">
+<!ENTITY cong "&#8773;">
+<!ENTITY copy "&#169;">
+<!ENTITY crarr "&#8629;">
+<!ENTITY cup "&#8746;">
+<!ENTITY curren "&#164;">
+<!ENTITY dagger "&#8224;">
+<!ENTITY Dagger "&#8225;">
+<!ENTITY darr "&#8595;">
+<!ENTITY dArr "&#8659;">
+<!ENTITY deg "&#176;">
+<!ENTITY Delta "&#916;">
+<!ENTITY delta "&#948;">
+<!ENTITY diams "&#9830;">
+<!ENTITY divide "&#247;">
+<!ENTITY Eacute "&#201;">
+<!ENTITY eacute "&#233;">
+<!ENTITY Ecirc "&#202;">
+<!ENTITY ecirc "&#234;">
+<!ENTITY Egrave "&#200;">
+<!ENTITY egrave "&#232;">
+<!ENTITY empty "&#8709;">
+<!ENTITY emsp "&#8195;">
+<!ENTITY ensp "&#8194;">
+<!ENTITY epsilon "&#949;">
+<!ENTITY Epsilon "&#917;">
+<!ENTITY equiv "&#8801;">
+<!ENTITY Eta "&#919;">
+<!ENTITY eta "&#951;">
+<!ENTITY ETH "&#208;">
+<!ENTITY eth "&#240;">
+<!ENTITY Euml "&#203;">
+<!ENTITY euml "&#235;">
+<!ENTITY exist "&#8707;">
+<!ENTITY fnof "&#402;">
+<!ENTITY forall "&#8704;">
+<!ENTITY frac12 "&#189;">
+<!ENTITY frac14 "&#188;">
+<!ENTITY frac34 "&#190;">
+<!ENTITY frasl "&#8260;">
+<!ENTITY Gamma "&#915;">
+<!ENTITY gamma "&#947;">
+<!ENTITY ge "&#8805;">
+<!ENTITY gt "&#62;">
+<!ENTITY harr "&#8596;">
+<!ENTITY hArr "&#8660;">
+<!ENTITY hearts "&#9829;">
+<!ENTITY hellip "&#8230;">
+<!ENTITY Iacute "&#205;">
+<!ENTITY iacute "&#237;">
+<!ENTITY Icirc "&#206;">
+<!ENTITY icirc "&#238;">
+<!ENTITY iexcl "&#161;">
+<!ENTITY Igrave "&#204;">
+<!ENTITY igrave "&#236;">
+<!ENTITY image "&#8465;">
+<!ENTITY infin "&#8734;">
+<!ENTITY int "&#8747;">
+<!ENTITY Iota "&#921;">
+<!ENTITY iota "&#953;">
+<!ENTITY iquest "&#191;">
+<!ENTITY isin "&#8712;">
+<!ENTITY Iuml "&#207;">
+<!ENTITY iuml "&#239;">
+<!ENTITY Kappa "&#922;">
+<!ENTITY kappa "&#954;">
+<!ENTITY Lambda "&#923;">
+<!ENTITY lambda "&#955;">
+<!ENTITY lang "&#9001;">
+<!ENTITY laquo "&#171;">
+<!ENTITY larr "&#8592;">
+<!ENTITY lArr "&#8656;">
+<!ENTITY lceil "&#8968;">
+<!ENTITY ldquo "&#8220;">
+<!ENTITY le "&#8804;">
+<!ENTITY lfloor "&#8970;">
+<!ENTITY lowast "&#8727;">
+<!ENTITY loz "&#9674;">
+<!ENTITY lrm "&#8206;">
+<!ENTITY lsaquo "&#8249;">
+<!ENTITY lsquo "&#8216;">
+<!ENTITY lt "&#60;">
+<!ENTITY macr "&#175;">
+<!ENTITY mdash "&#8212;">
+<!ENTITY micro "&#181;">
+<!ENTITY middot "&#183;">
+<!ENTITY minus "&#8722;">
+<!ENTITY Mu "&#924;">
+<!ENTITY mu "&#956;">
+<!ENTITY nabla "&#8711;">
+<!ENTITY nbsp "&#160;">
+<!ENTITY ndash "&#8211;">
+<!ENTITY ne "&#8800;">
+<!ENTITY ni "&#8715;">
+<!ENTITY not "&#172;">
+<!ENTITY notin "&#8713;">
+<!ENTITY nsub "&#8836;">
+<!ENTITY Ntilde "&#209;">
+<!ENTITY ntilde "&#241;">
+<!ENTITY Nu "&#925;">
+<!ENTITY nu "&#957;">
+<!ENTITY Oacute "&#211;">
+<!ENTITY oacute "&#243;">
+<!ENTITY Ocirc "&#212;">
+<!ENTITY ocirc "&#244;">
+<!ENTITY OElig "&#338;">
+<!ENTITY oelig "&#339;">
+<!ENTITY Ograve "&#210;">
+<!ENTITY ograve "&#242;">
+<!ENTITY oline "&#8254;">
+<!ENTITY Omega "&#937;">
+<!ENTITY omega "&#969;">
+<!ENTITY Omicron "&#927;">
+<!ENTITY omicron "&#959;">
+<!ENTITY oplus "&#8853;">
+<!ENTITY or "&#8870;">
+<!ENTITY ordf "&#170;">
+<!ENTITY ordm "&#186;">
+<!ENTITY Oslash "&#216;">
+<!ENTITY oslash "&#248;">
+<!ENTITY Otilde "&#213;">
+<!ENTITY otilde "&#245;">
+<!ENTITY otimes "&#8855;">
+<!ENTITY Ouml "&#214;">
+<!ENTITY ouml "&#246;">
+<!ENTITY para "&#182;">
+<!ENTITY part "&#8706;">
+<!ENTITY permil "&#8240;">
+<!ENTITY perp "&#8869;">
+<!ENTITY Phi "&#934;">
+<!ENTITY phi "&#966;">
+<!ENTITY Pi "&#928;">
+<!ENTITY pi "&#960;">
+<!ENTITY piv "&#982;">
+<!ENTITY plusmn "&#177;">
+<!ENTITY pound "&#163;">
+<!ENTITY prime "&#8242;">
+<!ENTITY Prime "&#8243;">
+<!ENTITY prod "&#8719;">
+<!ENTITY prop "&#8733;">
+<!ENTITY Psi "&#936;">
+<!ENTITY psi "&#968;">
+<!ENTITY quot "&#34;">
+<!ENTITY radic "&#8730;">
+<!ENTITY rang "&#9002;">
+<!ENTITY raquo "&#187;">
+<!ENTITY rarr "&#8594;">
+<!ENTITY rArr "&#8658;">
+<!ENTITY rceil "&#8969;">
+<!ENTITY rdquo "&#8221;">
+<!ENTITY real "&#8476;">
+<!ENTITY reg "&#174;">
+<!ENTITY rfloor "&#8971;">
+<!ENTITY Rho "&#929;">
+<!ENTITY rho "&#961;">
+<!ENTITY rlm "&#8207;">
+<!ENTITY rsaquo "&#8250;">
+<!ENTITY rsquo "&#8217;">
+<!ENTITY sbquo "&#8218;">
+<!ENTITY Scaron "&#352;">
+<!ENTITY scaron "&#353;">
+<!ENTITY sdot "&#8901;">
+<!ENTITY sect "&#167;">
+<!ENTITY shy "&#173;">
+<!ENTITY Sigma "&#931;">
+<!ENTITY sigma "&#963;">
+<!ENTITY sigmaf "&#962;">
+<!ENTITY sim "&#8764;">
+<!ENTITY spades "&#9824;">
+<!ENTITY sub "&#8834;">
+<!ENTITY sube "&#8838;">
+<!ENTITY sum "&#8721;">
+<!ENTITY sup "&#8835;">
+<!ENTITY sup1 "&#185;">
+<!ENTITY sup2 "&#178;">
+<!ENTITY sup3 "&#179;">
+<!ENTITY supe "&#8839;">
+<!ENTITY szlig "&#223;">
+<!ENTITY Tau "&#932;">
+<!ENTITY tau "&#964;">
+<!ENTITY there4 "&#8756;">
+<!ENTITY Theta "&#920;">
+<!ENTITY theta "&#952;">
+<!ENTITY thetasym "&#977;">
+<!ENTITY thinsp "&#8201;">
+<!ENTITY THORN "&#222;">
+<!ENTITY thorn "&#254;">
+<!ENTITY tilde "&#732;">
+<!ENTITY times "&#215;">
+<!ENTITY trade "&#8482;">
+<!ENTITY Uacute "&#218;">
+<!ENTITY uacute "&#250;">
+<!ENTITY uarr "&#8593;">
+<!ENTITY uArr "&#8657;">
+<!ENTITY Ucirc "&#219;">
+<!ENTITY ucirc "&#251;">
+<!ENTITY Ugrave "&#217;">
+<!ENTITY ugrave "&#249;">
+<!ENTITY uml "&#168;">
+<!ENTITY upsih "&#978;">
+<!ENTITY Upsilon "&#933;">
+<!ENTITY upsilon "&#965;">
+<!ENTITY Uuml "&#220;">
+<!ENTITY uuml "&#252;">
+<!ENTITY weierp "&#8472;">
+<!ENTITY Xi "&#926;">
+<!ENTITY xi "&#958;">
+<!ENTITY Yacute "&#221;">
+<!ENTITY yacute "&#253;">
+<!ENTITY yen "&#165;">
+<!ENTITY Yuml "&#376;">
+<!ENTITY yuml "&#255;">
+<!ENTITY Zeta "&#918;">
+<!ENTITY zeta "&#950;">
+<!ENTITY zwj "&#8205;">
+<!ENTITY zwnj "&#8204;">`.replace(/\n/g, ' ');
+
+  /**
+   * A reasonably strict xml declaration.
+   */
+  const XML_DECL = '<?xml version="1.0" standalone="no"?>';
+
+  /**
+   * The beginning of the XML doctype declaration.
+   */
+  const DOCTYPE_START = `<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" [`;
+
+  /**
+   * The end of the XML docype declaration.
+   */
+  const DOCTYPE_END = ']>';
+
+  /**
+   * A full header for an SVG XML document.
+   */
+  const SVG_XML_HEADER = `${XML_DECL}
+    ${DOCTYPE_START}${HTML_ENTITIES}${DOCTYPE_END}`;
 
     void Promise.all([...diagrams].map(renderOneMarmaid));
   });
@@ -7515,7 +7800,7 @@ a.anchor-link {
 <div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
 </div>
 <div class="jp-InputArea jp-Cell-inputArea">
-<div class="jp-InputPrompt jp-InputArea-prompt">In [1]:</div>
+<div class="jp-InputPrompt jp-InputArea-prompt">In [ ]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
 <div class="cm-editor cm-s-jupyter">
 <div class="highlight hl-ipython3"><pre><span></span><span class="n">__nbid__</span> <span class="o">=</span> <span class="s1">'0052'</span>
@@ -7643,17 +7928,16 @@ a.anchor-link {
 </div>
 </div>
 </div>
-</div><div class="jp-Cell jp-CodeCell jp-Notebook-cell" id="cell-id=1b12bf2e">
+</div><div class="jp-Cell jp-CodeCell jp-Notebook-cell jp-mod-noOutputs" id="cell-id=1b12bf2e">
 <div class="jp-Cell-inputWrapper" tabindex="0">
 <div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
 </div>
 <div class="jp-InputArea jp-Cell-inputArea">
-<div class="jp-InputPrompt jp-InputArea-prompt">In [2]:</div>
+<div class="jp-InputPrompt jp-InputArea-prompt">In [ ]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
 <div class="cm-editor cm-s-jupyter">
 <div class="highlight hl-ipython3"><pre><span></span><span class="kn">import</span><span class="w"> </span><span class="nn">os</span>
 <span class="kn">import</span><span class="w"> </span><span class="nn">sys</span>
-<span class="n">sys</span><span class="o">.</span><span class="n">path</span><span class="o">.</span><span class="n">insert</span><span class="p">(</span><span class="mi">1</span><span class="p">,</span> <span class="n">os</span><span class="o">.</span><span class="n">path</span><span class="o">.</span><span class="n">join</span><span class="p">(</span><span class="n">os</span><span class="o">.</span><span class="n">environ</span><span class="p">[</span><span class="s1">'HOME'</span><span class="p">],</span> <span class="s1">'Documents'</span><span class="p">,</span> <span class="s1">'Code'</span><span class="p">,</span> <span class="s1">'git'</span><span class="p">,</span> <span class="s1">'nsf-noirlab'</span><span class="p">,</span> <span class="s1">'csdc'</span><span class="p">,</span> <span class="s1">'datalab'</span><span class="p">,</span> <span class="s1">'sparcl'</span><span class="p">,</span> <span class="s1">'sparclclient'</span><span class="p">))</span>
 <span class="c1"># Handle warnings below</span>
 <span class="kn">import</span><span class="w"> </span><span class="nn">warnings</span>
 <span class="c1"># Numpy import</span>
@@ -7686,21 +7970,6 @@ a.anchor-link {
 </div>
 </div>
 </div>
-<div class="jp-Cell-outputWrapper">
-<div class="jp-Collapser jp-OutputCollapser jp-Cell-outputCollapser">
-</div>
-<div class="jp-OutputArea jp-Cell-outputArea">
-<div class="jp-OutputArea-child">
-<div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
-<div class="jp-RenderedText jp-OutputArea-output" data-mime-type="text/plain" tabindex="0">
-<pre>sparcl_version==1.2.8
-jdaviz_version==4.2.3
-specutils_version==1.20.3
-</pre>
-</div>
-</div>
-</div>
-</div>
 </div>
 <div class="jp-Cell jp-MarkdownCell jp-Notebook-cell" id="cell-id=5580d04f">
 <div class="jp-Cell-inputWrapper" tabindex="0">
@@ -7712,36 +7981,17 @@ specutils_version==1.20.3
 </div>
 </div>
 </div>
-</div><div class="jp-Cell jp-CodeCell jp-Notebook-cell" id="cell-id=482c5e93">
+</div><div class="jp-Cell jp-CodeCell jp-Notebook-cell jp-mod-noOutputs" id="cell-id=482c5e93">
 <div class="jp-Cell-inputWrapper" tabindex="0">
 <div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
 </div>
 <div class="jp-InputArea jp-Cell-inputArea">
-<div class="jp-InputPrompt jp-InputArea-prompt">In [3]:</div>
+<div class="jp-InputPrompt jp-InputArea-prompt">In [ ]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
 <div class="cm-editor cm-s-jupyter">
 <div class="highlight hl-ipython3"><pre><span></span><span class="n">client</span> <span class="o">=</span> <span class="n">SparclClient</span><span class="p">()</span>
 <span class="n">client</span>
 </pre></div>
-</div>
-</div>
-</div>
-</div>
-<div class="jp-Cell-outputWrapper">
-<div class="jp-Collapser jp-OutputCollapser jp-Cell-outputCollapser">
-</div>
-<div class="jp-OutputArea jp-Cell-outputArea">
-<div class="jp-OutputArea-child">
-<div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
-<div class="jp-RenderedText jp-OutputArea-output" data-mime-type="text/plain" tabindex="0">
-<pre>announcement=Data set deprecation notice: on November 19, 2025 the SDSS/BOSS DR16 data sets were deprecated. Please use the new SDSS/BOSS DR17 data sets instead.
-</pre>
-</div>
-</div>
-<div class="jp-OutputArea-child jp-OutputArea-executeResult">
-<div class="jp-OutputPrompt jp-OutputArea-prompt">Out[3]:</div>
-<div class="jp-RenderedText jp-OutputArea-output jp-OutputArea-executeResult" data-mime-type="text/plain" tabindex="0">
-<pre>(sparclclient:1.2.8, api:13.0, https://astrosparcl.datalab.noirlab.edu/api, client_hash=16e04212a9a27f648c0f43dcb99d9b5ae9ec37e0, verbose=False, connect_timeout=1.1, read_timeout=5400.0, announcement=True)</pre>
 </div>
 </div>
 </div>
@@ -7757,30 +8007,17 @@ specutils_version==1.20.3
 </div>
 </div>
 </div>
-</div><div class="jp-Cell jp-CodeCell jp-Notebook-cell" id="cell-id=9e288542-73aa-45cf-9f69-668bd3208d70">
+</div><div class="jp-Cell jp-CodeCell jp-Notebook-cell jp-mod-noOutputs" id="cell-id=9e288542-73aa-45cf-9f69-668bd3208d70">
 <div class="jp-Cell-inputWrapper" tabindex="0">
 <div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
 </div>
 <div class="jp-InputArea jp-Cell-inputArea">
-<div class="jp-InputPrompt jp-InputArea-prompt">In [4]:</div>
+<div class="jp-InputPrompt jp-InputArea-prompt">In [ ]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
 <div class="cm-editor cm-s-jupyter">
 <div class="highlight hl-ipython3"><pre><span></span><span class="n">desi_fields</span> <span class="o">=</span> <span class="n">client</span><span class="o">.</span><span class="n">get_all_fields</span><span class="p">(</span><span class="n">dataset_list</span><span class="o">=</span><span class="p">[</span><span class="s1">'DESI-DR1'</span><span class="p">])</span>
 <span class="nb">print</span><span class="p">(</span><span class="n">desi_fields</span><span class="p">)</span>
 </pre></div>
-</div>
-</div>
-</div>
-</div>
-<div class="jp-Cell-outputWrapper">
-<div class="jp-Collapser jp-OutputCollapser jp-Cell-outputCollapser">
-</div>
-<div class="jp-OutputArea jp-Cell-outputArea">
-<div class="jp-OutputArea-child">
-<div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
-<div class="jp-RenderedText jp-OutputArea-output" data-mime-type="text/plain" tabindex="0">
-<pre>['bgs_target', 'chi2', 'cmx_target', 'coadd_fiberstatus', 'coadd_numexp', 'coadd_numnight', 'coadd_numtile', 'coeff', 'data_release', 'datasetgroup', 'dateobs', 'dateobs_center', 'dec', 'deltachi2', 'desi_target', 'desiname', 'exptime', 'fa_target', 'fa_type', 'flux', 'healpix', 'instrument', 'ivar', 'main_nspec', 'main_primary', 'mask', 'mean_delta_x', 'mean_delta_y', 'mean_fiber_dec', 'mean_fiber_ra', 'mean_mjd', 'mean_psf_to_fiber_specflux', 'model', 'mws_target', 'ncoeff', 'npixels', 'numobs_init', 'objtype', 'obsconditions', 'plate_dec', 'plate_ra', 'pmdec', 'pmra', 'priority_init', 'program', 'ra', 'redshift', 'redshift_err', 'redshift_warning', 'ref_epoch', 'rms_delta_x', 'rms_delta_y', 'scnd_target', 'site', 'sparcl_id', 'specid', 'specprimary', 'spectype', 'spgrpval', 'std_fiber_dec', 'std_fiber_ra', 'subpriority', 'subtype', 'survey', 'sv1_bgs_target', 'sv1_desi_target', 'sv1_mws_target', 'sv1_scnd_target', 'sv2_bgs_target', 'sv2_desi_target', 'sv2_mws_target', 'sv2_scnd_target', 'sv3_bgs_target', 'sv3_desi_target', 'sv3_mws_target', 'sv3_scnd_target', 'sv_nspec', 'sv_primary', 'targetid', 'telescope', 'tsnr2_bgs', 'tsnr2_elg', 'tsnr2_gpbbackup', 'tsnr2_gpbbright', 'tsnr2_gpbdark', 'tsnr2_lrg', 'tsnr2_lya', 'tsnr2_qso', 'wave_sigma', 'wavelength', 'wavemax', 'wavemin', 'zcat_nspec']
-</pre>
 </div>
 </div>
 </div>
@@ -7820,7 +8057,7 @@ specutils_version==1.20.3
 <div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
 </div>
 <div class="jp-InputArea jp-Cell-inputArea">
-<div class="jp-InputPrompt jp-InputArea-prompt">In [5]:</div>
+<div class="jp-InputPrompt jp-InputArea-prompt">In [ ]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
 <div class="cm-editor cm-s-jupyter">
 <div class="highlight hl-ipython3"><pre><span></span><span class="n">outfields</span> <span class="o">=</span> <span class="p">[</span><span class="s1">'sparcl_id'</span><span class="p">,</span> <span class="s1">'ra'</span><span class="p">,</span> <span class="s1">'dec'</span><span class="p">,</span> <span class="s1">'spectype'</span><span class="p">,</span> <span class="s1">'subtype'</span><span class="p">,</span> <span class="s1">'specid'</span><span class="p">,</span>
@@ -7841,7 +8078,7 @@ specutils_version==1.20.3
 <div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
 </div>
 <div class="jp-InputArea jp-Cell-inputArea">
-<div class="jp-InputPrompt jp-InputArea-prompt">In [6]:</div>
+<div class="jp-InputPrompt jp-InputArea-prompt">In [ ]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
 <div class="cm-editor cm-s-jupyter">
 <div class="highlight hl-ipython3"><pre><span></span><span class="n">found</span> <span class="o">=</span> <span class="n">client</span><span class="o">.</span><span class="n">find</span><span class="p">(</span><span class="n">outfields</span><span class="o">=</span><span class="n">outfields</span><span class="p">,</span>
@@ -7869,7 +8106,7 @@ specutils_version==1.20.3
 <div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
 </div>
 <div class="jp-InputArea jp-Cell-inputArea">
-<div class="jp-InputPrompt jp-InputArea-prompt">In [7]:</div>
+<div class="jp-InputPrompt jp-InputArea-prompt">In [ ]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
 <div class="cm-editor cm-s-jupyter">
 <div class="highlight hl-ipython3"><pre><span></span><span class="k">def</span><span class="w"> </span><span class="nf">radec_to_desiname</span><span class="p">(</span><span class="n">target_ra</span><span class="p">,</span> <span class="n">target_dec</span><span class="p">):</span>
@@ -7944,7 +8181,7 @@ specutils_version==1.20.3
 <div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
 </div>
 <div class="jp-InputArea jp-Cell-inputArea">
-<div class="jp-InputPrompt jp-InputArea-prompt">In [8]:</div>
+<div class="jp-InputPrompt jp-InputArea-prompt">In [ ]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
 <div class="cm-editor cm-s-jupyter">
 <div class="highlight hl-ipython3"><pre><span></span><span class="k">for</span> <span class="n">record</span> <span class="ow">in</span> <span class="n">found</span><span class="o">.</span><span class="n">records</span><span class="p">:</span>
@@ -7968,9 +8205,9 @@ specutils_version==1.20.3
 <h2 id="Retrieve-spectra-from-SPARCL-and-prepare-plot-data">Retrieve spectra from SPARCL and prepare plot data<a class="anchor-link" href="#Retrieve-spectra-from-SPARCL-and-prepare-plot-data">¶</a></h2><p>Here we define a function that:</p>
 <ol>
 <li>Uses the <code>client.retrieve()</code> method from SPARCL to retrieve spectra for the list of IDs from DESI DR1.</li>
-<li>Creates a <code>specutils.Spectrum1D</code> object from the retrieved data.</li>
+<li>Creates a <code>specutils.Spectrum</code> object from the retrieved data.</li>
 <li>Loads the spectrum, metadata, and model.</li>
-<li>Caches the converted <code>Spectrum1D</code> object.</li>
+<li>Caches the converted <code>Spectrum</code> object.</li>
 </ol>
 </div>
 </div>
@@ -7980,7 +8217,7 @@ specutils_version==1.20.3
 <div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
 </div>
 <div class="jp-InputArea jp-Cell-inputArea">
-<div class="jp-InputPrompt jp-InputArea-prompt">In [12]:</div>
+<div class="jp-InputPrompt jp-InputArea-prompt">In [ ]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
 <div class="cm-editor cm-s-jupyter">
 <div class="highlight hl-ipython3"><pre><span></span><span class="k">def</span><span class="w"> </span><span class="nf">on_selected</span><span class="p">(</span><span class="n">b</span><span class="p">):</span>
@@ -8010,20 +8247,24 @@ specutils_version==1.20.3
         <span class="c1">#</span>
         <span class="c1"># Note how the data and the model are prepared as two separate objects.</span>
         <span class="c1">#</span>
-        <span class="c1"># result_specutils = result.to_specutils()</span>
+        <span class="n">result_specutils</span> <span class="o">=</span> <span class="n">result</span><span class="o">.</span><span class="n">to_specutils</span><span class="p">()</span>
+        <span class="n">spectra</span><span class="p">[</span><span class="n">key</span><span class="p">]</span> <span class="o">=</span> <span class="p">(</span><span class="n">result_specutils</span><span class="p">,</span>
+                        <span class="n">Spectrum</span><span class="p">(</span><span class="n">spectral_axis</span><span class="o">=</span><span class="n">result_specutils</span><span class="o">.</span><span class="n">spectral_axis</span><span class="p">,</span>
+                                 <span class="n">flux</span><span class="o">=</span><span class="n">result_specutils</span><span class="o">.</span><span class="n">meta</span><span class="p">[</span><span class="s1">'model'</span><span class="p">]</span><span class="o">*</span><span class="n">specunit</span><span class="p">))</span>
+        <span class="c1">#</span>
+        <span class="c1"># This block is retained for possible use with Jdaviz 4.</span>
         <span class="c1">#</span>
         <span class="c1"># result_specutils.flux = result_specutils.flux[0, :]</span>
         <span class="c1"># result_specutils.uncertainty = result_specutils.uncertainty.represent_as(StdDevUncertainty)[0, :]</span>
         <span class="c1"># result_specutils.mask = result_specutils.mask[0, :]</span>
-        <span class="n">spectra</span><span class="p">[</span><span class="n">key</span><span class="p">]</span> <span class="o">=</span> <span class="p">(</span><span class="n">Spectrum</span><span class="p">(</span><span class="n">spectral_axis</span><span class="o">=</span><span class="n">result</span><span class="o">.</span><span class="n">records</span><span class="p">[</span><span class="mi">0</span><span class="p">][</span><span class="s1">'wavelength'</span><span class="p">]</span><span class="o">*</span><span class="n">u</span><span class="o">.</span><span class="n">AA</span><span class="p">,</span>
-                                 <span class="n">flux</span><span class="o">=</span><span class="n">result</span><span class="o">.</span><span class="n">records</span><span class="p">[</span><span class="mi">0</span><span class="p">][</span><span class="s1">'flux'</span><span class="p">]</span><span class="o">*</span><span class="n">specunit</span><span class="p">,</span>
-                                 <span class="n">uncertainty</span><span class="o">=</span><span class="n">InverseVariance</span><span class="p">(</span><span class="n">result</span><span class="o">.</span><span class="n">records</span><span class="p">[</span><span class="mi">0</span><span class="p">][</span><span class="s1">'ivar'</span><span class="p">]</span><span class="o">*</span><span class="p">(</span><span class="n">specunit</span><span class="o">**-</span><span class="mi">2</span><span class="p">))</span><span class="o">.</span><span class="n">represent_as</span><span class="p">(</span><span class="n">StdDevUncertainty</span><span class="p">),</span>
-                                 <span class="n">mask</span><span class="o">=</span><span class="n">result</span><span class="o">.</span><span class="n">records</span><span class="p">[</span><span class="mi">0</span><span class="p">][</span><span class="s1">'mask'</span><span class="p">],</span>
-                                 <span class="n">redshift</span><span class="o">=</span><span class="n">result</span><span class="o">.</span><span class="n">records</span><span class="p">[</span><span class="mi">0</span><span class="p">][</span><span class="s1">'redshift'</span><span class="p">]),</span>
-                        <span class="n">Spectrum</span><span class="p">(</span><span class="n">spectral_axis</span><span class="o">=</span><span class="n">result</span><span class="o">.</span><span class="n">records</span><span class="p">[</span><span class="mi">0</span><span class="p">][</span><span class="s1">'wavelength'</span><span class="p">]</span><span class="o">*</span><span class="n">u</span><span class="o">.</span><span class="n">AA</span><span class="p">,</span>
-                                 <span class="n">flux</span><span class="o">=</span><span class="n">result</span><span class="o">.</span><span class="n">records</span><span class="p">[</span><span class="mi">0</span><span class="p">][</span><span class="s1">'model'</span><span class="p">]</span><span class="o">*</span><span class="n">specunit</span><span class="p">))</span>
-        <span class="c1"># spectra[key] = (result_specutils, Spectrum(spectral_axis=result_specutils.spectral_axis, flux=result_specutils.meta['model']*specunit))</span>
-        <span class="nb">print</span><span class="p">(</span><span class="n">spectra</span><span class="p">[</span><span class="n">key</span><span class="p">][</span><span class="mi">0</span><span class="p">]</span><span class="o">.</span><span class="n">flux</span><span class="o">.</span><span class="n">shape</span><span class="p">)</span>
+        <span class="c1"># spectra[key] = (Spectrum(spectral_axis=result.records[0]['wavelength']*u.AA,</span>
+        <span class="c1">#                          flux=result.records[0]['flux']*specunit,</span>
+        <span class="c1">#                          uncertainty=InverseVariance(result.records[0]['ivar']*(specunit**-2)).represent_as(StdDevUncertainty),</span>
+        <span class="c1">#                          mask=result.records[0]['mask'],</span>
+        <span class="c1">#                          redshift=result.records[0]['redshift']),</span>
+        <span class="c1">#                 Spectrum(spectral_axis=result.records[0]['wavelength']*u.AA,</span>
+        <span class="c1">#                          flux=result.records[0]['model']*specunit))</span>
+        <span class="c1"># print(spectra[key][0].flux.shape)</span>
     <span class="k">if</span> <span class="s1">'old'</span> <span class="ow">in</span> <span class="n">b</span><span class="p">:</span>
         <span class="c1">#</span>
         <span class="c1"># Remove the previous spectrum.</span>
@@ -8037,7 +8278,10 @@ specutils_version==1.20.3
     <span class="c1">#</span>
     <span class="n">specviz</span><span class="o">.</span><span class="n">load_data</span><span class="p">(</span><span class="n">spectra</span><span class="p">[</span><span class="n">key</span><span class="p">][</span><span class="mi">0</span><span class="p">],</span> <span class="n">data_label</span><span class="o">=</span><span class="n">key</span> <span class="o">+</span> <span class="s1">' Data'</span><span class="p">)</span>
     <span class="n">opt</span> <span class="o">=</span> <span class="n">specviz</span><span class="o">.</span><span class="n">plugins</span><span class="p">[</span><span class="s1">'Plot Options'</span><span class="p">]</span>
-    <span class="n">opt</span><span class="o">.</span><span class="n">layer</span> <span class="o">=</span> <span class="n">key</span> <span class="o">+</span> <span class="s1">' Data [0]'</span>
+    <span class="c1"># Jdaviz 3</span>
+    <span class="n">opt</span><span class="o">.</span><span class="n">layer</span> <span class="o">=</span> <span class="n">key</span> <span class="o">+</span> <span class="s1">' Data'</span>
+    <span class="c1"># Jdaviz 4</span>
+    <span class="c1"># opt.layer = key + ' Data [0]'</span>
     <span class="n">opt</span><span class="o">.</span><span class="n">line_color</span><span class="o">.</span><span class="n">value</span> <span class="o">=</span> <span class="s1">'#000000'</span>  <span class="c1"># Black</span>
     <span class="n">opt</span><span class="o">.</span><span class="n">line_as_steps</span> <span class="o">=</span> <span class="kc">True</span>
     <span class="n">opt</span><span class="o">.</span><span class="n">uncertainty_visible</span> <span class="o">=</span> <span class="kc">True</span>
@@ -8054,15 +8298,22 @@ specutils_version==1.20.3
     <span class="c1">#</span>
     <span class="n">specviz</span><span class="o">.</span><span class="n">load_data</span><span class="p">(</span><span class="n">spectra</span><span class="p">[</span><span class="n">key</span><span class="p">][</span><span class="mi">1</span><span class="p">],</span> <span class="n">data_label</span><span class="o">=</span><span class="n">key</span> <span class="o">+</span> <span class="s1">' Model'</span><span class="p">)</span>
     <span class="n">opt</span> <span class="o">=</span> <span class="n">specviz</span><span class="o">.</span><span class="n">plugins</span><span class="p">[</span><span class="s1">'Plot Options'</span><span class="p">]</span>
-    <span class="n">opt</span><span class="o">.</span><span class="n">layer</span> <span class="o">=</span> <span class="n">key</span> <span class="o">+</span> <span class="s1">' Model [0]'</span>
+    <span class="c1"># Jdaviz 3</span>
+    <span class="n">opt</span><span class="o">.</span><span class="n">layer</span> <span class="o">=</span> <span class="n">key</span> <span class="o">+</span> <span class="s1">' Model'</span>
+    <span class="c1"># Jdaviz 4</span>
+    <span class="c1"># opt.layer = key + ' Model [0]'</span>
     <span class="n">opt</span><span class="o">.</span><span class="n">line_color</span><span class="o">.</span><span class="n">value</span> <span class="o">=</span> <span class="s1">'#FF0000'</span>  <span class="c1"># Red</span>
     <span class="n">opt</span><span class="o">.</span><span class="n">line_as_steps</span> <span class="o">=</span> <span class="kc">True</span>
     <span class="c1">#</span>
     <span class="c1"># This is a workaround for a bug where metadata is not initially displayed.</span>
     <span class="c1">#</span>
     <span class="n">m</span> <span class="o">=</span> <span class="n">specviz</span><span class="o">.</span><span class="n">plugins</span><span class="p">[</span><span class="s1">'Metadata'</span><span class="p">]</span>
-    <span class="n">m</span><span class="o">.</span><span class="n">dataset</span> <span class="o">=</span> <span class="n">key</span> <span class="o">+</span> <span class="s1">' Model [0]'</span>
-    <span class="n">m</span><span class="o">.</span><span class="n">dataset</span> <span class="o">=</span> <span class="n">key</span> <span class="o">+</span> <span class="s1">' Data [0]'</span>
+    <span class="c1"># Jdaviz 3</span>
+    <span class="n">m</span><span class="o">.</span><span class="n">dataset</span> <span class="o">=</span> <span class="n">key</span> <span class="o">+</span> <span class="s1">' Model'</span>
+    <span class="n">m</span><span class="o">.</span><span class="n">dataset</span> <span class="o">=</span> <span class="n">key</span> <span class="o">+</span> <span class="s1">' Data'</span>
+    <span class="c1"># Jdaviz 4</span>
+    <span class="c1"># m.dataset = key + ' Model [0]'</span>
+    <span class="c1"># m.dataset = key + ' Data [0]'</span>
 </pre></div>
 </div>
 </div>
@@ -8081,12 +8332,12 @@ specutils_version==1.20.3
 </div>
 </div>
 </div>
-</div><div class="jp-Cell jp-CodeCell jp-Notebook-cell" id="cell-id=e6867ab3-b29c-46f1-94b8-7b5665c8bed5">
+</div><div class="jp-Cell jp-CodeCell jp-Notebook-cell jp-mod-noOutputs" id="cell-id=e6867ab3-b29c-46f1-94b8-7b5665c8bed5">
 <div class="jp-Cell-inputWrapper" tabindex="0">
 <div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
 </div>
 <div class="jp-InputArea jp-Cell-inputArea">
-<div class="jp-InputPrompt jp-InputArea-prompt">In [13]:</div>
+<div class="jp-InputPrompt jp-InputArea-prompt">In [ ]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
 <div class="cm-editor cm-s-jupyter">
 <div class="highlight hl-ipython3"><pre><span></span><span class="c1">#</span>
@@ -8114,103 +8365,6 @@ specutils_version==1.20.3
 <span class="c1">#</span>
 <span class="n">display</span><span class="p">(</span><span class="n">select</span><span class="p">,</span> <span class="n">output</span><span class="p">)</span>
 </pre></div>
-</div>
-</div>
-</div>
-</div>
-<div class="jp-Cell-outputWrapper">
-<div class="jp-Collapser jp-OutputCollapser jp-Cell-outputCollapser">
-</div>
-<div class="jp-OutputArea jp-Cell-outputArea">
-<div class="jp-OutputArea-child">
-<div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
-<div class="jp-RenderedText jp-OutputArea-output" data-mime-type="text/plain" tabindex="0">
-<pre>(7781,)
-</pre>
-</div>
-</div>
-<div class="jp-OutputArea-child">
-<div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
-<div class="jp-RenderedText jp-OutputArea-output" data-mime-type="application/vnd.jupyter.stderr" tabindex="0">
-<pre>
-<span class="ansi-red-fg">---------------------------------------------------------------------------</span>
-<span class="ansi-red-fg">ValueError</span>                                Traceback (most recent call last)
-Cell <span class="ansi-green-fg">In[13], line 12</span>
-<span class="ansi-green-intense-fg ansi-bold">      8</span> specviz <span style="color: rgb(98,98,98)">=</span> Specviz()
-<span class="ansi-green-intense-fg ansi-bold">      9</span> <span style="color: rgb(95,135,135)">#</span>
-<span class="ansi-green-intense-fg ansi-bold">     10</span> <span style="color: rgb(95,135,135)"># Trigger the download if this is the very first spectrum.</span>
-<span class="ansi-green-intense-fg ansi-bold">     11</span> <span style="color: rgb(95,135,135)">#</span>
-<span class="ansi-green-fg">---&gt; 12</span> <span class="ansi-yellow-bg">on_selected</span><span class="ansi-yellow-bg">(</span><span class="ansi-yellow-bg">{</span><span class="ansi-yellow-bg" style="color: rgb(175,0,0)">'</span><span class="ansi-yellow-bg" style="color: rgb(175,0,0)">new</span><span class="ansi-yellow-bg" style="color: rgb(175,0,0)">'</span><span class="ansi-yellow-bg">:</span><span class="ansi-yellow-bg"> </span><span class="ansi-yellow-bg" style="color: rgb(98,98,98)">0</span><span class="ansi-yellow-bg">}</span><span class="ansi-yellow-bg">)</span>
-<span class="ansi-green-intense-fg ansi-bold">     13</span> <span style="color: rgb(95,135,135)">#</span>
-<span class="ansi-green-intense-fg ansi-bold">     14</span> <span style="color: rgb(95,135,135)"># Connect the function action to the dropdown menu.</span>
-<span class="ansi-green-intense-fg ansi-bold">     15</span> <span style="color: rgb(95,135,135)">#</span>
-<span class="ansi-green-intense-fg ansi-bold">     16</span> select<span style="color: rgb(98,98,98)">.</span>observe(on_selected, names<span style="color: rgb(98,98,98)">=</span><span style="color: rgb(175,0,0)">'</span><span style="color: rgb(175,0,0)">value</span><span style="color: rgb(175,0,0)">'</span>)
-
-Cell <span class="ansi-green-fg">In[12], line 55</span>, in <span class="ansi-cyan-fg">on_selected</span><span class="ansi-blue-fg">(b)</span>
-<span class="ansi-green-intense-fg ansi-bold">     53</span> specviz<span style="color: rgb(98,98,98)">.</span>load_data(spectra[key][<span style="color: rgb(98,98,98)">0</span>], data_label<span style="color: rgb(98,98,98)">=</span>key <span style="color: rgb(98,98,98)">+</span> <span style="color: rgb(175,0,0)">'</span><span style="color: rgb(175,0,0)"> Data</span><span style="color: rgb(175,0,0)">'</span>)
-<span class="ansi-green-intense-fg ansi-bold">     54</span> opt <span style="color: rgb(98,98,98)">=</span> specviz<span style="color: rgb(98,98,98)">.</span>plugins[<span style="color: rgb(175,0,0)">'</span><span style="color: rgb(175,0,0)">Plot Options</span><span style="color: rgb(175,0,0)">'</span>]
-<span class="ansi-green-fg">---&gt; 55</span> <span class="ansi-yellow-bg">opt</span><span class="ansi-yellow-bg" style="color: rgb(98,98,98)">.</span><span class="ansi-yellow-bg">layer</span> <span style="color: rgb(98,98,98)">=</span> key <span style="color: rgb(98,98,98)">+</span> <span style="color: rgb(175,0,0)">'</span><span style="color: rgb(175,0,0)"> Data [0]</span><span style="color: rgb(175,0,0)">'</span>
-<span class="ansi-green-intense-fg ansi-bold">     56</span> opt<span style="color: rgb(98,98,98)">.</span>line_color<span style="color: rgb(98,98,98)">.</span>value <span style="color: rgb(98,98,98)">=</span> <span style="color: rgb(175,0,0)">'</span><span style="color: rgb(175,0,0)">#000000</span><span style="color: rgb(175,0,0)">'</span>  <span style="color: rgb(95,135,135)"># Black</span>
-<span class="ansi-green-intense-fg ansi-bold">     57</span> opt<span style="color: rgb(98,98,98)">.</span>line_as_steps <span style="color: rgb(98,98,98)">=</span> <span class="ansi-bold" style="color: rgb(0,135,0)">True</span>
-
-File <span class="ansi-green-fg">~/Documents/local/products/venv/kitchen_sink/lib/python3.10/site-packages/jdaviz/core/user_api.py:69</span>, in <span class="ansi-cyan-fg">UserApiWrapper.__setattr__</span><span class="ansi-blue-fg">(self, attr, value)</span>
-<span class="ansi-green-intense-fg ansi-bold">     67</span>     <span class="ansi-bold" style="color: rgb(0,135,0)">if</span> <span style="color: rgb(0,135,0)">isinstance</span>(exp_obj, UnitSelectPluginComponent) <span class="ansi-bold" style="color: rgb(175,0,255)">and</span> <span style="color: rgb(0,135,0)">isinstance</span>(value, u<span style="color: rgb(98,98,98)">.</span>Unit):
-<span class="ansi-green-intense-fg ansi-bold">     68</span>         value <span style="color: rgb(98,98,98)">=</span> value<span style="color: rgb(98,98,98)">.</span>to_string()
-<span class="ansi-green-fg">---&gt; 69</span>     <span class="ansi-yellow-bg">exp_obj</span><span class="ansi-yellow-bg" style="color: rgb(98,98,98)">.</span><span class="ansi-yellow-bg">selected</span> <span style="color: rgb(98,98,98)">=</span> value
-<span class="ansi-green-intense-fg ansi-bold">     70</span>     <span class="ansi-bold" style="color: rgb(0,135,0)">return</span>
-<span class="ansi-green-intense-fg ansi-bold">     71</span> <span class="ansi-bold" style="color: rgb(0,135,0)">elif</span> <span style="color: rgb(0,135,0)">isinstance</span>(exp_obj, AddResults):
-
-File <span class="ansi-green-fg">~/Documents/local/products/venv/kitchen_sink/lib/python3.10/site-packages/jdaviz/core/template_mixin.py:767</span>, in <span class="ansi-cyan-fg">BasePluginComponent.__setattr__</span><span class="ansi-blue-fg">(self, attr, value, force_super)</span>
-<span class="ansi-green-intense-fg ansi-bold">    764</span> <span class="ansi-bold" style="color: rgb(0,135,0)">if</span> attr[<span style="color: rgb(98,98,98)">0</span>] <span style="color: rgb(98,98,98)">==</span> <span style="color: rgb(175,0,0)">'</span><span style="color: rgb(175,0,0)">_</span><span style="color: rgb(175,0,0)">'</span> <span class="ansi-bold" style="color: rgb(175,0,255)">or</span> force_super <span class="ansi-bold" style="color: rgb(175,0,255)">or</span> attr <span class="ansi-bold" style="color: rgb(175,0,255)">not</span> <span class="ansi-bold" style="color: rgb(175,0,255)">in</span> <span style="color: rgb(0,135,0)">self</span><span style="color: rgb(98,98,98)">.</span>_plugin_traitlets<span style="color: rgb(98,98,98)">.</span>keys():
-<span class="ansi-green-intense-fg ansi-bold">    765</span>     <span class="ansi-bold" style="color: rgb(0,135,0)">return</span> <span style="color: rgb(0,135,0)">super</span>()<span style="color: rgb(98,98,98)">.</span><span style="color: rgb(0,0,255)">__setattr__</span>(attr, value)
-<span class="ansi-green-fg">--&gt; 767</span> <span class="ansi-bold" style="color: rgb(0,135,0)">return</span> <span class="ansi-yellow-bg" style="color: rgb(0,135,0)">setattr</span><span class="ansi-yellow-bg">(</span><span class="ansi-yellow-bg" style="color: rgb(0,135,0)">self</span><span class="ansi-yellow-bg" style="color: rgb(98,98,98)">.</span><span class="ansi-yellow-bg">_plugin</span><span class="ansi-yellow-bg">,</span><span class="ansi-yellow-bg"> </span><span class="ansi-yellow-bg" style="color: rgb(0,135,0)">self</span><span class="ansi-yellow-bg" style="color: rgb(98,98,98)">.</span><span class="ansi-yellow-bg">_plugin_traitlets</span><span class="ansi-yellow-bg" style="color: rgb(98,98,98)">.</span><span class="ansi-yellow-bg">get</span><span class="ansi-yellow-bg">(</span><span class="ansi-yellow-bg">attr</span><span class="ansi-yellow-bg">)</span><span class="ansi-yellow-bg">,</span><span class="ansi-yellow-bg"> </span><span class="ansi-yellow-bg">value</span><span class="ansi-yellow-bg">)</span>
-
-File <span class="ansi-green-fg">~/Documents/local/products/venv/kitchen_sink/lib/python3.10/site-packages/traitlets/traitlets.py:716</span>, in <span class="ansi-cyan-fg">TraitType.__set__</span><span class="ansi-blue-fg">(self, obj, value)</span>
-<span class="ansi-green-intense-fg ansi-bold">    714</span> <span class="ansi-bold" style="color: rgb(0,135,0)">if</span> <span style="color: rgb(0,135,0)">self</span><span style="color: rgb(98,98,98)">.</span>read_only:
-<span class="ansi-green-intense-fg ansi-bold">    715</span>     <span class="ansi-bold" style="color: rgb(0,135,0)">raise</span> TraitError(<span style="color: rgb(175,0,0)">'</span><span style="color: rgb(175,0,0)">The </span><span style="color: rgb(175,0,0)">"</span><span class="ansi-bold" style="color: rgb(175,95,135)">%s</span><span style="color: rgb(175,0,0)">"</span><span style="color: rgb(175,0,0)"> trait is read-only.</span><span style="color: rgb(175,0,0)">'</span> <span style="color: rgb(98,98,98)">%</span> <span style="color: rgb(0,135,0)">self</span><span style="color: rgb(98,98,98)">.</span>name)
-<span class="ansi-green-fg">--&gt; 716</span> <span class="ansi-yellow-bg" style="color: rgb(0,135,0)">self</span><span class="ansi-yellow-bg" style="color: rgb(98,98,98)">.</span><span class="ansi-yellow-bg">set</span><span class="ansi-yellow-bg">(</span><span class="ansi-yellow-bg">obj</span><span class="ansi-yellow-bg">,</span><span class="ansi-yellow-bg"> </span><span class="ansi-yellow-bg">value</span><span class="ansi-yellow-bg">)</span>
-
-File <span class="ansi-green-fg">~/Documents/local/products/venv/kitchen_sink/lib/python3.10/site-packages/traitlets/traitlets.py:706</span>, in <span class="ansi-cyan-fg">TraitType.set</span><span class="ansi-blue-fg">(self, obj, value)</span>
-<span class="ansi-green-intense-fg ansi-bold">    702</span>     silent <span style="color: rgb(98,98,98)">=</span> <span class="ansi-bold" style="color: rgb(0,135,0)">False</span>
-<span class="ansi-green-intense-fg ansi-bold">    703</span> <span class="ansi-bold" style="color: rgb(0,135,0)">if</span> silent <span class="ansi-bold" style="color: rgb(175,0,255)">is</span> <span class="ansi-bold" style="color: rgb(175,0,255)">not</span> <span class="ansi-bold" style="color: rgb(0,135,0)">True</span>:
-<span class="ansi-green-intense-fg ansi-bold">    704</span>     <span style="color: rgb(95,135,135)"># we explicitly compare silent to True just in case the equality</span>
-<span class="ansi-green-intense-fg ansi-bold">    705</span>     <span style="color: rgb(95,135,135)"># comparison above returns something other than True/False</span>
-<span class="ansi-green-fg">--&gt; 706</span>     <span class="ansi-yellow-bg">obj</span><span class="ansi-yellow-bg" style="color: rgb(98,98,98)">.</span><span class="ansi-yellow-bg">_notify_trait</span><span class="ansi-yellow-bg">(</span><span class="ansi-yellow-bg" style="color: rgb(0,135,0)">self</span><span class="ansi-yellow-bg" style="color: rgb(98,98,98)">.</span><span class="ansi-yellow-bg">name</span><span class="ansi-yellow-bg">,</span><span class="ansi-yellow-bg"> </span><span class="ansi-yellow-bg">old_value</span><span class="ansi-yellow-bg">,</span><span class="ansi-yellow-bg"> </span><span class="ansi-yellow-bg">new_value</span><span class="ansi-yellow-bg">)</span>
-
-File <span class="ansi-green-fg">~/Documents/local/products/venv/kitchen_sink/lib/python3.10/site-packages/traitlets/traitlets.py:1513</span>, in <span class="ansi-cyan-fg">HasTraits._notify_trait</span><span class="ansi-blue-fg">(self, name, old_value, new_value)</span>
-<span class="ansi-green-intense-fg ansi-bold">   1512</span> <span class="ansi-bold" style="color: rgb(0,135,0)">def</span><span style="color: rgb(188,188,188)"> </span><span style="color: rgb(0,0,255)">_notify_trait</span>(<span style="color: rgb(0,135,0)">self</span>, name: <span style="color: rgb(0,135,0)">str</span>, old_value: t<span style="color: rgb(98,98,98)">.</span>Any, new_value: t<span style="color: rgb(98,98,98)">.</span>Any) <span style="color: rgb(98,98,98)">-</span><span style="color: rgb(98,98,98)">&gt;</span> <span class="ansi-bold" style="color: rgb(0,135,0)">None</span>:
-<span class="ansi-green-fg">-&gt; 1513</span>     <span class="ansi-yellow-bg" style="color: rgb(0,135,0)">self</span><span class="ansi-yellow-bg" style="color: rgb(98,98,98)">.</span><span class="ansi-yellow-bg">notify_change</span><span class="ansi-yellow-bg">(</span>
-<span class="ansi-green-intense-fg ansi-bold">   1514</span> <span class="ansi-yellow-bg">        </span><span class="ansi-yellow-bg">Bunch</span><span class="ansi-yellow-bg">(</span>
-<span class="ansi-green-intense-fg ansi-bold">   1515</span> <span class="ansi-yellow-bg">            </span><span class="ansi-yellow-bg">name</span><span class="ansi-yellow-bg" style="color: rgb(98,98,98)">=</span><span class="ansi-yellow-bg">name</span><span class="ansi-yellow-bg">,</span>
-<span class="ansi-green-intense-fg ansi-bold">   1516</span> <span class="ansi-yellow-bg">            </span><span class="ansi-yellow-bg">old</span><span class="ansi-yellow-bg" style="color: rgb(98,98,98)">=</span><span class="ansi-yellow-bg">old_value</span><span class="ansi-yellow-bg">,</span>
-<span class="ansi-green-intense-fg ansi-bold">   1517</span> <span class="ansi-yellow-bg">            </span><span class="ansi-yellow-bg">new</span><span class="ansi-yellow-bg" style="color: rgb(98,98,98)">=</span><span class="ansi-yellow-bg">new_value</span><span class="ansi-yellow-bg">,</span>
-<span class="ansi-green-intense-fg ansi-bold">   1518</span> <span class="ansi-yellow-bg">            </span><span class="ansi-yellow-bg">owner</span><span class="ansi-yellow-bg" style="color: rgb(98,98,98)">=</span><span class="ansi-yellow-bg" style="color: rgb(0,135,0)">self</span><span class="ansi-yellow-bg">,</span>
-<span class="ansi-green-intense-fg ansi-bold">   1519</span> <span class="ansi-yellow-bg">            </span><span class="ansi-yellow-bg" style="color: rgb(0,135,0)">type</span><span class="ansi-yellow-bg" style="color: rgb(98,98,98)">=</span><span class="ansi-yellow-bg" style="color: rgb(175,0,0)">"</span><span class="ansi-yellow-bg" style="color: rgb(175,0,0)">change</span><span class="ansi-yellow-bg" style="color: rgb(175,0,0)">"</span><span class="ansi-yellow-bg">,</span>
-<span class="ansi-green-intense-fg ansi-bold">   1520</span> <span class="ansi-yellow-bg">        </span><span class="ansi-yellow-bg">)</span>
-<span class="ansi-green-intense-fg ansi-bold">   1521</span> <span class="ansi-yellow-bg">    </span><span class="ansi-yellow-bg">)</span>
-
-File <span class="ansi-green-fg">~/Documents/local/products/venv/kitchen_sink/lib/python3.10/site-packages/ipywidgets/widgets/widget.py:701</span>, in <span class="ansi-cyan-fg">Widget.notify_change</span><span class="ansi-blue-fg">(self, change)</span>
-<span class="ansi-green-intense-fg ansi-bold">    698</span>     <span class="ansi-bold" style="color: rgb(0,135,0)">if</span> name <span class="ansi-bold" style="color: rgb(175,0,255)">in</span> <span style="color: rgb(0,135,0)">self</span><span style="color: rgb(98,98,98)">.</span>keys <span class="ansi-bold" style="color: rgb(175,0,255)">and</span> <span style="color: rgb(0,135,0)">self</span><span style="color: rgb(98,98,98)">.</span>_should_send_property(name, <span style="color: rgb(0,135,0)">getattr</span>(<span style="color: rgb(0,135,0)">self</span>, name)):
-<span class="ansi-green-intense-fg ansi-bold">    699</span>         <span style="color: rgb(95,135,135)"># Send new state to front-end</span>
-<span class="ansi-green-intense-fg ansi-bold">    700</span>         <span style="color: rgb(0,135,0)">self</span><span style="color: rgb(98,98,98)">.</span>send_state(key<span style="color: rgb(98,98,98)">=</span>name)
-<span class="ansi-green-fg">--&gt; 701</span> <span class="ansi-yellow-bg" style="color: rgb(0,135,0)">super</span><span class="ansi-yellow-bg">(</span><span class="ansi-yellow-bg">)</span><span class="ansi-yellow-bg" style="color: rgb(98,98,98)">.</span><span class="ansi-yellow-bg">notify_change</span><span class="ansi-yellow-bg">(</span><span class="ansi-yellow-bg">change</span><span class="ansi-yellow-bg">)</span>
-
-File <span class="ansi-green-fg">~/Documents/local/products/venv/kitchen_sink/lib/python3.10/site-packages/traitlets/traitlets.py:1525</span>, in <span class="ansi-cyan-fg">HasTraits.notify_change</span><span class="ansi-blue-fg">(self, change)</span>
-<span class="ansi-green-intense-fg ansi-bold">   1523</span> <span class="ansi-bold" style="color: rgb(0,135,0)">def</span><span style="color: rgb(188,188,188)"> </span><span style="color: rgb(0,0,255)">notify_change</span>(<span style="color: rgb(0,135,0)">self</span>, change: Bunch) <span style="color: rgb(98,98,98)">-</span><span style="color: rgb(98,98,98)">&gt;</span> <span class="ansi-bold" style="color: rgb(0,135,0)">None</span>:
-<span class="ansi-green-intense-fg ansi-bold">   1524</span> <span style="color: rgb(188,188,188)">    </span><span style="color: rgb(175,0,0)">"""Notify observers of a change event"""</span>
-<span class="ansi-green-fg">-&gt; 1525</span>     <span class="ansi-bold" style="color: rgb(0,135,0)">return</span> <span class="ansi-yellow-bg" style="color: rgb(0,135,0)">self</span><span class="ansi-yellow-bg" style="color: rgb(98,98,98)">.</span><span class="ansi-yellow-bg">_notify_observers</span><span class="ansi-yellow-bg">(</span><span class="ansi-yellow-bg">change</span><span class="ansi-yellow-bg">)</span>
-
-File <span class="ansi-green-fg">~/Documents/local/products/venv/kitchen_sink/lib/python3.10/site-packages/traitlets/traitlets.py:1568</span>, in <span class="ansi-cyan-fg">HasTraits._notify_observers</span><span class="ansi-blue-fg">(self, event)</span>
-<span class="ansi-green-intense-fg ansi-bold">   1565</span> <span class="ansi-bold" style="color: rgb(0,135,0)">elif</span> <span style="color: rgb(0,135,0)">isinstance</span>(c, EventHandler) <span class="ansi-bold" style="color: rgb(175,0,255)">and</span> c<span style="color: rgb(98,98,98)">.</span>name <span class="ansi-bold" style="color: rgb(175,0,255)">is</span> <span class="ansi-bold" style="color: rgb(175,0,255)">not</span> <span class="ansi-bold" style="color: rgb(0,135,0)">None</span>:
-<span class="ansi-green-intense-fg ansi-bold">   1566</span>     c <span style="color: rgb(98,98,98)">=</span> <span style="color: rgb(0,135,0)">getattr</span>(<span style="color: rgb(0,135,0)">self</span>, c<span style="color: rgb(98,98,98)">.</span>name)
-<span class="ansi-green-fg">-&gt; 1568</span> <span class="ansi-yellow-bg">c</span><span class="ansi-yellow-bg">(</span><span class="ansi-yellow-bg">event</span><span class="ansi-yellow-bg">)</span>
-
-File <span class="ansi-green-fg">~/Documents/local/products/venv/kitchen_sink/lib/python3.10/site-packages/jdaviz/core/template_mixin.py:1141</span>, in <span class="ansi-cyan-fg">SelectPluginComponent._selected_changed</span><span class="ansi-blue-fg">(self, event)</span>
-<span class="ansi-green-intense-fg ansi-bold">   1139</span> <span class="ansi-bold" style="color: rgb(0,135,0)">if</span> event[<span style="color: rgb(175,0,0)">'</span><span style="color: rgb(175,0,0)">new</span><span style="color: rgb(175,0,0)">'</span>] <span class="ansi-bold" style="color: rgb(175,0,255)">not</span> <span class="ansi-bold" style="color: rgb(175,0,255)">in</span> valid <span style="color: rgb(98,98,98)">+</span> [<span style="color: rgb(175,0,0)">'</span><span style="color: rgb(175,0,0)">'</span>]:
-<span class="ansi-green-intense-fg ansi-bold">   1140</span>     <span style="color: rgb(0,135,0)">self</span><span style="color: rgb(98,98,98)">.</span>selected <span style="color: rgb(98,98,98)">=</span> event[<span style="color: rgb(175,0,0)">'</span><span style="color: rgb(175,0,0)">old</span><span style="color: rgb(175,0,0)">'</span>]
-<span class="ansi-green-fg">-&gt; 1141</span>     <span class="ansi-bold" style="color: rgb(0,135,0)">raise</span> <span class="ansi-bold" style="color: rgb(215,95,95)">ValueError</span>(<span style="color: rgb(175,0,0)">f</span><span style="color: rgb(175,0,0)">"</span><span class="ansi-bold" style="color: rgb(175,95,0)">\'</span><span class="ansi-bold" style="color: rgb(175,95,135)">{</span>event[<span style="color: rgb(175,0,0)">'</span><span style="color: rgb(175,0,0)">new</span><span style="color: rgb(175,0,0)">'</span>]<span class="ansi-bold" style="color: rgb(175,95,135)">}</span><span class="ansi-bold" style="color: rgb(175,95,0)">\'</span><span style="color: rgb(175,0,0)"> not one of </span><span class="ansi-bold" style="color: rgb(175,95,135)">{</span>valid<span class="ansi-bold" style="color: rgb(175,95,135)">}</span><span style="color: rgb(175,0,0)">, reverting selection to </span><span class="ansi-bold" style="color: rgb(175,95,0)">\'</span><span class="ansi-bold" style="color: rgb(175,95,135)">{</span>event[<span style="color: rgb(175,0,0)">'</span><span style="color: rgb(175,0,0)">old</span><span style="color: rgb(175,0,0)">'</span>]<span class="ansi-bold" style="color: rgb(175,95,135)">}</span><span class="ansi-bold" style="color: rgb(175,95,0)">\'</span><span style="color: rgb(175,0,0)">"</span>)
-
-<span class="ansi-red-fg">ValueError</span>: 'DESI J003.7111+07.9541 Data [0]' not one of ['DESI J003.7111+07.9541 Data'], reverting selection to 'DESI J003.7111+07.9541 Data'</pre>
 </div>
 </div>
 </div>

--- a/04_HowTos/SPARCL/Plot_SPARCL_Spectra_with_Jdaviz.ipynb
+++ b/04_HowTos/SPARCL/Plot_SPARCL_Spectra_with_Jdaviz.ipynb
@@ -126,31 +126,60 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "1b12bf2e",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-01-13T17:48:17.159289Z",
+     "iopub.status.busy": "2026-01-13T17:48:17.159034Z",
+     "iopub.status.idle": "2026-01-13T17:48:19.783305Z",
+     "shell.execute_reply": "2026-01-13T17:48:19.782612Z",
+     "shell.execute_reply.started": "2026-01-13T17:48:17.159259Z"
+    },
     "tags": []
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "sparcl_version==1.2.8\n",
+      "jdaviz_version==3.8.2\n",
+      "specutils_version==1.13.0\n"
+     ]
+    }
+   ],
    "source": [
+    "import os\n",
+    "import sys\n",
+    "sys.path.insert(1, os.path.join(os.environ['HOME'], 'Documents', 'Code', 'git', 'nsf-noirlab', 'csdc', 'datalab', 'sparcl', 'sparclclient'))\n",
     "# Handle warnings below\n",
     "import warnings\n",
     "# Numpy import\n",
     "import numpy as np\n",
     "# SPARCL import\n",
+    "from sparcl import __version__ as sparcl_version\n",
     "from sparcl.client import SparclClient\n",
     "# Jdaviz import\n",
+    "from jdaviz import __version__ as jdaviz_version\n",
     "from jdaviz import Specviz\n",
     "# Jupyter\n",
     "import ipywidgets as widgets\n",
     "from IPython.display import display\n",
     "# Specutils import\n",
-    "from specutils import Spectrum1D\n",
+    "from specutils import __version__ as specutils_version\n",
+    "try:\n",
+    "    from specutils import Spectrum\n",
+    "except:\n",
+    "    from specutils import Spectrum1D as Spectrum\n",
     "# Astropy import\n",
     "import astropy.units as u\n",
     "from astropy.nddata import InverseVariance, StdDevUncertainty\n",
     "# Jdaviz can emit warnings about Angstrom which we will ignore.\n",
-    "warnings.filterwarnings('ignore', category=u.UnitsWarning, message=r'.*VOUnit standard.*')"
+    "warnings.filterwarnings('ignore', category=u.UnitsWarning, message=r'.*VOUnit standard.*')\n",
+    "print(f\"sparcl_version=={sparcl_version}\")\n",
+    "print(f\"jdaviz_version=={jdaviz_version}\")\n",
+    "print(f\"specutils_version=={specutils_version}\")"
    ]
   },
   {
@@ -163,12 +192,37 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "id": "482c5e93",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-01-13T17:48:21.332000Z",
+     "iopub.status.busy": "2026-01-13T17:48:21.331783Z",
+     "iopub.status.idle": "2026-01-13T17:48:21.623124Z",
+     "shell.execute_reply": "2026-01-13T17:48:21.622493Z",
+     "shell.execute_reply.started": "2026-01-13T17:48:21.331986Z"
+    },
     "tags": []
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "announcement=Data set deprecation notice: on November 19, 2025 the SDSS/BOSS DR16 data sets were deprecated. Please use the new SDSS/BOSS DR17 data sets instead.\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "(sparclclient:1.2.8, api:13.0, https://astrosparcl.datalab.noirlab.edu/api, client_hash=829f72b02e216275c9f079aeea2a162e2cf6e795, verbose=False, connect_timeout=1.1, read_timeout=5400.0, announcement=True)"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "client = SparclClient()\n",
     "client"
@@ -184,12 +238,27 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "id": "9e288542-73aa-45cf-9f69-668bd3208d70",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-01-13T17:48:22.751355Z",
+     "iopub.status.busy": "2026-01-13T17:48:22.750947Z",
+     "iopub.status.idle": "2026-01-13T17:48:22.754839Z",
+     "shell.execute_reply": "2026-01-13T17:48:22.754238Z",
+     "shell.execute_reply.started": "2026-01-13T17:48:22.751337Z"
+    },
     "tags": []
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "['bgs_target', 'chi2', 'cmx_target', 'coadd_fiberstatus', 'coadd_numexp', 'coadd_numnight', 'coadd_numtile', 'coeff', 'data_release', 'datasetgroup', 'dateobs', 'dateobs_center', 'dec', 'deltachi2', 'desi_target', 'desiname', 'exptime', 'fa_target', 'fa_type', 'flux', 'healpix', 'instrument', 'ivar', 'main_nspec', 'main_primary', 'mask', 'mean_delta_x', 'mean_delta_y', 'mean_fiber_dec', 'mean_fiber_ra', 'mean_mjd', 'mean_psf_to_fiber_specflux', 'model', 'mws_target', 'ncoeff', 'npixels', 'numobs_init', 'objtype', 'obsconditions', 'plate_dec', 'plate_ra', 'pmdec', 'pmra', 'priority_init', 'program', 'ra', 'redshift', 'redshift_err', 'redshift_warning', 'ref_epoch', 'rms_delta_x', 'rms_delta_y', 'scnd_target', 'site', 'sparcl_id', 'specid', 'specprimary', 'spectype', 'spgrpval', 'std_fiber_dec', 'std_fiber_ra', 'subpriority', 'subtype', 'survey', 'sv1_bgs_target', 'sv1_desi_target', 'sv1_mws_target', 'sv1_scnd_target', 'sv2_bgs_target', 'sv2_desi_target', 'sv2_mws_target', 'sv2_scnd_target', 'sv3_bgs_target', 'sv3_desi_target', 'sv3_mws_target', 'sv3_scnd_target', 'sv_nspec', 'sv_primary', 'targetid', 'telescope', 'tsnr2_bgs', 'tsnr2_elg', 'tsnr2_gpbbackup', 'tsnr2_gpbbright', 'tsnr2_gpbdark', 'tsnr2_lrg', 'tsnr2_lya', 'tsnr2_qso', 'wave_sigma', 'wavelength', 'wavemax', 'wavemin', 'zcat_nspec']\n"
+     ]
+    }
+   ],
    "source": [
     "desi_fields = client.get_all_fields(dataset_list=['DESI-DR1'])\n",
     "print(desi_fields)"
@@ -222,9 +291,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "id": "9b7d99c6",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-01-13T17:48:24.404099Z",
+     "iopub.status.busy": "2026-01-13T17:48:24.403745Z",
+     "iopub.status.idle": "2026-01-13T17:48:24.407255Z",
+     "shell.execute_reply": "2026-01-13T17:48:24.406696Z",
+     "shell.execute_reply.started": "2026-01-13T17:48:24.404084Z"
+    },
     "tags": []
    },
    "outputs": [],
@@ -241,9 +317,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "id": "9ae27a9b",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-01-13T17:48:25.226064Z",
+     "iopub.status.busy": "2026-01-13T17:48:25.225793Z",
+     "iopub.status.idle": "2026-01-13T17:48:25.346519Z",
+     "shell.execute_reply": "2026-01-13T17:48:25.345934Z",
+     "shell.execute_reply.started": "2026-01-13T17:48:25.226050Z"
+    },
     "tags": []
    },
    "outputs": [],
@@ -267,9 +350,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "id": "6e31ef55-3e14-45ab-9c9e-5a2da06f403b",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-01-13T17:48:26.754445Z",
+     "iopub.status.busy": "2026-01-13T17:48:26.754186Z",
+     "iopub.status.idle": "2026-01-13T17:48:26.759767Z",
+     "shell.execute_reply": "2026-01-13T17:48:26.759170Z",
+     "shell.execute_reply.started": "2026-01-13T17:48:26.754430Z"
+    }
+   },
    "outputs": [],
    "source": [
     "def radec_to_desiname(target_ra, target_dec):\n",
@@ -335,9 +426,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "id": "91008745-9ff5-485c-92cb-7554628a0f60",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-01-13T17:48:28.183657Z",
+     "iopub.status.busy": "2026-01-13T17:48:28.183397Z",
+     "iopub.status.idle": "2026-01-13T17:48:28.188462Z",
+     "shell.execute_reply": "2026-01-13T17:48:28.187882Z",
+     "shell.execute_reply.started": "2026-01-13T17:48:28.183643Z"
+    },
     "tags": []
    },
    "outputs": [],
@@ -365,9 +463,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 14,
    "id": "1d036ac5-7310-43a1-8346-f0eff7c0010d",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-01-13T18:04:40.599658Z",
+     "iopub.status.busy": "2026-01-13T18:04:40.599363Z",
+     "iopub.status.idle": "2026-01-13T18:04:40.610568Z",
+     "shell.execute_reply": "2026-01-13T18:04:40.610123Z",
+     "shell.execute_reply.started": "2026-01-13T18:04:40.599638Z"
+    },
     "tags": []
    },
    "outputs": [],
@@ -383,7 +488,8 @@
     "    specunit = u.Unit('10-17 erg cm-2 s-1 AA-1')\n",
     "    key = entries[b['new']][0]\n",
     "    result = client.retrieve(uuid_list=[ids[b['new']]],\n",
-    "                             include=['specid',\n",
+    "                             include=['data_release',\n",
+    "                                      'specid',\n",
     "                                      'survey',\n",
     "                                      'ra',\n",
     "                                      'dec',\n",
@@ -398,13 +504,21 @@
     "        #\n",
     "        # Note how the data and the model are prepared as two separate objects.\n",
     "        #\n",
-    "        spectra[key] = (Spectrum1D(spectral_axis=result.records[0]['wavelength']*u.AA,\n",
-    "                                   flux=result.records[0]['flux']*specunit,\n",
-    "                                   uncertainty=InverseVariance(result.records[0]['ivar']*(specunit**-2)).represent_as(StdDevUncertainty),\n",
-    "                                   mask=result.records[0]['mask'],\n",
-    "                                   redshift=result.records[0]['redshift']),\n",
-    "                        Spectrum1D(spectral_axis=result.records[0]['wavelength']*u.AA,\n",
-    "                                   flux=result.records[0]['model']*specunit))\n",
+    "        # result_specutils = result.to_specutils()\n",
+    "        #\n",
+    "        # result_specutils.flux = result_specutils.flux[0, :]\n",
+    "        # result_specutils.uncertainty = result_specutils.uncertainty.represent_as(StdDevUncertainty)[0, :]\n",
+    "        # result_specutils.mask = result_specutils.mask[0, :]\n",
+    "        # print(result_specutils.flux.shape)\n",
+    "        spectra[key] = (Spectrum(spectral_axis=result.records[0]['wavelength']*u.AA,\n",
+    "                                 flux=result.records[0]['flux']*specunit,\n",
+    "                                 uncertainty=InverseVariance(result.records[0]['ivar']*(specunit**-2)).represent_as(StdDevUncertainty),\n",
+    "                                 mask=result.records[0]['mask'],\n",
+    "                                 redshift=result.records[0]['redshift']),\n",
+    "                        Spectrum(spectral_axis=result.records[0]['wavelength']*u.AA,\n",
+    "                                 flux=result.records[0]['model']*specunit))\n",
+    "        # print(spectra[key][0].flux.shape)\n",
+    "        # spectra[key] = (result_specutils, Spectrum(spectral_axis=result_specutils.spectral_axis, flux=result_specutils.meta['model'][0, :]*specunit))\n",
     "    if 'old' in b:\n",
     "        #\n",
     "        # Remove the previous spectrum.\n",
@@ -460,10 +574,31 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 15,
    "id": "e6867ab3-b29c-46f1-94b8-7b5665c8bed5",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-01-13T18:04:41.644616Z",
+     "iopub.status.busy": "2026-01-13T18:04:41.644299Z",
+     "iopub.status.idle": "2026-01-13T18:04:42.386400Z",
+     "shell.execute_reply": "2026-01-13T18:04:42.385532Z",
+     "shell.execute_reply.started": "2026-01-13T18:04:41.644592Z"
+    }
+   },
+   "outputs": [
+    {
+     "ename": "AttributeError",
+     "evalue": "can't set attribute 'flux'",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mAttributeError\u001b[0m                            Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[15], line 12\u001b[0m\n\u001b[1;32m      8\u001b[0m specviz \u001b[38;5;241m=\u001b[39m Specviz()\n\u001b[1;32m      9\u001b[0m \u001b[38;5;66;03m#\u001b[39;00m\n\u001b[1;32m     10\u001b[0m \u001b[38;5;66;03m# Trigger the download if this is the very first spectrum.\u001b[39;00m\n\u001b[1;32m     11\u001b[0m \u001b[38;5;66;03m#\u001b[39;00m\n\u001b[0;32m---> 12\u001b[0m \u001b[43mon_selected\u001b[49m\u001b[43m(\u001b[49m\u001b[43m{\u001b[49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[38;5;124;43mnew\u001b[39;49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[43m:\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m0\u001b[39;49m\u001b[43m}\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m     13\u001b[0m \u001b[38;5;66;03m#\u001b[39;00m\n\u001b[1;32m     14\u001b[0m \u001b[38;5;66;03m# Connect the function action to the dropdown menu.\u001b[39;00m\n\u001b[1;32m     15\u001b[0m \u001b[38;5;66;03m#\u001b[39;00m\n\u001b[1;32m     16\u001b[0m select\u001b[38;5;241m.\u001b[39mobserve(on_selected, names\u001b[38;5;241m=\u001b[39m\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mvalue\u001b[39m\u001b[38;5;124m'\u001b[39m)\n",
+      "Cell \u001b[0;32mIn[14], line 30\u001b[0m, in \u001b[0;36mon_selected\u001b[0;34m(b)\u001b[0m\n\u001b[1;32m     28\u001b[0m result_specutils \u001b[38;5;241m=\u001b[39m result\u001b[38;5;241m.\u001b[39mto_specutils()\n\u001b[1;32m     29\u001b[0m \u001b[38;5;66;03m#\u001b[39;00m\n\u001b[0;32m---> 30\u001b[0m \u001b[43mresult_specutils\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mflux\u001b[49m \u001b[38;5;241m=\u001b[39m result_specutils\u001b[38;5;241m.\u001b[39mflux[\u001b[38;5;241m0\u001b[39m, :]\n\u001b[1;32m     31\u001b[0m result_specutils\u001b[38;5;241m.\u001b[39muncertainty \u001b[38;5;241m=\u001b[39m result_specutils\u001b[38;5;241m.\u001b[39muncertainty\u001b[38;5;241m.\u001b[39mrepresent_as(StdDevUncertainty)[\u001b[38;5;241m0\u001b[39m, :]\n\u001b[1;32m     32\u001b[0m result_specutils\u001b[38;5;241m.\u001b[39mmask \u001b[38;5;241m=\u001b[39m result_specutils\u001b[38;5;241m.\u001b[39mmask[\u001b[38;5;241m0\u001b[39m, :]\n",
+      "\u001b[0;31mAttributeError\u001b[0m: can't set attribute 'flux'"
+     ]
+    }
+   ],
    "source": [
     "#\n",
     "# Set up Specviz and the drop-down menu.\n",
@@ -502,7 +637,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (DL,Py3.10.13)",
    "language": "python",
    "name": "python3"
   },

--- a/04_HowTos/SPARCL/Plot_SPARCL_Spectra_with_Jdaviz.ipynb
+++ b/04_HowTos/SPARCL/Plot_SPARCL_Spectra_with_Jdaviz.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "0d6d67d9-3c55-455a-bfae-0a7f9ec27a02",
    "metadata": {},
    "outputs": [],
@@ -126,16 +126,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 2,
    "id": "1b12bf2e",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-01-13T17:48:17.159289Z",
-     "iopub.status.busy": "2026-01-13T17:48:17.159034Z",
-     "iopub.status.idle": "2026-01-13T17:48:19.783305Z",
-     "shell.execute_reply": "2026-01-13T17:48:19.782612Z",
-     "shell.execute_reply.started": "2026-01-13T17:48:17.159259Z"
-    },
     "tags": []
    },
    "outputs": [
@@ -144,8 +137,8 @@
      "output_type": "stream",
      "text": [
       "sparcl_version==1.2.8\n",
-      "jdaviz_version==3.8.2\n",
-      "specutils_version==1.13.0\n"
+      "jdaviz_version==4.2.3\n",
+      "specutils_version==1.20.3\n"
      ]
     }
    ],
@@ -192,16 +185,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 3,
    "id": "482c5e93",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-01-13T17:48:21.332000Z",
-     "iopub.status.busy": "2026-01-13T17:48:21.331783Z",
-     "iopub.status.idle": "2026-01-13T17:48:21.623124Z",
-     "shell.execute_reply": "2026-01-13T17:48:21.622493Z",
-     "shell.execute_reply.started": "2026-01-13T17:48:21.331986Z"
-    },
     "tags": []
    },
    "outputs": [
@@ -215,10 +201,10 @@
     {
      "data": {
       "text/plain": [
-       "(sparclclient:1.2.8, api:13.0, https://astrosparcl.datalab.noirlab.edu/api, client_hash=829f72b02e216275c9f079aeea2a162e2cf6e795, verbose=False, connect_timeout=1.1, read_timeout=5400.0, announcement=True)"
+       "(sparclclient:1.2.8, api:13.0, https://astrosparcl.datalab.noirlab.edu/api, client_hash=16e04212a9a27f648c0f43dcb99d9b5ae9ec37e0, verbose=False, connect_timeout=1.1, read_timeout=5400.0, announcement=True)"
       ]
      },
-     "execution_count": 2,
+     "execution_count": 3,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -238,16 +224,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "id": "9e288542-73aa-45cf-9f69-668bd3208d70",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-01-13T17:48:22.751355Z",
-     "iopub.status.busy": "2026-01-13T17:48:22.750947Z",
-     "iopub.status.idle": "2026-01-13T17:48:22.754839Z",
-     "shell.execute_reply": "2026-01-13T17:48:22.754238Z",
-     "shell.execute_reply.started": "2026-01-13T17:48:22.751337Z"
-    },
     "tags": []
    },
    "outputs": [
@@ -291,16 +270,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "id": "9b7d99c6",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-01-13T17:48:24.404099Z",
-     "iopub.status.busy": "2026-01-13T17:48:24.403745Z",
-     "iopub.status.idle": "2026-01-13T17:48:24.407255Z",
-     "shell.execute_reply": "2026-01-13T17:48:24.406696Z",
-     "shell.execute_reply.started": "2026-01-13T17:48:24.404084Z"
-    },
     "tags": []
    },
    "outputs": [],
@@ -317,16 +289,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "id": "9ae27a9b",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-01-13T17:48:25.226064Z",
-     "iopub.status.busy": "2026-01-13T17:48:25.225793Z",
-     "iopub.status.idle": "2026-01-13T17:48:25.346519Z",
-     "shell.execute_reply": "2026-01-13T17:48:25.345934Z",
-     "shell.execute_reply.started": "2026-01-13T17:48:25.226050Z"
-    },
     "tags": []
    },
    "outputs": [],
@@ -350,17 +315,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "id": "6e31ef55-3e14-45ab-9c9e-5a2da06f403b",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-01-13T17:48:26.754445Z",
-     "iopub.status.busy": "2026-01-13T17:48:26.754186Z",
-     "iopub.status.idle": "2026-01-13T17:48:26.759767Z",
-     "shell.execute_reply": "2026-01-13T17:48:26.759170Z",
-     "shell.execute_reply.started": "2026-01-13T17:48:26.754430Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "def radec_to_desiname(target_ra, target_dec):\n",
@@ -426,16 +383,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "id": "91008745-9ff5-485c-92cb-7554628a0f60",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-01-13T17:48:28.183657Z",
-     "iopub.status.busy": "2026-01-13T17:48:28.183397Z",
-     "iopub.status.idle": "2026-01-13T17:48:28.188462Z",
-     "shell.execute_reply": "2026-01-13T17:48:28.187882Z",
-     "shell.execute_reply.started": "2026-01-13T17:48:28.183643Z"
-    },
     "tags": []
    },
    "outputs": [],
@@ -463,16 +413,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 12,
    "id": "1d036ac5-7310-43a1-8346-f0eff7c0010d",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-01-13T18:04:40.599658Z",
-     "iopub.status.busy": "2026-01-13T18:04:40.599363Z",
-     "iopub.status.idle": "2026-01-13T18:04:40.610568Z",
-     "shell.execute_reply": "2026-01-13T18:04:40.610123Z",
-     "shell.execute_reply.started": "2026-01-13T18:04:40.599638Z"
-    },
     "tags": []
    },
    "outputs": [],
@@ -509,7 +452,6 @@
     "        # result_specutils.flux = result_specutils.flux[0, :]\n",
     "        # result_specutils.uncertainty = result_specutils.uncertainty.represent_as(StdDevUncertainty)[0, :]\n",
     "        # result_specutils.mask = result_specutils.mask[0, :]\n",
-    "        # print(result_specutils.flux.shape)\n",
     "        spectra[key] = (Spectrum(spectral_axis=result.records[0]['wavelength']*u.AA,\n",
     "                                 flux=result.records[0]['flux']*specunit,\n",
     "                                 uncertainty=InverseVariance(result.records[0]['ivar']*(specunit**-2)).represent_as(StdDevUncertainty),\n",
@@ -517,8 +459,8 @@
     "                                 redshift=result.records[0]['redshift']),\n",
     "                        Spectrum(spectral_axis=result.records[0]['wavelength']*u.AA,\n",
     "                                 flux=result.records[0]['model']*specunit))\n",
-    "        # print(spectra[key][0].flux.shape)\n",
-    "        # spectra[key] = (result_specutils, Spectrum(spectral_axis=result_specutils.spectral_axis, flux=result_specutils.meta['model'][0, :]*specunit))\n",
+    "        # spectra[key] = (result_specutils, Spectrum(spectral_axis=result_specutils.spectral_axis, flux=result_specutils.meta['model']*specunit))\n",
+    "        print(spectra[key][0].flux.shape)\n",
     "    if 'old' in b:\n",
     "        #\n",
     "        # Remove the previous spectrum.\n",
@@ -532,7 +474,7 @@
     "    #\n",
     "    specviz.load_data(spectra[key][0], data_label=key + ' Data')\n",
     "    opt = specviz.plugins['Plot Options']\n",
-    "    opt.layer = key + ' Data'\n",
+    "    opt.layer = key + ' Data [0]'\n",
     "    opt.line_color.value = '#000000'  # Black\n",
     "    opt.line_as_steps = True\n",
     "    opt.uncertainty_visible = True\n",
@@ -549,15 +491,15 @@
     "    #\n",
     "    specviz.load_data(spectra[key][1], data_label=key + ' Model')\n",
     "    opt = specviz.plugins['Plot Options']\n",
-    "    opt.layer = key + ' Model'\n",
+    "    opt.layer = key + ' Model [0]'\n",
     "    opt.line_color.value = '#FF0000'  # Red\n",
     "    opt.line_as_steps = True\n",
     "    #\n",
     "    # This is a workaround for a bug where metadata is not initially displayed.\n",
     "    #\n",
     "    m = specviz.plugins['Metadata']\n",
-    "    m.dataset = key + ' Model'\n",
-    "    m.dataset = key + ' Data'"
+    "    m.dataset = key + ' Model [0]'\n",
+    "    m.dataset = key + ' Data [0]'"
    ]
   },
   {
@@ -574,28 +516,36 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 13,
    "id": "e6867ab3-b29c-46f1-94b8-7b5665c8bed5",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-01-13T18:04:41.644616Z",
-     "iopub.status.busy": "2026-01-13T18:04:41.644299Z",
-     "iopub.status.idle": "2026-01-13T18:04:42.386400Z",
-     "shell.execute_reply": "2026-01-13T18:04:42.385532Z",
-     "shell.execute_reply.started": "2026-01-13T18:04:41.644592Z"
-    }
-   },
+   "metadata": {},
    "outputs": [
     {
-     "ename": "AttributeError",
-     "evalue": "can't set attribute 'flux'",
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(7781,)\n"
+     ]
+    },
+    {
+     "ename": "ValueError",
+     "evalue": "'DESI J003.7111+07.9541 Data [0]' not one of ['DESI J003.7111+07.9541 Data'], reverting selection to 'DESI J003.7111+07.9541 Data'",
      "output_type": "error",
      "traceback": [
       "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mAttributeError\u001b[0m                            Traceback (most recent call last)",
-      "Cell \u001b[0;32mIn[15], line 12\u001b[0m\n\u001b[1;32m      8\u001b[0m specviz \u001b[38;5;241m=\u001b[39m Specviz()\n\u001b[1;32m      9\u001b[0m \u001b[38;5;66;03m#\u001b[39;00m\n\u001b[1;32m     10\u001b[0m \u001b[38;5;66;03m# Trigger the download if this is the very first spectrum.\u001b[39;00m\n\u001b[1;32m     11\u001b[0m \u001b[38;5;66;03m#\u001b[39;00m\n\u001b[0;32m---> 12\u001b[0m \u001b[43mon_selected\u001b[49m\u001b[43m(\u001b[49m\u001b[43m{\u001b[49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[38;5;124;43mnew\u001b[39;49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[43m:\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m0\u001b[39;49m\u001b[43m}\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m     13\u001b[0m \u001b[38;5;66;03m#\u001b[39;00m\n\u001b[1;32m     14\u001b[0m \u001b[38;5;66;03m# Connect the function action to the dropdown menu.\u001b[39;00m\n\u001b[1;32m     15\u001b[0m \u001b[38;5;66;03m#\u001b[39;00m\n\u001b[1;32m     16\u001b[0m select\u001b[38;5;241m.\u001b[39mobserve(on_selected, names\u001b[38;5;241m=\u001b[39m\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mvalue\u001b[39m\u001b[38;5;124m'\u001b[39m)\n",
-      "Cell \u001b[0;32mIn[14], line 30\u001b[0m, in \u001b[0;36mon_selected\u001b[0;34m(b)\u001b[0m\n\u001b[1;32m     28\u001b[0m result_specutils \u001b[38;5;241m=\u001b[39m result\u001b[38;5;241m.\u001b[39mto_specutils()\n\u001b[1;32m     29\u001b[0m \u001b[38;5;66;03m#\u001b[39;00m\n\u001b[0;32m---> 30\u001b[0m \u001b[43mresult_specutils\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mflux\u001b[49m \u001b[38;5;241m=\u001b[39m result_specutils\u001b[38;5;241m.\u001b[39mflux[\u001b[38;5;241m0\u001b[39m, :]\n\u001b[1;32m     31\u001b[0m result_specutils\u001b[38;5;241m.\u001b[39muncertainty \u001b[38;5;241m=\u001b[39m result_specutils\u001b[38;5;241m.\u001b[39muncertainty\u001b[38;5;241m.\u001b[39mrepresent_as(StdDevUncertainty)[\u001b[38;5;241m0\u001b[39m, :]\n\u001b[1;32m     32\u001b[0m result_specutils\u001b[38;5;241m.\u001b[39mmask \u001b[38;5;241m=\u001b[39m result_specutils\u001b[38;5;241m.\u001b[39mmask[\u001b[38;5;241m0\u001b[39m, :]\n",
-      "\u001b[0;31mAttributeError\u001b[0m: can't set attribute 'flux'"
+      "\u001b[0;31mValueError\u001b[0m                                Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[13], line 12\u001b[0m\n\u001b[1;32m      8\u001b[0m specviz \u001b[38;5;241m=\u001b[39m Specviz()\n\u001b[1;32m      9\u001b[0m \u001b[38;5;66;03m#\u001b[39;00m\n\u001b[1;32m     10\u001b[0m \u001b[38;5;66;03m# Trigger the download if this is the very first spectrum.\u001b[39;00m\n\u001b[1;32m     11\u001b[0m \u001b[38;5;66;03m#\u001b[39;00m\n\u001b[0;32m---> 12\u001b[0m \u001b[43mon_selected\u001b[49m\u001b[43m(\u001b[49m\u001b[43m{\u001b[49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[38;5;124;43mnew\u001b[39;49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[43m:\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m0\u001b[39;49m\u001b[43m}\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m     13\u001b[0m \u001b[38;5;66;03m#\u001b[39;00m\n\u001b[1;32m     14\u001b[0m \u001b[38;5;66;03m# Connect the function action to the dropdown menu.\u001b[39;00m\n\u001b[1;32m     15\u001b[0m \u001b[38;5;66;03m#\u001b[39;00m\n\u001b[1;32m     16\u001b[0m select\u001b[38;5;241m.\u001b[39mobserve(on_selected, names\u001b[38;5;241m=\u001b[39m\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mvalue\u001b[39m\u001b[38;5;124m'\u001b[39m)\n",
+      "Cell \u001b[0;32mIn[12], line 55\u001b[0m, in \u001b[0;36mon_selected\u001b[0;34m(b)\u001b[0m\n\u001b[1;32m     53\u001b[0m specviz\u001b[38;5;241m.\u001b[39mload_data(spectra[key][\u001b[38;5;241m0\u001b[39m], data_label\u001b[38;5;241m=\u001b[39mkey \u001b[38;5;241m+\u001b[39m \u001b[38;5;124m'\u001b[39m\u001b[38;5;124m Data\u001b[39m\u001b[38;5;124m'\u001b[39m)\n\u001b[1;32m     54\u001b[0m opt \u001b[38;5;241m=\u001b[39m specviz\u001b[38;5;241m.\u001b[39mplugins[\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mPlot Options\u001b[39m\u001b[38;5;124m'\u001b[39m]\n\u001b[0;32m---> 55\u001b[0m \u001b[43mopt\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mlayer\u001b[49m \u001b[38;5;241m=\u001b[39m key \u001b[38;5;241m+\u001b[39m \u001b[38;5;124m'\u001b[39m\u001b[38;5;124m Data [0]\u001b[39m\u001b[38;5;124m'\u001b[39m\n\u001b[1;32m     56\u001b[0m opt\u001b[38;5;241m.\u001b[39mline_color\u001b[38;5;241m.\u001b[39mvalue \u001b[38;5;241m=\u001b[39m \u001b[38;5;124m'\u001b[39m\u001b[38;5;124m#000000\u001b[39m\u001b[38;5;124m'\u001b[39m  \u001b[38;5;66;03m# Black\u001b[39;00m\n\u001b[1;32m     57\u001b[0m opt\u001b[38;5;241m.\u001b[39mline_as_steps \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;01mTrue\u001b[39;00m\n",
+      "File \u001b[0;32m~/Documents/local/products/venv/kitchen_sink/lib/python3.10/site-packages/jdaviz/core/user_api.py:69\u001b[0m, in \u001b[0;36mUserApiWrapper.__setattr__\u001b[0;34m(self, attr, value)\u001b[0m\n\u001b[1;32m     67\u001b[0m     \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28misinstance\u001b[39m(exp_obj, UnitSelectPluginComponent) \u001b[38;5;129;01mand\u001b[39;00m \u001b[38;5;28misinstance\u001b[39m(value, u\u001b[38;5;241m.\u001b[39mUnit):\n\u001b[1;32m     68\u001b[0m         value \u001b[38;5;241m=\u001b[39m value\u001b[38;5;241m.\u001b[39mto_string()\n\u001b[0;32m---> 69\u001b[0m     \u001b[43mexp_obj\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mselected\u001b[49m \u001b[38;5;241m=\u001b[39m value\n\u001b[1;32m     70\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m\n\u001b[1;32m     71\u001b[0m \u001b[38;5;28;01melif\u001b[39;00m \u001b[38;5;28misinstance\u001b[39m(exp_obj, AddResults):\n",
+      "File \u001b[0;32m~/Documents/local/products/venv/kitchen_sink/lib/python3.10/site-packages/jdaviz/core/template_mixin.py:767\u001b[0m, in \u001b[0;36mBasePluginComponent.__setattr__\u001b[0;34m(self, attr, value, force_super)\u001b[0m\n\u001b[1;32m    764\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m attr[\u001b[38;5;241m0\u001b[39m] \u001b[38;5;241m==\u001b[39m \u001b[38;5;124m'\u001b[39m\u001b[38;5;124m_\u001b[39m\u001b[38;5;124m'\u001b[39m \u001b[38;5;129;01mor\u001b[39;00m force_super \u001b[38;5;129;01mor\u001b[39;00m attr \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;129;01min\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_plugin_traitlets\u001b[38;5;241m.\u001b[39mkeys():\n\u001b[1;32m    765\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28msuper\u001b[39m()\u001b[38;5;241m.\u001b[39m\u001b[38;5;21m__setattr__\u001b[39m(attr, value)\n\u001b[0;32m--> 767\u001b[0m \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28;43msetattr\u001b[39;49m\u001b[43m(\u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43m_plugin\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43m_plugin_traitlets\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mget\u001b[49m\u001b[43m(\u001b[49m\u001b[43mattr\u001b[49m\u001b[43m)\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mvalue\u001b[49m\u001b[43m)\u001b[49m\n",
+      "File \u001b[0;32m~/Documents/local/products/venv/kitchen_sink/lib/python3.10/site-packages/traitlets/traitlets.py:716\u001b[0m, in \u001b[0;36mTraitType.__set__\u001b[0;34m(self, obj, value)\u001b[0m\n\u001b[1;32m    714\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mread_only:\n\u001b[1;32m    715\u001b[0m     \u001b[38;5;28;01mraise\u001b[39;00m TraitError(\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mThe \u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;132;01m%s\u001b[39;00m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124m trait is read-only.\u001b[39m\u001b[38;5;124m'\u001b[39m \u001b[38;5;241m%\u001b[39m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mname)\n\u001b[0;32m--> 716\u001b[0m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mset\u001b[49m\u001b[43m(\u001b[49m\u001b[43mobj\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mvalue\u001b[49m\u001b[43m)\u001b[49m\n",
+      "File \u001b[0;32m~/Documents/local/products/venv/kitchen_sink/lib/python3.10/site-packages/traitlets/traitlets.py:706\u001b[0m, in \u001b[0;36mTraitType.set\u001b[0;34m(self, obj, value)\u001b[0m\n\u001b[1;32m    702\u001b[0m     silent \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;01mFalse\u001b[39;00m\n\u001b[1;32m    703\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m silent \u001b[38;5;129;01mis\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;28;01mTrue\u001b[39;00m:\n\u001b[1;32m    704\u001b[0m     \u001b[38;5;66;03m# we explicitly compare silent to True just in case the equality\u001b[39;00m\n\u001b[1;32m    705\u001b[0m     \u001b[38;5;66;03m# comparison above returns something other than True/False\u001b[39;00m\n\u001b[0;32m--> 706\u001b[0m     \u001b[43mobj\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43m_notify_trait\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mname\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mold_value\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mnew_value\u001b[49m\u001b[43m)\u001b[49m\n",
+      "File \u001b[0;32m~/Documents/local/products/venv/kitchen_sink/lib/python3.10/site-packages/traitlets/traitlets.py:1513\u001b[0m, in \u001b[0;36mHasTraits._notify_trait\u001b[0;34m(self, name, old_value, new_value)\u001b[0m\n\u001b[1;32m   1512\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[38;5;21m_notify_trait\u001b[39m(\u001b[38;5;28mself\u001b[39m, name: \u001b[38;5;28mstr\u001b[39m, old_value: t\u001b[38;5;241m.\u001b[39mAny, new_value: t\u001b[38;5;241m.\u001b[39mAny) \u001b[38;5;241m-\u001b[39m\u001b[38;5;241m>\u001b[39m \u001b[38;5;28;01mNone\u001b[39;00m:\n\u001b[0;32m-> 1513\u001b[0m     \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mnotify_change\u001b[49m\u001b[43m(\u001b[49m\n\u001b[1;32m   1514\u001b[0m \u001b[43m        \u001b[49m\u001b[43mBunch\u001b[49m\u001b[43m(\u001b[49m\n\u001b[1;32m   1515\u001b[0m \u001b[43m            \u001b[49m\u001b[43mname\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mname\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m   1516\u001b[0m \u001b[43m            \u001b[49m\u001b[43mold\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mold_value\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m   1517\u001b[0m \u001b[43m            \u001b[49m\u001b[43mnew\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mnew_value\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m   1518\u001b[0m \u001b[43m            \u001b[49m\u001b[43mowner\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[43m,\u001b[49m\n\u001b[1;32m   1519\u001b[0m \u001b[43m            \u001b[49m\u001b[38;5;28;43mtype\u001b[39;49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43mchange\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m,\u001b[49m\n\u001b[1;32m   1520\u001b[0m \u001b[43m        \u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m   1521\u001b[0m \u001b[43m    \u001b[49m\u001b[43m)\u001b[49m\n",
+      "File \u001b[0;32m~/Documents/local/products/venv/kitchen_sink/lib/python3.10/site-packages/ipywidgets/widgets/widget.py:701\u001b[0m, in \u001b[0;36mWidget.notify_change\u001b[0;34m(self, change)\u001b[0m\n\u001b[1;32m    698\u001b[0m     \u001b[38;5;28;01mif\u001b[39;00m name \u001b[38;5;129;01min\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mkeys \u001b[38;5;129;01mand\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_should_send_property(name, \u001b[38;5;28mgetattr\u001b[39m(\u001b[38;5;28mself\u001b[39m, name)):\n\u001b[1;32m    699\u001b[0m         \u001b[38;5;66;03m# Send new state to front-end\u001b[39;00m\n\u001b[1;32m    700\u001b[0m         \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39msend_state(key\u001b[38;5;241m=\u001b[39mname)\n\u001b[0;32m--> 701\u001b[0m \u001b[38;5;28;43msuper\u001b[39;49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mnotify_change\u001b[49m\u001b[43m(\u001b[49m\u001b[43mchange\u001b[49m\u001b[43m)\u001b[49m\n",
+      "File \u001b[0;32m~/Documents/local/products/venv/kitchen_sink/lib/python3.10/site-packages/traitlets/traitlets.py:1525\u001b[0m, in \u001b[0;36mHasTraits.notify_change\u001b[0;34m(self, change)\u001b[0m\n\u001b[1;32m   1523\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[38;5;21mnotify_change\u001b[39m(\u001b[38;5;28mself\u001b[39m, change: Bunch) \u001b[38;5;241m-\u001b[39m\u001b[38;5;241m>\u001b[39m \u001b[38;5;28;01mNone\u001b[39;00m:\n\u001b[1;32m   1524\u001b[0m \u001b[38;5;250m    \u001b[39m\u001b[38;5;124;03m\"\"\"Notify observers of a change event\"\"\"\u001b[39;00m\n\u001b[0;32m-> 1525\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43m_notify_observers\u001b[49m\u001b[43m(\u001b[49m\u001b[43mchange\u001b[49m\u001b[43m)\u001b[49m\n",
+      "File \u001b[0;32m~/Documents/local/products/venv/kitchen_sink/lib/python3.10/site-packages/traitlets/traitlets.py:1568\u001b[0m, in \u001b[0;36mHasTraits._notify_observers\u001b[0;34m(self, event)\u001b[0m\n\u001b[1;32m   1565\u001b[0m \u001b[38;5;28;01melif\u001b[39;00m \u001b[38;5;28misinstance\u001b[39m(c, EventHandler) \u001b[38;5;129;01mand\u001b[39;00m c\u001b[38;5;241m.\u001b[39mname \u001b[38;5;129;01mis\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;28;01mNone\u001b[39;00m:\n\u001b[1;32m   1566\u001b[0m     c \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mgetattr\u001b[39m(\u001b[38;5;28mself\u001b[39m, c\u001b[38;5;241m.\u001b[39mname)\n\u001b[0;32m-> 1568\u001b[0m \u001b[43mc\u001b[49m\u001b[43m(\u001b[49m\u001b[43mevent\u001b[49m\u001b[43m)\u001b[49m\n",
+      "File \u001b[0;32m~/Documents/local/products/venv/kitchen_sink/lib/python3.10/site-packages/jdaviz/core/template_mixin.py:1141\u001b[0m, in \u001b[0;36mSelectPluginComponent._selected_changed\u001b[0;34m(self, event)\u001b[0m\n\u001b[1;32m   1139\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m event[\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mnew\u001b[39m\u001b[38;5;124m'\u001b[39m] \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;129;01min\u001b[39;00m valid \u001b[38;5;241m+\u001b[39m [\u001b[38;5;124m'\u001b[39m\u001b[38;5;124m'\u001b[39m]:\n\u001b[1;32m   1140\u001b[0m     \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mselected \u001b[38;5;241m=\u001b[39m event[\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mold\u001b[39m\u001b[38;5;124m'\u001b[39m]\n\u001b[0;32m-> 1141\u001b[0m     \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mValueError\u001b[39;00m(\u001b[38;5;124mf\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;130;01m\\'\u001b[39;00m\u001b[38;5;132;01m{\u001b[39;00mevent[\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mnew\u001b[39m\u001b[38;5;124m'\u001b[39m]\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;130;01m\\'\u001b[39;00m\u001b[38;5;124m not one of \u001b[39m\u001b[38;5;132;01m{\u001b[39;00mvalid\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m, reverting selection to \u001b[39m\u001b[38;5;130;01m\\'\u001b[39;00m\u001b[38;5;132;01m{\u001b[39;00mevent[\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mold\u001b[39m\u001b[38;5;124m'\u001b[39m]\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;130;01m\\'\u001b[39;00m\u001b[38;5;124m\"\u001b[39m)\n",
+      "\u001b[0;31mValueError\u001b[0m: 'DESI J003.7111+07.9541 Data [0]' not one of ['DESI J003.7111+07.9541 Data'], reverting selection to 'DESI J003.7111+07.9541 Data'"
      ]
     }
    ],
@@ -637,7 +587,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (DL,Py3.10.13)",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -651,7 +601,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.13"
+   "version": "3.10.19"
   }
  },
  "nbformat": 4,

--- a/04_HowTos/SPARCL/Plot_SPARCL_Spectra_with_Jdaviz.ipynb
+++ b/04_HowTos/SPARCL/Plot_SPARCL_Spectra_with_Jdaviz.ipynb
@@ -9,7 +9,7 @@
    "source": [
     "__nbid__ = '0052'\n",
     "__author__ = 'Camilla Pacifici, Brett Morris, Benjamin Weaver <benjamin.weaver@noirlab.edu>, Alice Jacques <alice.jacques@noirlab.edu>'\n",
-    "__version__ = '20250317' # yyyymmdd\n",
+    "__version__ = '20260505' # yyyymmdd\n",
     "__datasets__ = ['desi_dr1']\n",
     "__keywords__ = ['sparcl', 'jdaviz', 'specutils', 'spectroscopy', 'desi spectra', 'tutorial']"
    ]

--- a/04_HowTos/SPARCL/Plot_SPARCL_Spectra_with_Jdaviz.ipynb
+++ b/04_HowTos/SPARCL/Plot_SPARCL_Spectra_with_Jdaviz.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "0d6d67d9-3c55-455a-bfae-0a7f9ec27a02",
    "metadata": {},
    "outputs": [],
@@ -126,26 +126,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "1b12bf2e",
    "metadata": {
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "sparcl_version==1.2.8\n",
-      "jdaviz_version==4.2.3\n",
-      "specutils_version==1.20.3\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import os\n",
     "import sys\n",
-    "sys.path.insert(1, os.path.join(os.environ['HOME'], 'Documents', 'Code', 'git', 'nsf-noirlab', 'csdc', 'datalab', 'sparcl', 'sparclclient'))\n",
     "# Handle warnings below\n",
     "import warnings\n",
     "# Numpy import\n",
@@ -185,30 +174,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "482c5e93",
    "metadata": {
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "announcement=Data set deprecation notice: on November 19, 2025 the SDSS/BOSS DR16 data sets were deprecated. Please use the new SDSS/BOSS DR17 data sets instead.\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "(sparclclient:1.2.8, api:13.0, https://astrosparcl.datalab.noirlab.edu/api, client_hash=16e04212a9a27f648c0f43dcb99d9b5ae9ec37e0, verbose=False, connect_timeout=1.1, read_timeout=5400.0, announcement=True)"
-      ]
-     },
-     "execution_count": 3,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "client = SparclClient()\n",
     "client"
@@ -224,20 +195,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "id": "9e288542-73aa-45cf-9f69-668bd3208d70",
    "metadata": {
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "['bgs_target', 'chi2', 'cmx_target', 'coadd_fiberstatus', 'coadd_numexp', 'coadd_numnight', 'coadd_numtile', 'coeff', 'data_release', 'datasetgroup', 'dateobs', 'dateobs_center', 'dec', 'deltachi2', 'desi_target', 'desiname', 'exptime', 'fa_target', 'fa_type', 'flux', 'healpix', 'instrument', 'ivar', 'main_nspec', 'main_primary', 'mask', 'mean_delta_x', 'mean_delta_y', 'mean_fiber_dec', 'mean_fiber_ra', 'mean_mjd', 'mean_psf_to_fiber_specflux', 'model', 'mws_target', 'ncoeff', 'npixels', 'numobs_init', 'objtype', 'obsconditions', 'plate_dec', 'plate_ra', 'pmdec', 'pmra', 'priority_init', 'program', 'ra', 'redshift', 'redshift_err', 'redshift_warning', 'ref_epoch', 'rms_delta_x', 'rms_delta_y', 'scnd_target', 'site', 'sparcl_id', 'specid', 'specprimary', 'spectype', 'spgrpval', 'std_fiber_dec', 'std_fiber_ra', 'subpriority', 'subtype', 'survey', 'sv1_bgs_target', 'sv1_desi_target', 'sv1_mws_target', 'sv1_scnd_target', 'sv2_bgs_target', 'sv2_desi_target', 'sv2_mws_target', 'sv2_scnd_target', 'sv3_bgs_target', 'sv3_desi_target', 'sv3_mws_target', 'sv3_scnd_target', 'sv_nspec', 'sv_primary', 'targetid', 'telescope', 'tsnr2_bgs', 'tsnr2_elg', 'tsnr2_gpbbackup', 'tsnr2_gpbbright', 'tsnr2_gpbdark', 'tsnr2_lrg', 'tsnr2_lya', 'tsnr2_qso', 'wave_sigma', 'wavelength', 'wavemax', 'wavemin', 'zcat_nspec']\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "desi_fields = client.get_all_fields(dataset_list=['DESI-DR1'])\n",
     "print(desi_fields)"
@@ -270,7 +233,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "id": "9b7d99c6",
    "metadata": {
     "tags": []
@@ -289,7 +252,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "id": "9ae27a9b",
    "metadata": {
     "tags": []
@@ -315,7 +278,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "id": "6e31ef55-3e14-45ab-9c9e-5a2da06f403b",
    "metadata": {},
    "outputs": [],
@@ -383,7 +346,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "id": "91008745-9ff5-485c-92cb-7554628a0f60",
    "metadata": {
     "tags": []
@@ -406,14 +369,14 @@
     "## Retrieve spectra from SPARCL and prepare plot data\n",
     "Here we define a function that:\n",
     "1. Uses the `client.retrieve()` method from SPARCL to retrieve spectra for the list of IDs from DESI DR1.\n",
-    "2. Creates a `specutils.Spectrum1D` object from the retrieved data.\n",
+    "2. Creates a `specutils.Spectrum` object from the retrieved data.\n",
     "3. Loads the spectrum, metadata, and model.\n",
-    "4. Caches the converted `Spectrum1D` object."
+    "4. Caches the converted `Spectrum` object."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "id": "1d036ac5-7310-43a1-8346-f0eff7c0010d",
    "metadata": {
     "tags": []
@@ -447,20 +410,24 @@
     "        #\n",
     "        # Note how the data and the model are prepared as two separate objects.\n",
     "        #\n",
-    "        # result_specutils = result.to_specutils()\n",
+    "        result_specutils = result.to_specutils()\n",
+    "        spectra[key] = (result_specutils,\n",
+    "                        Spectrum(spectral_axis=result_specutils.spectral_axis,\n",
+    "                                 flux=result_specutils.meta['model']*specunit))\n",
+    "        #\n",
+    "        # This block is retained for possible use with Jdaviz 4.\n",
     "        #\n",
     "        # result_specutils.flux = result_specutils.flux[0, :]\n",
     "        # result_specutils.uncertainty = result_specutils.uncertainty.represent_as(StdDevUncertainty)[0, :]\n",
     "        # result_specutils.mask = result_specutils.mask[0, :]\n",
-    "        spectra[key] = (Spectrum(spectral_axis=result.records[0]['wavelength']*u.AA,\n",
-    "                                 flux=result.records[0]['flux']*specunit,\n",
-    "                                 uncertainty=InverseVariance(result.records[0]['ivar']*(specunit**-2)).represent_as(StdDevUncertainty),\n",
-    "                                 mask=result.records[0]['mask'],\n",
-    "                                 redshift=result.records[0]['redshift']),\n",
-    "                        Spectrum(spectral_axis=result.records[0]['wavelength']*u.AA,\n",
-    "                                 flux=result.records[0]['model']*specunit))\n",
-    "        # spectra[key] = (result_specutils, Spectrum(spectral_axis=result_specutils.spectral_axis, flux=result_specutils.meta['model']*specunit))\n",
-    "        print(spectra[key][0].flux.shape)\n",
+    "        # spectra[key] = (Spectrum(spectral_axis=result.records[0]['wavelength']*u.AA,\n",
+    "        #                          flux=result.records[0]['flux']*specunit,\n",
+    "        #                          uncertainty=InverseVariance(result.records[0]['ivar']*(specunit**-2)).represent_as(StdDevUncertainty),\n",
+    "        #                          mask=result.records[0]['mask'],\n",
+    "        #                          redshift=result.records[0]['redshift']),\n",
+    "        #                 Spectrum(spectral_axis=result.records[0]['wavelength']*u.AA,\n",
+    "        #                          flux=result.records[0]['model']*specunit))\n",
+    "        # print(spectra[key][0].flux.shape)\n",
     "    if 'old' in b:\n",
     "        #\n",
     "        # Remove the previous spectrum.\n",
@@ -474,7 +441,10 @@
     "    #\n",
     "    specviz.load_data(spectra[key][0], data_label=key + ' Data')\n",
     "    opt = specviz.plugins['Plot Options']\n",
-    "    opt.layer = key + ' Data [0]'\n",
+    "    # Jdaviz 3\n",
+    "    opt.layer = key + ' Data'\n",
+    "    # Jdaviz 4\n",
+    "    # opt.layer = key + ' Data [0]'\n",
     "    opt.line_color.value = '#000000'  # Black\n",
     "    opt.line_as_steps = True\n",
     "    opt.uncertainty_visible = True\n",
@@ -491,15 +461,22 @@
     "    #\n",
     "    specviz.load_data(spectra[key][1], data_label=key + ' Model')\n",
     "    opt = specviz.plugins['Plot Options']\n",
-    "    opt.layer = key + ' Model [0]'\n",
+    "    # Jdaviz 3\n",
+    "    opt.layer = key + ' Model'\n",
+    "    # Jdaviz 4\n",
+    "    # opt.layer = key + ' Model [0]'\n",
     "    opt.line_color.value = '#FF0000'  # Red\n",
     "    opt.line_as_steps = True\n",
     "    #\n",
     "    # This is a workaround for a bug where metadata is not initially displayed.\n",
     "    #\n",
     "    m = specviz.plugins['Metadata']\n",
-    "    m.dataset = key + ' Model [0]'\n",
-    "    m.dataset = key + ' Data [0]'"
+    "    # Jdaviz 3\n",
+    "    m.dataset = key + ' Model'\n",
+    "    m.dataset = key + ' Data'\n",
+    "    # Jdaviz 4\n",
+    "    # m.dataset = key + ' Model [0]'\n",
+    "    # m.dataset = key + ' Data [0]'"
    ]
   },
   {
@@ -516,39 +493,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "id": "e6867ab3-b29c-46f1-94b8-7b5665c8bed5",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "(7781,)\n"
-     ]
-    },
-    {
-     "ename": "ValueError",
-     "evalue": "'DESI J003.7111+07.9541 Data [0]' not one of ['DESI J003.7111+07.9541 Data'], reverting selection to 'DESI J003.7111+07.9541 Data'",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mValueError\u001b[0m                                Traceback (most recent call last)",
-      "Cell \u001b[0;32mIn[13], line 12\u001b[0m\n\u001b[1;32m      8\u001b[0m specviz \u001b[38;5;241m=\u001b[39m Specviz()\n\u001b[1;32m      9\u001b[0m \u001b[38;5;66;03m#\u001b[39;00m\n\u001b[1;32m     10\u001b[0m \u001b[38;5;66;03m# Trigger the download if this is the very first spectrum.\u001b[39;00m\n\u001b[1;32m     11\u001b[0m \u001b[38;5;66;03m#\u001b[39;00m\n\u001b[0;32m---> 12\u001b[0m \u001b[43mon_selected\u001b[49m\u001b[43m(\u001b[49m\u001b[43m{\u001b[49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[38;5;124;43mnew\u001b[39;49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[43m:\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m0\u001b[39;49m\u001b[43m}\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m     13\u001b[0m \u001b[38;5;66;03m#\u001b[39;00m\n\u001b[1;32m     14\u001b[0m \u001b[38;5;66;03m# Connect the function action to the dropdown menu.\u001b[39;00m\n\u001b[1;32m     15\u001b[0m \u001b[38;5;66;03m#\u001b[39;00m\n\u001b[1;32m     16\u001b[0m select\u001b[38;5;241m.\u001b[39mobserve(on_selected, names\u001b[38;5;241m=\u001b[39m\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mvalue\u001b[39m\u001b[38;5;124m'\u001b[39m)\n",
-      "Cell \u001b[0;32mIn[12], line 55\u001b[0m, in \u001b[0;36mon_selected\u001b[0;34m(b)\u001b[0m\n\u001b[1;32m     53\u001b[0m specviz\u001b[38;5;241m.\u001b[39mload_data(spectra[key][\u001b[38;5;241m0\u001b[39m], data_label\u001b[38;5;241m=\u001b[39mkey \u001b[38;5;241m+\u001b[39m \u001b[38;5;124m'\u001b[39m\u001b[38;5;124m Data\u001b[39m\u001b[38;5;124m'\u001b[39m)\n\u001b[1;32m     54\u001b[0m opt \u001b[38;5;241m=\u001b[39m specviz\u001b[38;5;241m.\u001b[39mplugins[\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mPlot Options\u001b[39m\u001b[38;5;124m'\u001b[39m]\n\u001b[0;32m---> 55\u001b[0m \u001b[43mopt\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mlayer\u001b[49m \u001b[38;5;241m=\u001b[39m key \u001b[38;5;241m+\u001b[39m \u001b[38;5;124m'\u001b[39m\u001b[38;5;124m Data [0]\u001b[39m\u001b[38;5;124m'\u001b[39m\n\u001b[1;32m     56\u001b[0m opt\u001b[38;5;241m.\u001b[39mline_color\u001b[38;5;241m.\u001b[39mvalue \u001b[38;5;241m=\u001b[39m \u001b[38;5;124m'\u001b[39m\u001b[38;5;124m#000000\u001b[39m\u001b[38;5;124m'\u001b[39m  \u001b[38;5;66;03m# Black\u001b[39;00m\n\u001b[1;32m     57\u001b[0m opt\u001b[38;5;241m.\u001b[39mline_as_steps \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;01mTrue\u001b[39;00m\n",
-      "File \u001b[0;32m~/Documents/local/products/venv/kitchen_sink/lib/python3.10/site-packages/jdaviz/core/user_api.py:69\u001b[0m, in \u001b[0;36mUserApiWrapper.__setattr__\u001b[0;34m(self, attr, value)\u001b[0m\n\u001b[1;32m     67\u001b[0m     \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28misinstance\u001b[39m(exp_obj, UnitSelectPluginComponent) \u001b[38;5;129;01mand\u001b[39;00m \u001b[38;5;28misinstance\u001b[39m(value, u\u001b[38;5;241m.\u001b[39mUnit):\n\u001b[1;32m     68\u001b[0m         value \u001b[38;5;241m=\u001b[39m value\u001b[38;5;241m.\u001b[39mto_string()\n\u001b[0;32m---> 69\u001b[0m     \u001b[43mexp_obj\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mselected\u001b[49m \u001b[38;5;241m=\u001b[39m value\n\u001b[1;32m     70\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m\n\u001b[1;32m     71\u001b[0m \u001b[38;5;28;01melif\u001b[39;00m \u001b[38;5;28misinstance\u001b[39m(exp_obj, AddResults):\n",
-      "File \u001b[0;32m~/Documents/local/products/venv/kitchen_sink/lib/python3.10/site-packages/jdaviz/core/template_mixin.py:767\u001b[0m, in \u001b[0;36mBasePluginComponent.__setattr__\u001b[0;34m(self, attr, value, force_super)\u001b[0m\n\u001b[1;32m    764\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m attr[\u001b[38;5;241m0\u001b[39m] \u001b[38;5;241m==\u001b[39m \u001b[38;5;124m'\u001b[39m\u001b[38;5;124m_\u001b[39m\u001b[38;5;124m'\u001b[39m \u001b[38;5;129;01mor\u001b[39;00m force_super \u001b[38;5;129;01mor\u001b[39;00m attr \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;129;01min\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_plugin_traitlets\u001b[38;5;241m.\u001b[39mkeys():\n\u001b[1;32m    765\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28msuper\u001b[39m()\u001b[38;5;241m.\u001b[39m\u001b[38;5;21m__setattr__\u001b[39m(attr, value)\n\u001b[0;32m--> 767\u001b[0m \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28;43msetattr\u001b[39;49m\u001b[43m(\u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43m_plugin\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43m_plugin_traitlets\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mget\u001b[49m\u001b[43m(\u001b[49m\u001b[43mattr\u001b[49m\u001b[43m)\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mvalue\u001b[49m\u001b[43m)\u001b[49m\n",
-      "File \u001b[0;32m~/Documents/local/products/venv/kitchen_sink/lib/python3.10/site-packages/traitlets/traitlets.py:716\u001b[0m, in \u001b[0;36mTraitType.__set__\u001b[0;34m(self, obj, value)\u001b[0m\n\u001b[1;32m    714\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mread_only:\n\u001b[1;32m    715\u001b[0m     \u001b[38;5;28;01mraise\u001b[39;00m TraitError(\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mThe \u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;132;01m%s\u001b[39;00m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124m trait is read-only.\u001b[39m\u001b[38;5;124m'\u001b[39m \u001b[38;5;241m%\u001b[39m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mname)\n\u001b[0;32m--> 716\u001b[0m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mset\u001b[49m\u001b[43m(\u001b[49m\u001b[43mobj\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mvalue\u001b[49m\u001b[43m)\u001b[49m\n",
-      "File \u001b[0;32m~/Documents/local/products/venv/kitchen_sink/lib/python3.10/site-packages/traitlets/traitlets.py:706\u001b[0m, in \u001b[0;36mTraitType.set\u001b[0;34m(self, obj, value)\u001b[0m\n\u001b[1;32m    702\u001b[0m     silent \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;01mFalse\u001b[39;00m\n\u001b[1;32m    703\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m silent \u001b[38;5;129;01mis\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;28;01mTrue\u001b[39;00m:\n\u001b[1;32m    704\u001b[0m     \u001b[38;5;66;03m# we explicitly compare silent to True just in case the equality\u001b[39;00m\n\u001b[1;32m    705\u001b[0m     \u001b[38;5;66;03m# comparison above returns something other than True/False\u001b[39;00m\n\u001b[0;32m--> 706\u001b[0m     \u001b[43mobj\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43m_notify_trait\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mname\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mold_value\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mnew_value\u001b[49m\u001b[43m)\u001b[49m\n",
-      "File \u001b[0;32m~/Documents/local/products/venv/kitchen_sink/lib/python3.10/site-packages/traitlets/traitlets.py:1513\u001b[0m, in \u001b[0;36mHasTraits._notify_trait\u001b[0;34m(self, name, old_value, new_value)\u001b[0m\n\u001b[1;32m   1512\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[38;5;21m_notify_trait\u001b[39m(\u001b[38;5;28mself\u001b[39m, name: \u001b[38;5;28mstr\u001b[39m, old_value: t\u001b[38;5;241m.\u001b[39mAny, new_value: t\u001b[38;5;241m.\u001b[39mAny) \u001b[38;5;241m-\u001b[39m\u001b[38;5;241m>\u001b[39m \u001b[38;5;28;01mNone\u001b[39;00m:\n\u001b[0;32m-> 1513\u001b[0m     \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mnotify_change\u001b[49m\u001b[43m(\u001b[49m\n\u001b[1;32m   1514\u001b[0m \u001b[43m        \u001b[49m\u001b[43mBunch\u001b[49m\u001b[43m(\u001b[49m\n\u001b[1;32m   1515\u001b[0m \u001b[43m            \u001b[49m\u001b[43mname\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mname\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m   1516\u001b[0m \u001b[43m            \u001b[49m\u001b[43mold\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mold_value\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m   1517\u001b[0m \u001b[43m            \u001b[49m\u001b[43mnew\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mnew_value\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m   1518\u001b[0m \u001b[43m            \u001b[49m\u001b[43mowner\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[43m,\u001b[49m\n\u001b[1;32m   1519\u001b[0m \u001b[43m            \u001b[49m\u001b[38;5;28;43mtype\u001b[39;49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43mchange\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m,\u001b[49m\n\u001b[1;32m   1520\u001b[0m \u001b[43m        \u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m   1521\u001b[0m \u001b[43m    \u001b[49m\u001b[43m)\u001b[49m\n",
-      "File \u001b[0;32m~/Documents/local/products/venv/kitchen_sink/lib/python3.10/site-packages/ipywidgets/widgets/widget.py:701\u001b[0m, in \u001b[0;36mWidget.notify_change\u001b[0;34m(self, change)\u001b[0m\n\u001b[1;32m    698\u001b[0m     \u001b[38;5;28;01mif\u001b[39;00m name \u001b[38;5;129;01min\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mkeys \u001b[38;5;129;01mand\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_should_send_property(name, \u001b[38;5;28mgetattr\u001b[39m(\u001b[38;5;28mself\u001b[39m, name)):\n\u001b[1;32m    699\u001b[0m         \u001b[38;5;66;03m# Send new state to front-end\u001b[39;00m\n\u001b[1;32m    700\u001b[0m         \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39msend_state(key\u001b[38;5;241m=\u001b[39mname)\n\u001b[0;32m--> 701\u001b[0m \u001b[38;5;28;43msuper\u001b[39;49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mnotify_change\u001b[49m\u001b[43m(\u001b[49m\u001b[43mchange\u001b[49m\u001b[43m)\u001b[49m\n",
-      "File \u001b[0;32m~/Documents/local/products/venv/kitchen_sink/lib/python3.10/site-packages/traitlets/traitlets.py:1525\u001b[0m, in \u001b[0;36mHasTraits.notify_change\u001b[0;34m(self, change)\u001b[0m\n\u001b[1;32m   1523\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[38;5;21mnotify_change\u001b[39m(\u001b[38;5;28mself\u001b[39m, change: Bunch) \u001b[38;5;241m-\u001b[39m\u001b[38;5;241m>\u001b[39m \u001b[38;5;28;01mNone\u001b[39;00m:\n\u001b[1;32m   1524\u001b[0m \u001b[38;5;250m    \u001b[39m\u001b[38;5;124;03m\"\"\"Notify observers of a change event\"\"\"\u001b[39;00m\n\u001b[0;32m-> 1525\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43m_notify_observers\u001b[49m\u001b[43m(\u001b[49m\u001b[43mchange\u001b[49m\u001b[43m)\u001b[49m\n",
-      "File \u001b[0;32m~/Documents/local/products/venv/kitchen_sink/lib/python3.10/site-packages/traitlets/traitlets.py:1568\u001b[0m, in \u001b[0;36mHasTraits._notify_observers\u001b[0;34m(self, event)\u001b[0m\n\u001b[1;32m   1565\u001b[0m \u001b[38;5;28;01melif\u001b[39;00m \u001b[38;5;28misinstance\u001b[39m(c, EventHandler) \u001b[38;5;129;01mand\u001b[39;00m c\u001b[38;5;241m.\u001b[39mname \u001b[38;5;129;01mis\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;28;01mNone\u001b[39;00m:\n\u001b[1;32m   1566\u001b[0m     c \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mgetattr\u001b[39m(\u001b[38;5;28mself\u001b[39m, c\u001b[38;5;241m.\u001b[39mname)\n\u001b[0;32m-> 1568\u001b[0m \u001b[43mc\u001b[49m\u001b[43m(\u001b[49m\u001b[43mevent\u001b[49m\u001b[43m)\u001b[49m\n",
-      "File \u001b[0;32m~/Documents/local/products/venv/kitchen_sink/lib/python3.10/site-packages/jdaviz/core/template_mixin.py:1141\u001b[0m, in \u001b[0;36mSelectPluginComponent._selected_changed\u001b[0;34m(self, event)\u001b[0m\n\u001b[1;32m   1139\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m event[\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mnew\u001b[39m\u001b[38;5;124m'\u001b[39m] \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;129;01min\u001b[39;00m valid \u001b[38;5;241m+\u001b[39m [\u001b[38;5;124m'\u001b[39m\u001b[38;5;124m'\u001b[39m]:\n\u001b[1;32m   1140\u001b[0m     \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mselected \u001b[38;5;241m=\u001b[39m event[\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mold\u001b[39m\u001b[38;5;124m'\u001b[39m]\n\u001b[0;32m-> 1141\u001b[0m     \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mValueError\u001b[39;00m(\u001b[38;5;124mf\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;130;01m\\'\u001b[39;00m\u001b[38;5;132;01m{\u001b[39;00mevent[\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mnew\u001b[39m\u001b[38;5;124m'\u001b[39m]\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;130;01m\\'\u001b[39;00m\u001b[38;5;124m not one of \u001b[39m\u001b[38;5;132;01m{\u001b[39;00mvalid\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m, reverting selection to \u001b[39m\u001b[38;5;130;01m\\'\u001b[39;00m\u001b[38;5;132;01m{\u001b[39;00mevent[\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mold\u001b[39m\u001b[38;5;124m'\u001b[39m]\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;130;01m\\'\u001b[39;00m\u001b[38;5;124m\"\u001b[39m)\n",
-      "\u001b[0;31mValueError\u001b[0m: 'DESI J003.7111+07.9541 Data [0]' not one of ['DESI J003.7111+07.9541 Data'], reverting selection to 'DESI J003.7111+07.9541 Data'"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "#\n",
     "# Set up Specviz and the drop-down menu.\n",
@@ -587,7 +535,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3 (DL,Py3.10.13)",
    "language": "python",
    "name": "python3"
   },
@@ -601,7 +549,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.19"
+   "version": "3.10.13"
   }
  },
  "nbformat": 4,

--- a/04_HowTos/SPARCL/Plot_SPARCL_Spectra_with_Prospect.html
+++ b/04_HowTos/SPARCL/Plot_SPARCL_Spectra_with_Prospect.html
@@ -7515,7 +7515,7 @@ a.anchor-link {
 <div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
 </div>
 <div class="jp-InputArea jp-Cell-inputArea">
-<div class="jp-InputPrompt jp-InputArea-prompt">In [1]:</div>
+<div class="jp-InputPrompt jp-InputArea-prompt">In [ ]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
 <div class="cm-editor cm-s-jupyter">
 <div class="highlight hl-ipython3"><pre><span></span><span class="n">__nbid__</span> <span class="o">=</span> <span class="s1">'0053'</span>
@@ -7627,15 +7627,17 @@ a.anchor-link {
 </div>
 </div>
 </div>
-</div><div class="jp-Cell jp-CodeCell jp-Notebook-cell">
+</div><div class="jp-Cell jp-CodeCell jp-Notebook-cell jp-mod-noOutputs">
 <div class="jp-Cell-inputWrapper" tabindex="0">
 <div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
 </div>
 <div class="jp-InputArea jp-Cell-inputArea">
-<div class="jp-InputPrompt jp-InputArea-prompt">In [2]:</div>
+<div class="jp-InputPrompt jp-InputArea-prompt">In [ ]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
 <div class="cm-editor cm-s-jupyter">
 <div class="highlight hl-ipython3"><pre><span></span><span class="kn">import</span><span class="w"> </span><span class="nn">os</span>
+<span class="kn">import</span><span class="w"> </span><span class="nn">sys</span>
+<span class="n">sys</span><span class="o">.</span><span class="n">path</span><span class="o">.</span><span class="n">insert</span><span class="p">(</span><span class="mi">1</span><span class="p">,</span> <span class="n">os</span><span class="o">.</span><span class="n">path</span><span class="o">.</span><span class="n">join</span><span class="p">(</span><span class="n">os</span><span class="o">.</span><span class="n">environ</span><span class="p">[</span><span class="s1">'HOME'</span><span class="p">],</span> <span class="s1">'Documents'</span><span class="p">,</span> <span class="s1">'Code'</span><span class="p">,</span> <span class="s1">'git'</span><span class="p">,</span> <span class="s1">'nsf-noirlab'</span><span class="p">,</span> <span class="s1">'csdc'</span><span class="p">,</span> <span class="s1">'datalab'</span><span class="p">,</span> <span class="s1">'sparcl'</span><span class="p">,</span> <span class="s1">'sparclclient'</span><span class="p">))</span>
 <span class="kn">from</span><span class="w"> </span><span class="nn">numba</span><span class="w"> </span><span class="kn">import</span> <span class="n">NumbaDeprecationWarning</span>
 <span class="kn">import</span><span class="w"> </span><span class="nn">warnings</span>
 <span class="n">warnings</span><span class="o">.</span><span class="n">filterwarnings</span><span class="p">(</span><span class="s2">"ignore"</span><span class="p">,</span> <span class="n">category</span><span class="o">=</span><span class="n">NumbaDeprecationWarning</span><span class="p">,</span> <span class="n">message</span><span class="o">=</span><span class="sa">r</span><span class="s1">'.*numba\.jit.*'</span><span class="p">)</span>
@@ -7668,25 +7670,6 @@ a.anchor-link {
 </div>
 </div>
 </div>
-<div class="jp-Cell-outputWrapper">
-<div class="jp-Collapser jp-OutputCollapser jp-Cell-outputCollapser">
-</div>
-<div class="jp-OutputArea jp-Cell-outputArea">
-<div class="jp-OutputArea-child">
-<div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
-<div class="jp-RenderedText jp-OutputArea-output" data-mime-type="text/plain" tabindex="0">
-<pre>astro-datalab==2.24.0
-specutils==1.13.0
-bokeh==2.4.3
-prospect==1.3.3
-desispec==0.69.0
-redrock==0.20.4
-sparcl==1.2.7
-</pre>
-</div>
-</div>
-</div>
-</div>
 </div>
 <div class="jp-Cell jp-MarkdownCell jp-Notebook-cell">
 <div class="jp-Cell-inputWrapper" tabindex="0">
@@ -7704,12 +7687,12 @@ sparcl==1.2.7
 <div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
 </div>
 <div class="jp-InputArea jp-Cell-inputArea">
-<div class="jp-InputPrompt jp-InputArea-prompt">In [3]:</div>
+<div class="jp-InputPrompt jp-InputArea-prompt">In [ ]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
 <div class="cm-editor cm-s-jupyter">
 <div class="highlight hl-ipython3"><pre><span></span><span class="c1"># from getpass import getpass</span>
 <span class="c1"># token = ac.login(input("Enter user name: (+ENTER) "), getpass("Enter password: (+ENTER) "))</span>
-<span class="c1"># ac.whoAmI()</span>
+<span class="n">ac</span><span class="o">.</span><span class="n">whoAmI</span><span class="p">()</span>
 </pre></div>
 </div>
 </div>
@@ -7726,36 +7709,17 @@ sparcl==1.2.7
 </div>
 </div>
 </div>
-</div><div class="jp-Cell jp-CodeCell jp-Notebook-cell">
+</div><div class="jp-Cell jp-CodeCell jp-Notebook-cell jp-mod-noOutputs">
 <div class="jp-Cell-inputWrapper" tabindex="0">
 <div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
 </div>
 <div class="jp-InputArea jp-Cell-inputArea">
-<div class="jp-InputPrompt jp-InputArea-prompt">In [4]:</div>
+<div class="jp-InputPrompt jp-InputArea-prompt">In [ ]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
 <div class="cm-editor cm-s-jupyter">
 <div class="highlight hl-ipython3"><pre><span></span><span class="n">client</span> <span class="o">=</span> <span class="n">SparclClient</span><span class="p">()</span>
 <span class="n">client</span>
 </pre></div>
-</div>
-</div>
-</div>
-</div>
-<div class="jp-Cell-outputWrapper">
-<div class="jp-Collapser jp-OutputCollapser jp-Cell-outputCollapser">
-</div>
-<div class="jp-OutputArea jp-Cell-outputArea">
-<div class="jp-OutputArea-child">
-<div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
-<div class="jp-RenderedText jp-OutputArea-output" data-mime-type="text/plain" tabindex="0">
-<pre>announcement=Data set deprecation notice: on November 19, 2025 the SDSS/BOSS DR16 data sets were deprecated. Please use the new SDSS/BOSS DR17 data sets instead.
-</pre>
-</div>
-</div>
-<div class="jp-OutputArea-child jp-OutputArea-executeResult">
-<div class="jp-OutputPrompt jp-OutputArea-prompt">Out[4]:</div>
-<div class="jp-RenderedText jp-OutputArea-output jp-OutputArea-executeResult" data-mime-type="text/plain" tabindex="0">
-<pre>(sparclclient:1.2.7, api:13.0, https://astrosparcl.datalab.noirlab.edu/api, client_hash=, verbose=False, connect_timeout=1.1, read_timeout=5400.0, announcement=True)</pre>
 </div>
 </div>
 </div>
@@ -7771,28 +7735,16 @@ sparcl==1.2.7
 </div>
 </div>
 </div>
-</div><div class="jp-Cell jp-CodeCell jp-Notebook-cell">
+</div><div class="jp-Cell jp-CodeCell jp-Notebook-cell jp-mod-noOutputs">
 <div class="jp-Cell-inputWrapper" tabindex="0">
 <div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
 </div>
 <div class="jp-InputArea jp-Cell-inputArea">
-<div class="jp-InputPrompt jp-InputArea-prompt">In [5]:</div>
+<div class="jp-InputPrompt jp-InputArea-prompt">In [ ]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
 <div class="cm-editor cm-s-jupyter">
 <div class="highlight hl-ipython3"><pre><span></span><span class="n">qc</span><span class="o">.</span><span class="n">get_profile</span><span class="p">()</span>
 </pre></div>
-</div>
-</div>
-</div>
-</div>
-<div class="jp-Cell-outputWrapper">
-<div class="jp-Collapser jp-OutputCollapser jp-Cell-outputCollapser">
-</div>
-<div class="jp-OutputArea jp-Cell-outputArea">
-<div class="jp-OutputArea-child jp-OutputArea-executeResult">
-<div class="jp-OutputPrompt jp-OutputArea-prompt">Out[5]:</div>
-<div class="jp-RenderedText jp-OutputArea-output jp-OutputArea-executeResult" data-mime-type="text/plain" tabindex="0">
-<pre>'default'</pre>
 </div>
 </div>
 </div>
@@ -7820,12 +7772,12 @@ sparcl==1.2.7
 </div>
 </div>
 </div>
-</div><div class="jp-Cell jp-CodeCell jp-Notebook-cell">
+</div><div class="jp-Cell jp-CodeCell jp-Notebook-cell jp-mod-noOutputs">
 <div class="jp-Cell-inputWrapper" tabindex="0">
 <div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
 </div>
 <div class="jp-InputArea jp-Cell-inputArea">
-<div class="jp-InputPrompt jp-InputArea-prompt">In [6]:</div>
+<div class="jp-InputPrompt jp-InputArea-prompt">In [ ]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
 <div class="cm-editor cm-s-jupyter">
 <div class="highlight hl-ipython3"><pre><span></span><span class="n">q</span> <span class="o">=</span> <span class="s2">"""</span>
@@ -7848,43 +7800,6 @@ sparcl==1.2.7
 </div>
 </div>
 </div>
-<div class="jp-Cell-outputWrapper">
-<div class="jp-Collapser jp-OutputCollapser jp-Cell-outputCollapser">
-</div>
-<div class="jp-OutputArea jp-Cell-outputArea">
-<div class="jp-OutputArea-child jp-OutputArea-executeResult">
-<div class="jp-OutputPrompt jp-OutputArea-prompt">Out[6]:</div>
-<div class="jp-RenderedHTMLCommon jp-RenderedHTML jp-OutputArea-output jp-OutputArea-executeResult" data-mime-type="text/html" tabindex="0">
-<div><i>Table length=50</i>
-<table class="table-striped table-bordered table-condensed" id="table140047155214128">
-<thead><tr><th>targetid</th><th>chi2</th><th>z</th><th>zerr</th><th>zwarn</th><th>spectype</th><th>subtype</th><th>coadd_numexp</th><th>coadd_exptime</th><th>healpix</th><th>deltachi2</th></tr></thead>
-<thead><tr><th>int64</th><th>float64</th><th>float64</th><th>float64</th><th>int64</th><th>str6</th><th>int64</th><th>int64</th><th>float64</th><th>int64</th><th>float64</th></tr></thead>
-<tr><td>2204871004520448</td><td>7502.786605030298</td><td>0.8806668589719826</td><td>9.349553024613176e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>1</td><td>1046.75</td><td>25978</td><td>9.219138950109482</td></tr>
-<tr><td>2209099441766401</td><td>8006.957153789699</td><td>0.5376416668826327</td><td>8.224065899198639e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>1</td><td>1260.4886</td><td>25557</td><td>23.28271762281656</td></tr>
-<tr><td>2253218688008192</td><td>8434.394513607025</td><td>0.7807731132992886</td><td>9.001776300184597e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>1</td><td>949.2782</td><td>27650</td><td>80.38463451713324</td></tr>
-<tr><td>2253239848271873</td><td>8068.217628836632</td><td>0.8138682719950381</td><td>9.584803411923739e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>2</td><td>2201.3787</td><td>19462</td><td>11.19063480198383</td></tr>
-<tr><td>2253330273271809</td><td>8256.472001791</td><td>0.6026842080317678</td><td>2.811214761433289e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>1</td><td>1320.7625</td><td>19505</td><td>54.08813303161878</td></tr>
-<tr><td>2253938946473984</td><td>7914.019844397902</td><td>0.6929688143203399</td><td>6.916722607803487e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>1</td><td>824.6894</td><td>9161</td><td>11.24665383994579</td></tr>
-<tr><td>2315501380304901</td><td>8566.17580628395</td><td>0.7495491546701545</td><td>1.825370572872369e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>1</td><td>1023.1347</td><td>9160</td><td>157.1781300567091</td></tr>
-<tr><td>2323576464080897</td><td>10608.37604570389</td><td>0.6669901455530606</td><td>3.139990965279613e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>2</td><td>2315.1829</td><td>31319</td><td>28.90390665084124</td></tr>
-<tr><td>2349509577277441</td><td>8195.99036064744</td><td>0.6498143137995088</td><td>5.352659428856206e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>2</td><td>2919.674</td><td>36254</td><td>30.97397623211145</td></tr>
-<tr><td>2349509761826816</td><td>8478.736439570785</td><td>0.8820070608865096</td><td>9.368813688864787e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>2</td><td>2245.1704</td><td>36188</td><td>130.2464992851019</td></tr>
-<tr><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td></tr>
-<tr><td>2349804344573952</td><td>7783.598225384951</td><td>0.5971152109671497</td><td>9.467301428688893e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>1</td><td>1171.4036</td><td>17682</td><td>131.8656653612852</td></tr>
-<tr><td>2349804344573953</td><td>8384.117335557938</td><td>0.7734874911207676</td><td>5.094545938524808e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>2</td><td>2935.748</td><td>17682</td><td>191.5378779172897</td></tr>
-<tr><td>2349804403294209</td><td>8085.365272082388</td><td>0.6009882470468554</td><td>0.0001366930623599175</td><td>0</td><td>GALAXY</td><td>--</td><td>1</td><td>1129.9557</td><td>36799</td><td>9.397019170224667</td></tr>
-<tr><td>2349807154757633</td><td>7759.752056121826</td><td>0.8914747499370891</td><td>9.489360515236133e-06</td><td>0</td><td>GALAXY</td><td>--</td><td>1</td><td>1032.7631</td><td>25810</td><td>1990.393577575684</td></tr>
-<tr><td>2349810006884353</td><td>7813.356772936881</td><td>0.5897161345295494</td><td>8.995718391886062e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>1</td><td>1453.8173</td><td>17937</td><td>11.0996535718441</td></tr>
-<tr><td>2349810040438785</td><td>7739.014853719622</td><td>0.526467324140909</td><td>0.0001221272443611522</td><td>0</td><td>GALAXY</td><td>--</td><td>1</td><td>1121.3942</td><td>17599</td><td>12.56454463675618</td></tr>
-<tr><td>2349810086576128</td><td>9086.101851679385</td><td>0.5865114083692732</td><td>0.0001223150017235855</td><td>0</td><td>GALAXY</td><td>--</td><td>2</td><td>2988.0767</td><td>17635</td><td>523.5175925977528</td></tr>
-<tr><td>2349810359205889</td><td>7593.425254285336</td><td>0.7735598685660158</td><td>8.465901340157139e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>1</td><td>1171.4036</td><td>17683</td><td>73.9402380771935</td></tr>
-<tr><td>2349812292780033</td><td>9227.264025635086</td><td>0.7168970122818812</td><td>0.0002657236839550565</td><td>0</td><td>GALAXY</td><td>--</td><td>3</td><td>4244.771</td><td>26815</td><td>28.39506733883172</td></tr>
-<tr><td>2349816101208064</td><td>7941.910046570003</td><td>0.7993679938346777</td><td>0.0001038058256018967</td><td>0</td><td>GALAXY</td><td>--</td><td>1</td><td>1117.1798</td><td>17635</td><td>103.0777635909617</td></tr>
-</table></div>
-</div>
-</div>
-</div>
-</div>
 </div>
 <div class="jp-Cell jp-MarkdownCell jp-Notebook-cell">
 <div class="jp-Cell-inputWrapper" tabindex="0">
@@ -7902,7 +7817,7 @@ sparcl==1.2.7
 <div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
 </div>
 <div class="jp-InputArea jp-Cell-inputArea">
-<div class="jp-InputPrompt jp-InputArea-prompt">In [7]:</div>
+<div class="jp-InputPrompt jp-InputArea-prompt">In [ ]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
 <div class="cm-editor cm-s-jupyter">
 <div class="highlight hl-ipython3"><pre><span></span><span class="k">assert</span> <span class="p">(</span><span class="n">np</span><span class="o">.</span><span class="n">unique</span><span class="p">(</span><span class="n">desi_ids</span><span class="p">[</span><span class="s1">'targetid'</span><span class="p">])</span> <span class="o">==</span> <span class="n">desi_ids</span><span class="p">[</span><span class="s1">'targetid'</span><span class="p">])</span><span class="o">.</span><span class="n">all</span><span class="p">()</span>
@@ -7922,12 +7837,12 @@ sparcl==1.2.7
 </div>
 </div>
 </div>
-</div><div class="jp-Cell jp-CodeCell jp-Notebook-cell">
+</div><div class="jp-Cell jp-CodeCell jp-Notebook-cell jp-mod-noOutputs">
 <div class="jp-Cell-inputWrapper" tabindex="0">
 <div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
 </div>
 <div class="jp-InputArea jp-Cell-inputArea">
-<div class="jp-InputPrompt jp-InputArea-prompt">In [8]:</div>
+<div class="jp-InputPrompt jp-InputArea-prompt">In [ ]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
 <div class="cm-editor cm-s-jupyter">
 <div class="highlight hl-ipython3"><pre><span></span><span class="n">include</span> <span class="o">=</span> <span class="n">client</span><span class="o">.</span><span class="n">get_all_fields</span><span class="p">(</span><span class="n">dataset_list</span><span class="o">=</span><span class="p">[</span><span class="s1">'DESI-DR1'</span><span class="p">])</span>
@@ -7936,20 +7851,6 @@ sparcl==1.2.7
                                          <span class="n">dataset_list</span><span class="o">=</span><span class="p">[</span><span class="s1">'DESI-DR1'</span><span class="p">])</span>
 <span class="n">desi_spectra</span><span class="o">.</span><span class="n">info</span>
 </pre></div>
-</div>
-</div>
-</div>
-</div>
-<div class="jp-Cell-outputWrapper">
-<div class="jp-Collapser jp-OutputCollapser jp-Cell-outputCollapser">
-</div>
-<div class="jp-OutputArea jp-Cell-outputArea">
-<div class="jp-OutputArea-child jp-OutputArea-executeResult">
-<div class="jp-OutputPrompt jp-OutputArea-prompt">Out[8]:</div>
-<div class="jp-RenderedText jp-OutputArea-output jp-OutputArea-executeResult" data-mime-type="text/plain" tabindex="0">
-<pre>{'status': {'success': True,
-  'info': ["Successfully found 50 records in dr_list=['DESI-DR1']"],
-  'warnings': []}}</pre>
 </div>
 </div>
 </div>
@@ -7971,13 +7872,13 @@ sparcl==1.2.7
 <div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
 </div>
 <div class="jp-InputArea jp-Cell-inputArea">
-<div class="jp-InputPrompt jp-InputArea-prompt">In [9]:</div>
+<div class="jp-InputPrompt jp-InputArea-prompt">In [ ]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
 <div class="cm-editor cm-s-jupyter">
-<div class="highlight hl-ipython3"><pre><span></span><span class="n">desi_records</span> <span class="o">=</span> <span class="nb">sorted</span><span class="p">(</span><span class="n">desi_spectra</span><span class="o">.</span><span class="n">records</span><span class="p">,</span> <span class="n">key</span><span class="o">=</span><span class="k">lambda</span> <span class="n">x</span><span class="p">:</span> <span class="n">x</span><span class="o">.</span><span class="n">targetid</span><span class="p">)</span>
-<span class="k">assert</span> <span class="p">(</span><span class="n">np</span><span class="o">.</span><span class="n">array</span><span class="p">([</span><span class="n">r</span><span class="o">.</span><span class="n">targetid</span> <span class="k">for</span> <span class="n">r</span> <span class="ow">in</span> <span class="n">desi_records</span><span class="p">])</span> <span class="o">==</span> <span class="n">desi_ids</span><span class="p">[</span><span class="s1">'targetid'</span><span class="p">])</span><span class="o">.</span><span class="n">all</span><span class="p">()</span>
-<span class="k">assert</span> <span class="nb">all</span><span class="p">([</span><span class="n">r</span><span class="o">.</span><span class="n">survey</span> <span class="o">==</span> <span class="s1">'main'</span> <span class="k">for</span> <span class="n">r</span> <span class="ow">in</span> <span class="n">desi_records</span><span class="p">])</span>
-<span class="k">assert</span> <span class="nb">all</span><span class="p">([</span><span class="n">r</span><span class="o">.</span><span class="n">program</span> <span class="o">==</span> <span class="s1">'dark'</span> <span class="k">for</span> <span class="n">r</span> <span class="ow">in</span> <span class="n">desi_records</span><span class="p">])</span>
+<div class="highlight hl-ipython3"><pre><span></span><span class="n">desi_spectra</span> <span class="o">=</span> <span class="n">desi_spectra</span><span class="o">.</span><span class="n">reorder</span><span class="p">(</span><span class="n">desi_ids</span><span class="p">[</span><span class="s1">'targetid'</span><span class="p">]</span><span class="o">.</span><span class="n">value</span><span class="o">.</span><span class="n">tolist</span><span class="p">())</span>
+<span class="k">assert</span> <span class="p">(</span><span class="n">np</span><span class="o">.</span><span class="n">array</span><span class="p">([</span><span class="n">r</span><span class="o">.</span><span class="n">targetid</span> <span class="k">for</span> <span class="n">r</span> <span class="ow">in</span> <span class="n">desi_spectra</span><span class="o">.</span><span class="n">records</span><span class="p">])</span> <span class="o">==</span> <span class="n">desi_ids</span><span class="p">[</span><span class="s1">'targetid'</span><span class="p">])</span><span class="o">.</span><span class="n">all</span><span class="p">()</span>
+<span class="k">assert</span> <span class="nb">all</span><span class="p">([</span><span class="n">r</span><span class="o">.</span><span class="n">survey</span> <span class="o">==</span> <span class="s1">'main'</span> <span class="k">for</span> <span class="n">r</span> <span class="ow">in</span> <span class="n">desi_spectra</span><span class="o">.</span><span class="n">records</span><span class="p">])</span>
+<span class="k">assert</span> <span class="nb">all</span><span class="p">([</span><span class="n">r</span><span class="o">.</span><span class="n">program</span> <span class="o">==</span> <span class="s1">'dark'</span> <span class="k">for</span> <span class="n">r</span> <span class="ow">in</span> <span class="n">desi_spectra</span><span class="o">.</span><span class="n">records</span><span class="p">])</span>
 </pre></div>
 </div>
 </div>
@@ -7999,10 +7900,10 @@ sparcl==1.2.7
 <div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
 </div>
 <div class="jp-InputArea jp-Cell-inputArea">
-<div class="jp-InputPrompt jp-InputArea-prompt">In [10]:</div>
+<div class="jp-InputPrompt jp-InputArea-prompt">In [ ]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
 <div class="cm-editor cm-s-jupyter">
-<div class="highlight hl-ipython3"><pre><span></span><span class="k">assert</span> <span class="nb">all</span><span class="p">([(</span><span class="n">r</span><span class="o">.</span><span class="n">wavelength</span> <span class="o">==</span> <span class="n">desi_records</span><span class="p">[</span><span class="mi">0</span><span class="p">]</span><span class="o">.</span><span class="n">wavelength</span><span class="p">)</span><span class="o">.</span><span class="n">all</span><span class="p">()</span> <span class="k">for</span> <span class="n">r</span> <span class="ow">in</span> <span class="n">desi_records</span><span class="p">])</span>
+<div class="highlight hl-ipython3"><pre><span></span><span class="k">assert</span> <span class="nb">all</span><span class="p">([(</span><span class="n">r</span><span class="o">.</span><span class="n">wavelength</span> <span class="o">==</span> <span class="n">desi_spectra</span><span class="o">.</span><span class="n">records</span><span class="p">[</span><span class="mi">0</span><span class="p">]</span><span class="o">.</span><span class="n">wavelength</span><span class="p">)</span><span class="o">.</span><span class="n">all</span><span class="p">()</span> <span class="k">for</span> <span class="n">r</span> <span class="ow">in</span> <span class="n">desi_spectra</span><span class="o">.</span><span class="n">records</span><span class="p">])</span>
 </pre></div>
 </div>
 </div>
@@ -8024,15 +7925,15 @@ sparcl==1.2.7
 <div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
 </div>
 <div class="jp-InputArea jp-Cell-inputArea">
-<div class="jp-InputPrompt jp-InputArea-prompt">In [11]:</div>
+<div class="jp-InputPrompt jp-InputArea-prompt">In [ ]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
 <div class="cm-editor cm-s-jupyter">
-<div class="highlight hl-ipython3"><pre><span></span><span class="n">desi_fully_masked</span> <span class="o">=</span> <span class="n">np</span><span class="o">.</span><span class="n">zeros</span><span class="p">((</span><span class="nb">len</span><span class="p">(</span><span class="n">desi_records</span><span class="p">),</span> <span class="p">),</span> <span class="n">dtype</span><span class="o">=</span><span class="nb">bool</span><span class="p">)</span>
+<div class="highlight hl-ipython3"><pre><span></span><span class="n">desi_fully_masked</span> <span class="o">=</span> <span class="n">np</span><span class="o">.</span><span class="n">zeros</span><span class="p">((</span><span class="nb">len</span><span class="p">(</span><span class="n">desi_spectra</span><span class="o">.</span><span class="n">records</span><span class="p">),</span> <span class="p">),</span> <span class="n">dtype</span><span class="o">=</span><span class="nb">bool</span><span class="p">)</span>
 
-<span class="k">for</span> <span class="n">k</span> <span class="ow">in</span> <span class="nb">range</span><span class="p">(</span><span class="nb">len</span><span class="p">(</span><span class="n">desi_records</span><span class="p">)):</span>
-    <span class="k">assert</span> <span class="n">np</span><span class="o">.</span><span class="n">isfinite</span><span class="p">(</span><span class="n">desi_records</span><span class="p">[</span><span class="n">k</span><span class="p">]</span><span class="o">.</span><span class="n">flux</span><span class="p">)</span><span class="o">.</span><span class="n">all</span><span class="p">()</span>
-    <span class="k">assert</span> <span class="n">np</span><span class="o">.</span><span class="n">isfinite</span><span class="p">(</span><span class="n">desi_records</span><span class="p">[</span><span class="n">k</span><span class="p">]</span><span class="o">.</span><span class="n">ivar</span><span class="p">)</span><span class="o">.</span><span class="n">all</span><span class="p">()</span>
-    <span class="k">if</span> <span class="p">(</span><span class="n">desi_records</span><span class="p">[</span><span class="n">k</span><span class="p">]</span><span class="o">.</span><span class="n">mask</span> <span class="o">&gt;</span> <span class="mi">0</span><span class="p">)</span><span class="o">.</span><span class="n">all</span><span class="p">():</span>
+<span class="k">for</span> <span class="n">k</span> <span class="ow">in</span> <span class="nb">range</span><span class="p">(</span><span class="nb">len</span><span class="p">(</span><span class="n">desi_spectra</span><span class="o">.</span><span class="n">records</span><span class="p">)):</span>
+    <span class="k">assert</span> <span class="n">np</span><span class="o">.</span><span class="n">isfinite</span><span class="p">(</span><span class="n">desi_spectra</span><span class="o">.</span><span class="n">records</span><span class="p">[</span><span class="n">k</span><span class="p">]</span><span class="o">.</span><span class="n">flux</span><span class="p">)</span><span class="o">.</span><span class="n">all</span><span class="p">()</span>
+    <span class="k">assert</span> <span class="n">np</span><span class="o">.</span><span class="n">isfinite</span><span class="p">(</span><span class="n">desi_spectra</span><span class="o">.</span><span class="n">records</span><span class="p">[</span><span class="n">k</span><span class="p">]</span><span class="o">.</span><span class="n">ivar</span><span class="p">)</span><span class="o">.</span><span class="n">all</span><span class="p">()</span>
+    <span class="k">if</span> <span class="p">(</span><span class="n">desi_spectra</span><span class="o">.</span><span class="n">records</span><span class="p">[</span><span class="n">k</span><span class="p">]</span><span class="o">.</span><span class="n">mask</span> <span class="o">&gt;</span> <span class="mi">0</span><span class="p">)</span><span class="o">.</span><span class="n">all</span><span class="p">():</span>
         <span class="nb">print</span><span class="p">(</span><span class="sa">f</span><span class="s2">"WARNING: Spectrum record </span><span class="si">{</span><span class="n">k</span><span class="si">:</span><span class="s2">d</span><span class="si">}</span><span class="s2"> is fully masked!"</span><span class="p">)</span>
         <span class="n">desi_fully_masked</span><span class="p">[</span><span class="n">k</span><span class="p">]</span> <span class="o">=</span> <span class="kc">True</span>
 </pre></div>
@@ -8051,134 +7952,16 @@ sparcl==1.2.7
 </div>
 </div>
 </div>
-</div><div class="jp-Cell jp-CodeCell jp-Notebook-cell">
+</div><div class="jp-Cell jp-CodeCell jp-Notebook-cell jp-mod-noOutputs">
 <div class="jp-Cell-inputWrapper" tabindex="0">
 <div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
 </div>
 <div class="jp-InputArea jp-Cell-inputArea">
-<div class="jp-InputPrompt jp-InputArea-prompt">In [12]:</div>
+<div class="jp-InputPrompt jp-InputArea-prompt">In [ ]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
 <div class="cm-editor cm-s-jupyter">
-<div class="highlight hl-ipython3"><pre><span></span><span class="n">desi_records</span><span class="p">[</span><span class="mi">0</span><span class="p">]</span>
+<div class="highlight hl-ipython3"><pre><span></span><span class="n">desi_spectra</span><span class="o">.</span><span class="n">records</span><span class="p">[</span><span class="mi">0</span><span class="p">]</span>
 </pre></div>
-</div>
-</div>
-</div>
-</div>
-<div class="jp-Cell-outputWrapper">
-<div class="jp-Collapser jp-OutputCollapser jp-Cell-outputCollapser">
-</div>
-<div class="jp-OutputArea jp-Cell-outputArea">
-<div class="jp-OutputArea-child jp-OutputArea-executeResult">
-<div class="jp-OutputPrompt jp-OutputArea-prompt">Out[12]:</div>
-<div class="jp-RenderedText jp-OutputArea-output jp-OutputArea-executeResult" data-mime-type="text/plain" tabindex="0">
-<pre>{'redshift_err': 9.349553024613176e-05,
- 'specprimary': True,
- 'specid': 2204871004520448,
- 'wavemin': 3600.0,
- 'targetid': 2204871004520448,
- 'sparcl_id': '28f2f25e-85f2-11ef-bad2-525400f334e1',
- 'instrument': 'DESI',
- 'spectype': 'GALAXY',
- 'ra': 217.225839,
- 'data_release': 'DESI-DR1',
- 'datasetgroup': 'DESI',
- 'wavemax': 9800.0,
- 'telescope': 'kp4m',
- 'dec': 2.51927,
- 'redshift_warning': 0,
- 'exptime': 1046.75,
- 'site': 'kpno',
- 'redshift': 0.8806668589719826,
- 'subpriority': 0.5145195405365304,
- 'chi2': 7502.786605030298,
- 'scnd_target': 2,
- 'bgs_target': 0,
- 'rms_delta_x': 0.0027702876832336187,
- 'tsnr2_gpbdark': 11978.5859375,
- 'sv2_bgs_target': 0,
- 'sv3_bgs_target': 0,
- 'tsnr2_elg': 115.0233154296875,
- 'healpix': 25978,
- 'mean_delta_x': 0.0027702876832336187,
- 'objtype': 'TGT',
- 'ncoeff': 10,
- 'spgrpval': 25978,
- 'coadd_numexp': 1,
- 'obsconditions': 63,
- 'fa_type': 1,
- 'sv1_scnd_target': 0,
- 'pmdec': 0.0,
- 'sv3_desi_target': 0,
- 'subtype': '',
- 'sv2_mws_target': 0,
- 'survey': 'main',
- 'npixels': 7825,
- 'mean_delta_y': -0.0011232448741793633,
- 'coadd_numtile': 1,
- 'coeff': [25.44093808554416,
-  -3.6410153295212315,
-  0.9725984367631926,
-  11.240508979723524,
-  -0.2209052469004468,
-  -1.0802661550478518,
-  -7.258869651654611,
-  -0.3844962869827613,
-  -2.419508464923245,
-  -5.71567123041432],
- 'mean_fiber_dec': 2.51927430279325,
- 'tsnr2_qso': 29.331745147705078,
- 'plate_ra': 217.225839,
- 'sv1_mws_target': 0,
- 'fa_target': 4611686018427387904,
- 'mean_mjd': 59673.39638014,
- 'main_primary': True,
- 'sv_primary': False,
- 'tsnr2_lrg': 80.06736755371094,
- 'tsnr2_lya': 112.58667755126953,
- 'sv_nspec': 0,
- 'coadd_numnight': 1,
- 'ref_epoch': 2000.0,
- 'zcat_nspec': 1,
- 'sv2_desi_target': 0,
- 'desi_target': 4611686018427387904,
- 'tsnr2_bgs': 6585.67626953125,
- 'numobs_init': 1,
- 'rms_delta_y': 0.0011232448741793633,
- 'pmra': 0.0,
- 'cmx_target': 0,
- 'mws_target': 0,
- 'main_nspec': 1,
- 'sv1_desi_target': 0,
- 'coadd_fiberstatus': 0,
- 'std_fiber_ra': 0.0,
- 'desiname': 'DESI J217.2258+02.5192',
- 'sv3_mws_target': 0,
- 'priority_init': 1900,
- 'sv1_bgs_target': 0,
- 'plate_dec': 2.51927,
- 'deltachi2': 9.219138950109482,
- 'sv2_scnd_target': 0,
- 'std_fiber_dec': 0.0,
- 'tsnr2_gpbbright': 2042.88525390625,
- 'program': 'dark',
- 'mean_psf_to_fiber_specflux': 0.7923550605773926,
- 'mean_fiber_ra': 217.2258500531933,
- 'tsnr2_gpbbackup': 12749.2490234375,
- 'sv3_scnd_target': 0,
- 'mask': array([0, 0, 0, ..., 0, 0, 0]),
- 'wave_sigma': array([0.68404573, 0.68069285, 0.67530686, ..., 0.7782045 , 0.79153621,
-        0.81834054]),
- 'model': array([0.11206556, 0.14871655, 0.15365456, ..., 0.0821958 , 0.07696503,
-        0.05125701]),
- 'wavelength': array([3600. , 3600.8, 3601.6, ..., 9822.4, 9823.2, 9824. ]),
- 'ivar': array([ 0.09025028,  0.09778932,  0.09730244, ..., 12.65768719,
-        16.33502579, 25.78590393]),
- 'flux': array([-1.75440347, -5.81356716,  0.2588788 , ..., -0.42552659,
-         0.03952634,  0.13771901]),
- 'dateobs': '["2022-04-04 09:30:47.244+00","2022-04-04 09:30:47.244+00"]',
- 'dateobs_center': '2022-04-04 09:30:47.244096+00',
- '_dr': 'DESI-DR1'}</pre>
 </div>
 </div>
 </div>
@@ -8200,7 +7983,7 @@ sparcl==1.2.7
 <li>A redshift catalog. This should be an Astropy <code>Table</code> with the expected columns.</li>
 <li>A model spectrum.  The model is actually provided by SPARCL, but we need to input it separately.</li>
 </ol>
-<h4 id="Spectrum-object">Spectrum object<a class="anchor-link" href="#Spectrum-object">¶</a></h4><p>First we assemble the components of the spectrum object</p>
+<h4 id="Spectrum-object">Spectrum object<a class="anchor-link" href="#Spectrum-object">¶</a></h4><p>First we assemble the components of the spectrum object. Most of the work is done simply by converting the retrieved results to a <code>specutils</code> object.</p>
 </div>
 </div>
 </div>
@@ -8209,26 +7992,10 @@ sparcl==1.2.7
 <div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
 </div>
 <div class="jp-InputArea jp-Cell-inputArea">
-<div class="jp-InputPrompt jp-InputArea-prompt">In [13]:</div>
+<div class="jp-InputPrompt jp-InputArea-prompt">In [ ]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
 <div class="cm-editor cm-s-jupyter">
-<div class="highlight hl-ipython3"><pre><span></span><span class="n">flux</span> <span class="o">=</span> <span class="n">np</span><span class="o">.</span><span class="n">zeros</span><span class="p">((</span><span class="nb">len</span><span class="p">(</span><span class="n">desi_records</span><span class="p">),</span> <span class="n">desi_records</span><span class="p">[</span><span class="mi">0</span><span class="p">]</span><span class="o">.</span><span class="n">flux</span><span class="o">.</span><span class="n">shape</span><span class="p">[</span><span class="mi">0</span><span class="p">]),</span>
-                <span class="n">dtype</span><span class="o">=</span><span class="n">desi_records</span><span class="p">[</span><span class="mi">0</span><span class="p">]</span><span class="o">.</span><span class="n">flux</span><span class="o">.</span><span class="n">dtype</span><span class="p">)</span>
-<span class="n">uncertainty</span> <span class="o">=</span> <span class="n">np</span><span class="o">.</span><span class="n">zeros</span><span class="p">((</span><span class="nb">len</span><span class="p">(</span><span class="n">desi_records</span><span class="p">),</span> <span class="n">desi_records</span><span class="p">[</span><span class="mi">0</span><span class="p">]</span><span class="o">.</span><span class="n">ivar</span><span class="o">.</span><span class="n">shape</span><span class="p">[</span><span class="mi">0</span><span class="p">]),</span>
-                       <span class="n">dtype</span><span class="o">=</span><span class="n">desi_records</span><span class="p">[</span><span class="mi">0</span><span class="p">]</span><span class="o">.</span><span class="n">ivar</span><span class="o">.</span><span class="n">dtype</span><span class="p">)</span>
-<span class="n">mask</span> <span class="o">=</span> <span class="n">np</span><span class="o">.</span><span class="n">zeros</span><span class="p">((</span><span class="nb">len</span><span class="p">(</span><span class="n">desi_records</span><span class="p">),</span> <span class="n">desi_records</span><span class="p">[</span><span class="mi">0</span><span class="p">]</span><span class="o">.</span><span class="n">mask</span><span class="o">.</span><span class="n">shape</span><span class="p">[</span><span class="mi">0</span><span class="p">]),</span>
-                <span class="n">dtype</span><span class="o">=</span><span class="n">desi_records</span><span class="p">[</span><span class="mi">0</span><span class="p">]</span><span class="o">.</span><span class="n">mask</span><span class="o">.</span><span class="n">dtype</span><span class="p">)</span>
-
-<span class="n">meta</span> <span class="o">=</span> <span class="p">{</span><span class="s1">'sparcl_id'</span><span class="p">:</span> <span class="nb">list</span><span class="p">(),</span> <span class="s1">'data_release'</span><span class="p">:</span> <span class="nb">list</span><span class="p">()}</span>
-<span class="n">sparcl_id</span> <span class="o">=</span> <span class="nb">list</span><span class="p">()</span>
-<span class="n">data_release</span> <span class="o">=</span> <span class="nb">list</span><span class="p">()</span>
-
-<span class="k">for</span> <span class="n">k</span> <span class="ow">in</span> <span class="nb">range</span><span class="p">(</span><span class="nb">len</span><span class="p">(</span><span class="n">desi_records</span><span class="p">)):</span>
-    <span class="n">flux</span><span class="p">[</span><span class="n">k</span><span class="p">,</span> <span class="p">:]</span> <span class="o">=</span> <span class="n">desi_records</span><span class="p">[</span><span class="n">k</span><span class="p">]</span><span class="o">.</span><span class="n">flux</span>
-    <span class="n">uncertainty</span><span class="p">[</span><span class="n">k</span><span class="p">,</span> <span class="p">:]</span> <span class="o">=</span> <span class="n">desi_records</span><span class="p">[</span><span class="n">k</span><span class="p">]</span><span class="o">.</span><span class="n">ivar</span>
-    <span class="n">mask</span><span class="p">[</span><span class="n">k</span><span class="p">,</span> <span class="p">:]</span> <span class="o">=</span> <span class="n">desi_records</span><span class="p">[</span><span class="n">k</span><span class="p">]</span><span class="o">.</span><span class="n">mask</span>
-    <span class="n">meta</span><span class="p">[</span><span class="s1">'sparcl_id'</span><span class="p">]</span><span class="o">.</span><span class="n">append</span><span class="p">(</span><span class="n">desi_records</span><span class="p">[</span><span class="n">k</span><span class="p">]</span><span class="o">.</span><span class="n">sparcl_id</span><span class="p">)</span>
-    <span class="n">meta</span><span class="p">[</span><span class="s1">'data_release'</span><span class="p">]</span><span class="o">.</span><span class="n">append</span><span class="p">(</span><span class="n">desi_records</span><span class="p">[</span><span class="n">k</span><span class="p">]</span><span class="o">.</span><span class="n">data_release</span><span class="p">)</span>
+<div class="highlight hl-ipython3"><pre><span></span><span class="n">desi_specutils</span> <span class="o">=</span> <span class="n">desi_spectra</span><span class="o">.</span><span class="n">to_specutils</span><span class="p">()</span>
 </pre></div>
 </div>
 </div>
@@ -8241,7 +8008,7 @@ sparcl==1.2.7
 </div>
 <div class="jp-InputArea jp-Cell-inputArea"><div class="jp-InputPrompt jp-InputArea-prompt">
 </div><div class="jp-RenderedHTMLCommon jp-RenderedMarkdown jp-MarkdownOutput" data-mime-type="text/markdown">
-<p>And the "fibermap" table. We'll start with photometric quantities.</p>
+<p>We need a "fibermap" table. We'll start with photometric quantities.</p>
 </div>
 </div>
 </div>
@@ -8250,7 +8017,7 @@ sparcl==1.2.7
 <div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
 </div>
 <div class="jp-InputArea jp-Cell-inputArea">
-<div class="jp-InputPrompt jp-InputArea-prompt">In [14]:</div>
+<div class="jp-InputPrompt jp-InputArea-prompt">In [ ]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
 <div class="cm-editor cm-s-jupyter">
 <div class="highlight hl-ipython3"><pre><span></span><span class="n">columns</span> <span class="o">=</span> <span class="p">(</span><span class="s1">'targetid'</span><span class="p">,</span> <span class="s1">'ra'</span><span class="p">,</span> <span class="s1">'dec'</span><span class="p">,</span> <span class="s1">'ref_epoch'</span><span class="p">,</span> <span class="s1">'pmra'</span><span class="p">,</span> <span class="s1">'pmdec'</span><span class="p">,</span> <span class="s1">'ebv'</span><span class="p">,</span>
@@ -8284,7 +8051,7 @@ sparcl==1.2.7
 <div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
 </div>
 <div class="jp-InputArea jp-Cell-inputArea">
-<div class="jp-InputPrompt jp-InputArea-prompt">In [15]:</div>
+<div class="jp-InputPrompt jp-InputArea-prompt">In [ ]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
 <div class="cm-editor cm-s-jupyter">
 <div class="highlight hl-ipython3"><pre><span></span><span class="k">for</span> <span class="n">col</span> <span class="ow">in</span> <span class="n">fibermap</span><span class="o">.</span><span class="n">colnames</span><span class="p">:</span>
@@ -8313,7 +8080,7 @@ sparcl==1.2.7
 <div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
 </div>
 <div class="jp-InputArea jp-Cell-inputArea">
-<div class="jp-InputPrompt jp-InputArea-prompt">In [16]:</div>
+<div class="jp-InputPrompt jp-InputArea-prompt">In [ ]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
 <div class="cm-editor cm-s-jupyter">
 <div class="highlight hl-ipython3"><pre><span></span><span class="k">assert</span> <span class="p">(</span><span class="n">fibermap</span><span class="p">[</span><span class="s1">'TARGETID'</span><span class="p">]</span> <span class="o">==</span> <span class="n">desi_ids</span><span class="p">[</span><span class="s1">'targetid'</span><span class="p">])</span><span class="o">.</span><span class="n">all</span><span class="p">()</span>
@@ -8338,7 +8105,7 @@ sparcl==1.2.7
 <div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
 </div>
 <div class="jp-InputArea jp-Cell-inputArea">
-<div class="jp-InputPrompt jp-InputArea-prompt">In [17]:</div>
+<div class="jp-InputPrompt jp-InputArea-prompt">In [ ]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
 <div class="cm-editor cm-s-jupyter">
 <div class="highlight hl-ipython3"><pre><span></span><span class="n">columns</span> <span class="o">=</span> <span class="p">(</span><span class="s1">'targetid'</span><span class="p">,</span> <span class="s1">'desi_target'</span><span class="p">,</span> <span class="s1">'bgs_target'</span><span class="p">,</span> <span class="s1">'mws_target'</span><span class="p">,</span> <span class="s1">'scnd_target'</span><span class="p">)</span>
@@ -8371,7 +8138,7 @@ sparcl==1.2.7
 <div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
 </div>
 <div class="jp-InputArea jp-Cell-inputArea">
-<div class="jp-InputPrompt jp-InputArea-prompt">In [18]:</div>
+<div class="jp-InputPrompt jp-InputArea-prompt">In [ ]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
 <div class="cm-editor cm-s-jupyter">
 <div class="highlight hl-ipython3"><pre><span></span><span class="k">for</span> <span class="n">col</span> <span class="ow">in</span> <span class="n">targeting</span><span class="o">.</span><span class="n">colnames</span><span class="p">:</span>
@@ -8397,7 +8164,7 @@ sparcl==1.2.7
 <div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
 </div>
 <div class="jp-InputArea jp-Cell-inputArea">
-<div class="jp-InputPrompt jp-InputArea-prompt">In [19]:</div>
+<div class="jp-InputPrompt jp-InputArea-prompt">In [ ]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
 <div class="cm-editor cm-s-jupyter">
 <div class="highlight hl-ipython3"><pre><span></span><span class="k">assert</span> <span class="p">(</span><span class="n">targeting</span><span class="p">[</span><span class="s1">'TARGETID'</span><span class="p">]</span> <span class="o">==</span> <span class="n">fibermap</span><span class="p">[</span><span class="s1">'TARGETID'</span><span class="p">])</span><span class="o">.</span><span class="n">all</span><span class="p">()</span>
@@ -8422,10 +8189,10 @@ sparcl==1.2.7
 <div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
 </div>
 <div class="jp-InputArea jp-Cell-inputArea">
-<div class="jp-InputPrompt jp-InputArea-prompt">In [20]:</div>
+<div class="jp-InputPrompt jp-InputArea-prompt">In [ ]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
 <div class="cm-editor cm-s-jupyter">
-<div class="highlight hl-ipython3"><pre><span></span><span class="k">assert</span> <span class="p">(</span><span class="n">np</span><span class="o">.</span><span class="n">array</span><span class="p">([</span><span class="n">r</span><span class="o">.</span><span class="n">targetid</span> <span class="k">for</span> <span class="n">r</span> <span class="ow">in</span> <span class="n">desi_records</span><span class="p">])</span> <span class="o">==</span> <span class="n">fibermap</span><span class="p">[</span><span class="s1">'TARGETID'</span><span class="p">])</span><span class="o">.</span><span class="n">all</span><span class="p">()</span>
+<div class="highlight hl-ipython3"><pre><span></span><span class="k">assert</span> <span class="p">(</span><span class="n">np</span><span class="o">.</span><span class="n">array</span><span class="p">([</span><span class="n">r</span><span class="o">.</span><span class="n">targetid</span> <span class="k">for</span> <span class="n">r</span> <span class="ow">in</span> <span class="n">desi_spectra</span><span class="o">.</span><span class="n">records</span><span class="p">])</span> <span class="o">==</span> <span class="n">fibermap</span><span class="p">[</span><span class="s1">'TARGETID'</span><span class="p">])</span><span class="o">.</span><span class="n">all</span><span class="p">()</span>
 </pre></div>
 </div>
 </div>
@@ -8442,55 +8209,18 @@ sparcl==1.2.7
 </div>
 </div>
 </div>
-</div><div class="jp-Cell jp-CodeCell jp-Notebook-cell">
+</div><div class="jp-Cell jp-CodeCell jp-Notebook-cell jp-mod-noOutputs">
 <div class="jp-Cell-inputWrapper" tabindex="0">
 <div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
 </div>
 <div class="jp-InputArea jp-Cell-inputArea">
-<div class="jp-InputPrompt jp-InputArea-prompt">In [21]:</div>
+<div class="jp-InputPrompt jp-InputArea-prompt">In [ ]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
 <div class="cm-editor cm-s-jupyter">
 <div class="highlight hl-ipython3"><pre><span></span><span class="k">for</span> <span class="n">col</span> <span class="ow">in</span> <span class="p">(</span><span class="s1">'DESI_TARGET'</span><span class="p">,</span> <span class="s1">'BGS_TARGET'</span><span class="p">,</span> <span class="s1">'MWS_TARGET'</span><span class="p">,</span> <span class="s1">'SCND_TARGET'</span><span class="p">):</span>
     <span class="n">fibermap</span><span class="o">.</span><span class="n">add_column</span><span class="p">(</span><span class="n">targeting</span><span class="p">[</span><span class="n">col</span><span class="p">])</span>
 <span class="n">fibermap</span>
 </pre></div>
-</div>
-</div>
-</div>
-</div>
-<div class="jp-Cell-outputWrapper">
-<div class="jp-Collapser jp-OutputCollapser jp-Cell-outputCollapser">
-</div>
-<div class="jp-OutputArea jp-Cell-outputArea">
-<div class="jp-OutputArea-child jp-OutputArea-executeResult">
-<div class="jp-OutputPrompt jp-OutputArea-prompt">Out[21]:</div>
-<div class="jp-RenderedHTMLCommon jp-RenderedHTML jp-OutputArea-output jp-OutputArea-executeResult" data-mime-type="text/html" tabindex="0">
-<div><i>Table length=50</i>
-<table class="table-striped table-bordered table-condensed" id="table140046329411424">
-<thead><tr><th>TARGETID</th><th>TARGET_RA</th><th>TARGET_DEC</th><th>REF_EPOCH</th><th>PMRA</th><th>PMDEC</th><th>EBV</th><th>FLUX_G</th><th>FLUX_R</th><th>FLUX_Z</th><th>FLUX_W1</th><th>FLUX_W2</th><th>DESI_TARGET</th><th>BGS_TARGET</th><th>MWS_TARGET</th><th>SCND_TARGET</th></tr></thead>
-<thead><tr><th>int64</th><th>float64</th><th>float64</th><th>float64</th><th>int64</th><th>int64</th><th>float64</th><th>float64</th><th>float64</th><th>float64</th><th>float64</th><th>float64</th><th>int64</th><th>int64</th><th>int64</th><th>int64</th></tr></thead>
-<tr><td>2204871004520448</td><td>217.225839</td><td>2.51927</td><td>2000.0</td><td>0</td><td>0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>4611686018427387904</td><td>0</td><td>0</td><td>2</td></tr>
-<tr><td>2209099441766401</td><td>184.69048046</td><td>-4.38150356</td><td>2015.5</td><td>0</td><td>0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>4611686018427387904</td><td>0</td><td>0</td><td>4</td></tr>
-<tr><td>2253218688008192</td><td>179.5754362869344</td><td>1.28294636937531</td><td>0.0</td><td>0</td><td>0</td><td>0.016607514</td><td>0.21799669</td><td>1.6909436</td><td>6.8204284</td><td>1.5204644</td><td>0.1144698</td><td>4611686018427387904</td><td>0</td><td>0</td><td>4096</td></tr>
-<tr><td>2253239848271873</td><td>0.9572810349043309</td><td>2.144423462609681</td><td>0.0</td><td>0</td><td>0</td><td>0.034726426</td><td>0.30583543</td><td>1.0512924</td><td>2.7048514</td><td>0.95714384</td><td>0.10165523</td><td>4611686018427387904</td><td>0</td><td>0</td><td>4096</td></tr>
-<tr><td>2253330273271809</td><td>0.1660861096769561</td><td>6.104126419350009</td><td>0.0</td><td>0</td><td>0</td><td>0.05873131</td><td>0.55434924</td><td>2.0805817</td><td>8.749854</td><td>5.905693</td><td>1.927108</td><td>4611686018427387904</td><td>0</td><td>0</td><td>4096</td></tr>
-<tr><td>2253938946473984</td><td>224.6519905758737</td><td>32.74748369472182</td><td>0.0</td><td>0</td><td>0</td><td>0.015478675</td><td>1.128178</td><td>2.2834258</td><td>12.134571</td><td>9.021092</td><td>3.7852304</td><td>4611686018427387904</td><td>0</td><td>0</td><td>4096</td></tr>
-<tr><td>2315501380304901</td><td>223.9962846929875</td><td>32.34797052240934</td><td>2015.5</td><td>0</td><td>0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>4611686018427387904</td><td>0</td><td>0</td><td>67108864</td></tr>
-<tr><td>2323576464080897</td><td>245.796399002067</td><td>0.809652204860224</td><td>2015.5</td><td>0</td><td>0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>4611686018427387904</td><td>0</td><td>0</td><td>268435456</td></tr>
-<tr><td>2349509577277441</td><td>52.91607559005856</td><td>-18.21333492638648</td><td>0.0</td><td>0</td><td>0</td><td>0.042202096</td><td>0.27590653</td><td>0.39503357</td><td>0.44176143</td><td>3.9339137</td><td>8.551368</td><td>4611686018427387904</td><td>0</td><td>0</td><td>17179869184</td></tr>
-<tr><td>2349509761826816</td><td>64.63882388910243</td><td>-18.29809033472808</td><td>0.0</td><td>0</td><td>0</td><td>0.04455217</td><td>1.9623269</td><td>5.5475426</td><td>27.947685</td><td>39.58498</td><td>16.831314</td><td>4611686018427387904</td><td>0</td><td>0</td><td>17179869184</td></tr>
-<tr><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td></tr>
-<tr><td>2349804344573952</td><td>35.9184965505417</td><td>-5.84530583399778</td><td>0.0</td><td>0</td><td>0</td><td>0.02338664</td><td>1.2835658</td><td>4.7132916</td><td>13.472958</td><td>50.203278</td><td>38.516064</td><td>4611686018427387904</td><td>0</td><td>0</td><td>17179869184</td></tr>
-<tr><td>2349804344573953</td><td>35.91783811022479</td><td>-5.845063171501605</td><td>0.0</td><td>0</td><td>0</td><td>0.023381557</td><td>0.32031807</td><td>0.49168012</td><td>0.8512743</td><td>-4.455745</td><td>-7.842182</td><td>4611686018427387904</td><td>0</td><td>0</td><td>17179869184</td></tr>
-<tr><td>2349804403294209</td><td>39.5739</td><td>-5.765</td><td>2015.5</td><td>0</td><td>0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>4611686018427387904</td><td>0</td><td>0</td><td>17179869184</td></tr>
-<tr><td>2349807154757633</td><td>204.1660126643467</td><td>-5.782052431296652</td><td>0.0</td><td>0</td><td>0</td><td>0.02748748</td><td>0.692519</td><td>1.0083932</td><td>2.4016192</td><td>12.692081</td><td>11.705431</td><td>4611686018427387904</td><td>0</td><td>0</td><td>17179869184</td></tr>
-<tr><td>2349810006884353</td><td>14.95797496950264</td><td>-5.583761128538709</td><td>0.0</td><td>0</td><td>0</td><td>0.057812985</td><td>1.7276545</td><td>2.5348349</td><td>3.9569442</td><td>-10.098145</td><td>-0.743038</td><td>4611686018427387904</td><td>0</td><td>0</td><td>17179869184</td></tr>
-<tr><td>2349810040438785</td><td>16.9193527455842</td><td>-5.39187562193212</td><td>0.0</td><td>0</td><td>0</td><td>0.04618287</td><td>0.39203063</td><td>0.25528747</td><td>0.08371848</td><td>5.4100323</td><td>20.09819</td><td>4611686018427387904</td><td>0</td><td>0</td><td>17179869184</td></tr>
-<tr><td>2349810086576128</td><td>19.66075203568845</td><td>-5.444409844626712</td><td>0.0</td><td>0</td><td>0</td><td>0.05566529</td><td>1.0205576</td><td>5.9033976</td><td>21.924006</td><td>61.201687</td><td>32.800064</td><td>4611686018427387904</td><td>0</td><td>0</td><td>17179869184</td></tr>
-<tr><td>2349810359205889</td><td>36.1456</td><td>-5.4993</td><td>2015.5</td><td>0</td><td>0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>4611686018427387904</td><td>0</td><td>0</td><td>17179869184</td></tr>
-<tr><td>2349812292780033</td><td>151.8450879264672</td><td>-5.385951487253016</td><td>0.0</td><td>0</td><td>0</td><td>0.045914873</td><td>1.0359656</td><td>1.3913673</td><td>1.7665042</td><td>-4.595202</td><td>-3.8645167</td><td>4611686018427387904</td><td>0</td><td>0</td><td>17179869184</td></tr>
-<tr><td>2349816101208064</td><td>19.78856241203688</td><td>-5.218958968010406</td><td>0.0</td><td>0</td><td>0</td><td>0.050802644</td><td>2.6151247</td><td>5.0622296</td><td>12.391033</td><td>47.07424</td><td>38.79583</td><td>4611686018427387904</td><td>0</td><td>0</td><td>17179869184</td></tr>
-</table></div>
 </div>
 </div>
 </div>
@@ -8502,7 +8232,7 @@ sparcl==1.2.7
 </div>
 <div class="jp-InputArea jp-Cell-inputArea"><div class="jp-InputPrompt jp-InputArea-prompt">
 </div><div class="jp-RenderedHTMLCommon jp-RenderedMarkdown jp-MarkdownOutput" data-mime-type="text/markdown">
-<p>Finally assemble the object.</p>
+<p>Finally assemble the object. Although we already created a <code>specutils.Spectrum</code> object above, Prospect expects a slightly different version of a <code>specutils</code> object.</p>
 </div>
 </div>
 </div>
@@ -8511,16 +8241,16 @@ sparcl==1.2.7
 <div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
 </div>
 <div class="jp-InputArea jp-Cell-inputArea">
-<div class="jp-InputPrompt jp-InputArea-prompt">In [22]:</div>
+<div class="jp-InputPrompt jp-InputArea-prompt">In [ ]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
 <div class="cm-editor cm-s-jupyter">
 <div class="highlight hl-ipython3"><pre><span></span><span class="n">desi_prospect</span> <span class="o">=</span> <span class="n">Spectra</span><span class="p">(</span><span class="n">bands</span><span class="o">=</span><span class="p">[</span><span class="s1">'coadd'</span><span class="p">],</span>
-                        <span class="n">wave</span><span class="o">=</span><span class="p">{</span><span class="s1">'coadd'</span><span class="p">:</span> <span class="n">desi_records</span><span class="p">[</span><span class="mi">0</span><span class="p">]</span><span class="o">.</span><span class="n">wavelength</span><span class="p">},</span>
-                        <span class="n">flux</span><span class="o">=</span><span class="p">{</span><span class="s1">'coadd'</span><span class="p">:</span> <span class="n">flux</span><span class="p">[</span><span class="o">~</span><span class="n">desi_fully_masked</span><span class="p">,</span> <span class="p">:]},</span>
-                        <span class="n">ivar</span><span class="o">=</span><span class="p">{</span><span class="s1">'coadd'</span><span class="p">:</span> <span class="n">uncertainty</span><span class="p">[</span><span class="o">~</span><span class="n">desi_fully_masked</span><span class="p">,</span> <span class="p">:]},</span>
-                        <span class="n">mask</span><span class="o">=</span><span class="p">{</span><span class="s1">'coadd'</span><span class="p">:</span> <span class="n">mask</span><span class="p">[</span><span class="o">~</span><span class="n">desi_fully_masked</span><span class="p">,</span> <span class="p">:]},</span>
+                        <span class="n">wave</span><span class="o">=</span><span class="p">{</span><span class="s1">'coadd'</span><span class="p">:</span> <span class="n">desi_specutils</span><span class="o">.</span><span class="n">spectral_axis</span><span class="o">.</span><span class="n">value</span><span class="p">},</span>
+                        <span class="n">flux</span><span class="o">=</span><span class="p">{</span><span class="s1">'coadd'</span><span class="p">:</span> <span class="n">desi_specutils</span><span class="o">.</span><span class="n">flux</span><span class="p">[</span><span class="o">~</span><span class="n">desi_fully_masked</span><span class="p">,</span> <span class="p">:]},</span>
+                        <span class="n">ivar</span><span class="o">=</span><span class="p">{</span><span class="s1">'coadd'</span><span class="p">:</span> <span class="n">desi_specutils</span><span class="o">.</span><span class="n">uncertainty</span><span class="p">[</span><span class="o">~</span><span class="n">desi_fully_masked</span><span class="p">,</span> <span class="p">:]</span><span class="o">.</span><span class="n">array</span><span class="p">},</span>
+                        <span class="n">mask</span><span class="o">=</span><span class="p">{</span><span class="s1">'coadd'</span><span class="p">:</span> <span class="n">desi_specutils</span><span class="o">.</span><span class="n">mask</span><span class="p">[</span><span class="o">~</span><span class="n">desi_fully_masked</span><span class="p">,</span> <span class="p">:]},</span>
                         <span class="n">fibermap</span><span class="o">=</span><span class="n">fibermap</span><span class="p">[</span><span class="o">~</span><span class="n">desi_fully_masked</span><span class="p">],</span>
-                        <span class="n">meta</span><span class="o">=</span><span class="p">{</span><span class="s1">'coadd'</span><span class="p">:</span> <span class="n">meta</span><span class="p">})</span>
+                        <span class="n">meta</span><span class="o">=</span><span class="p">{</span><span class="s1">'coadd'</span><span class="p">:</span> <span class="n">desi_specutils</span><span class="o">.</span><span class="n">meta</span><span class="p">})</span>
 </pre></div>
 </div>
 </div>
@@ -8537,12 +8267,12 @@ sparcl==1.2.7
 </div>
 </div>
 </div>
-</div><div class="jp-Cell jp-CodeCell jp-Notebook-cell">
+</div><div class="jp-Cell jp-CodeCell jp-Notebook-cell jp-mod-noOutputs">
 <div class="jp-Cell-inputWrapper" tabindex="0">
 <div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
 </div>
 <div class="jp-InputArea jp-Cell-inputArea">
-<div class="jp-InputPrompt jp-InputArea-prompt">In [23]:</div>
+<div class="jp-InputPrompt jp-InputArea-prompt">In [ ]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
 <div class="cm-editor cm-s-jupyter">
 <div class="highlight hl-ipython3"><pre><span></span><span class="n">desi_zcatalog</span> <span class="o">=</span> <span class="n">desi_ids</span><span class="o">.</span><span class="n">copy</span><span class="p">()</span>
@@ -8556,43 +8286,6 @@ sparcl==1.2.7
         <span class="n">desi_zcatalog</span><span class="o">.</span><span class="n">rename_column</span><span class="p">(</span><span class="n">col</span><span class="p">,</span> <span class="n">col</span><span class="o">.</span><span class="n">upper</span><span class="p">())</span>
 <span class="n">desi_zcatalog</span>
 </pre></div>
-</div>
-</div>
-</div>
-</div>
-<div class="jp-Cell-outputWrapper">
-<div class="jp-Collapser jp-OutputCollapser jp-Cell-outputCollapser">
-</div>
-<div class="jp-OutputArea jp-Cell-outputArea">
-<div class="jp-OutputArea-child jp-OutputArea-executeResult">
-<div class="jp-OutputPrompt jp-OutputArea-prompt">Out[23]:</div>
-<div class="jp-RenderedHTMLCommon jp-RenderedHTML jp-OutputArea-output jp-OutputArea-executeResult" data-mime-type="text/html" tabindex="0">
-<div><i>Table length=50</i>
-<table class="table-striped table-bordered table-condensed" id="table140046329412672">
-<thead><tr><th>TARGETID</th><th>CHI2</th><th>Z</th><th>ZERR</th><th>ZWARN</th><th>SPECTYPE</th><th>SUBTYPE</th><th>COADD_NUMEXP</th><th>COADD_EXPTIME</th><th>HPXPIXEL</th><th>DELTACHI2</th></tr></thead>
-<thead><tr><th>int64</th><th>float64</th><th>float64</th><th>float64</th><th>int64</th><th>str6</th><th>int64</th><th>int64</th><th>float64</th><th>int64</th><th>float64</th></tr></thead>
-<tr><td>2204871004520448</td><td>7502.786605030298</td><td>0.8806668589719826</td><td>9.349553024613176e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>1</td><td>1046.75</td><td>25978</td><td>9.219138950109482</td></tr>
-<tr><td>2209099441766401</td><td>8006.957153789699</td><td>0.5376416668826327</td><td>8.224065899198639e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>1</td><td>1260.4886</td><td>25557</td><td>23.28271762281656</td></tr>
-<tr><td>2253218688008192</td><td>8434.394513607025</td><td>0.7807731132992886</td><td>9.001776300184597e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>1</td><td>949.2782</td><td>27650</td><td>80.38463451713324</td></tr>
-<tr><td>2253239848271873</td><td>8068.217628836632</td><td>0.8138682719950381</td><td>9.584803411923739e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>2</td><td>2201.3787</td><td>19462</td><td>11.19063480198383</td></tr>
-<tr><td>2253330273271809</td><td>8256.472001791</td><td>0.6026842080317678</td><td>2.811214761433289e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>1</td><td>1320.7625</td><td>19505</td><td>54.08813303161878</td></tr>
-<tr><td>2253938946473984</td><td>7914.019844397902</td><td>0.6929688143203399</td><td>6.916722607803487e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>1</td><td>824.6894</td><td>9161</td><td>11.24665383994579</td></tr>
-<tr><td>2315501380304901</td><td>8566.17580628395</td><td>0.7495491546701545</td><td>1.825370572872369e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>1</td><td>1023.1347</td><td>9160</td><td>157.1781300567091</td></tr>
-<tr><td>2323576464080897</td><td>10608.37604570389</td><td>0.6669901455530606</td><td>3.139990965279613e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>2</td><td>2315.1829</td><td>31319</td><td>28.90390665084124</td></tr>
-<tr><td>2349509577277441</td><td>8195.99036064744</td><td>0.6498143137995088</td><td>5.352659428856206e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>2</td><td>2919.674</td><td>36254</td><td>30.97397623211145</td></tr>
-<tr><td>2349509761826816</td><td>8478.736439570785</td><td>0.8820070608865096</td><td>9.368813688864787e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>2</td><td>2245.1704</td><td>36188</td><td>130.2464992851019</td></tr>
-<tr><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td></tr>
-<tr><td>2349804344573952</td><td>7783.598225384951</td><td>0.5971152109671497</td><td>9.467301428688893e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>1</td><td>1171.4036</td><td>17682</td><td>131.8656653612852</td></tr>
-<tr><td>2349804344573953</td><td>8384.117335557938</td><td>0.7734874911207676</td><td>5.094545938524808e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>2</td><td>2935.748</td><td>17682</td><td>191.5378779172897</td></tr>
-<tr><td>2349804403294209</td><td>8085.365272082388</td><td>0.6009882470468554</td><td>0.0001366930623599175</td><td>0</td><td>GALAXY</td><td>--</td><td>1</td><td>1129.9557</td><td>36799</td><td>9.397019170224667</td></tr>
-<tr><td>2349807154757633</td><td>7759.752056121826</td><td>0.8914747499370891</td><td>9.489360515236133e-06</td><td>0</td><td>GALAXY</td><td>--</td><td>1</td><td>1032.7631</td><td>25810</td><td>1990.393577575684</td></tr>
-<tr><td>2349810006884353</td><td>7813.356772936881</td><td>0.5897161345295494</td><td>8.995718391886062e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>1</td><td>1453.8173</td><td>17937</td><td>11.0996535718441</td></tr>
-<tr><td>2349810040438785</td><td>7739.014853719622</td><td>0.526467324140909</td><td>0.0001221272443611522</td><td>0</td><td>GALAXY</td><td>--</td><td>1</td><td>1121.3942</td><td>17599</td><td>12.56454463675618</td></tr>
-<tr><td>2349810086576128</td><td>9086.101851679385</td><td>0.5865114083692732</td><td>0.0001223150017235855</td><td>0</td><td>GALAXY</td><td>--</td><td>2</td><td>2988.0767</td><td>17635</td><td>523.5175925977528</td></tr>
-<tr><td>2349810359205889</td><td>7593.425254285336</td><td>0.7735598685660158</td><td>8.465901340157139e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>1</td><td>1171.4036</td><td>17683</td><td>73.9402380771935</td></tr>
-<tr><td>2349812292780033</td><td>9227.264025635086</td><td>0.7168970122818812</td><td>0.0002657236839550565</td><td>0</td><td>GALAXY</td><td>--</td><td>3</td><td>4244.771</td><td>26815</td><td>28.39506733883172</td></tr>
-<tr><td>2349816101208064</td><td>7941.910046570003</td><td>0.7993679938346777</td><td>0.0001038058256018967</td><td>0</td><td>GALAXY</td><td>--</td><td>1</td><td>1117.1798</td><td>17635</td><td>103.0777635909617</td></tr>
-</table></div>
 </div>
 </div>
 </div>
@@ -8613,16 +8306,10 @@ sparcl==1.2.7
 <div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
 </div>
 <div class="jp-InputArea jp-Cell-inputArea">
-<div class="jp-InputPrompt jp-InputArea-prompt">In [24]:</div>
+<div class="jp-InputPrompt jp-InputArea-prompt">In [ ]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
 <div class="cm-editor cm-s-jupyter">
-<div class="highlight hl-ipython3"><pre><span></span><span class="n">model_flux</span> <span class="o">=</span> <span class="n">np</span><span class="o">.</span><span class="n">zeros</span><span class="p">((</span><span class="nb">len</span><span class="p">(</span><span class="n">desi_records</span><span class="p">),</span> <span class="n">desi_records</span><span class="p">[</span><span class="mi">0</span><span class="p">]</span><span class="o">.</span><span class="n">model</span><span class="o">.</span><span class="n">shape</span><span class="p">[</span><span class="mi">0</span><span class="p">]),</span>
-                      <span class="n">dtype</span><span class="o">=</span><span class="n">desi_records</span><span class="p">[</span><span class="mi">0</span><span class="p">]</span><span class="o">.</span><span class="n">model</span><span class="o">.</span><span class="n">dtype</span><span class="p">)</span>
-
-<span class="k">for</span> <span class="n">k</span> <span class="ow">in</span> <span class="nb">range</span><span class="p">(</span><span class="nb">len</span><span class="p">(</span><span class="n">desi_records</span><span class="p">)):</span>
-        <span class="n">model_flux</span><span class="p">[</span><span class="n">k</span><span class="p">,</span> <span class="p">:]</span> <span class="o">=</span> <span class="n">desi_records</span><span class="p">[</span><span class="n">k</span><span class="p">]</span><span class="o">.</span><span class="n">model</span>
-
-<span class="n">desi_model</span> <span class="o">=</span> <span class="p">(</span><span class="n">desi_records</span><span class="p">[</span><span class="mi">0</span><span class="p">]</span><span class="o">.</span><span class="n">wavelength</span><span class="p">,</span> <span class="n">model_flux</span><span class="p">[</span><span class="o">~</span><span class="n">desi_fully_masked</span><span class="p">,</span> <span class="p">:])</span>
+<div class="highlight hl-ipython3"><pre><span></span><span class="n">desi_model</span> <span class="o">=</span> <span class="p">(</span><span class="n">desi_specutils</span><span class="o">.</span><span class="n">spectral_axis</span><span class="p">,</span> <span class="n">desi_specutils</span><span class="o">.</span><span class="n">meta</span><span class="p">[</span><span class="s1">'model'</span><span class="p">][</span><span class="o">~</span><span class="n">desi_fully_masked</span><span class="p">,</span> <span class="p">:])</span>
 </pre></div>
 </div>
 </div>
@@ -8695,43 +8382,18 @@ sparcl==1.2.7
 </div>
 </div>
 </div>
-</div><div class="jp-Cell jp-CodeCell jp-Notebook-cell">
+</div><div class="jp-Cell jp-CodeCell jp-Notebook-cell jp-mod-noOutputs">
 <div class="jp-Cell-inputWrapper" tabindex="0">
 <div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
 </div>
 <div class="jp-InputArea jp-Cell-inputArea">
-<div class="jp-InputPrompt jp-InputArea-prompt">In [26]:</div>
+<div class="jp-InputPrompt jp-InputArea-prompt">In [ ]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
 <div class="cm-editor cm-s-jupyter">
 <div class="highlight hl-ipython3"><pre><span></span><span class="n">specprod</span> <span class="o">=</span> <span class="s1">'iron'</span>
 <span class="n">template_dir</span> <span class="o">=</span> <span class="n">get_template_dir</span><span class="p">()</span>
 <span class="n">templates</span> <span class="o">=</span> <span class="n">load_templates</span><span class="p">(</span><span class="sa">f</span><span class="s1">'</span><span class="si">{</span><span class="n">template_dir</span><span class="si">}</span><span class="s1">/templates-</span><span class="si">{</span><span class="n">specprod</span><span class="si">}</span><span class="s1">.txt'</span><span class="p">,</span> <span class="n">asdict</span><span class="o">=</span><span class="kc">True</span><span class="p">)</span>
 </pre></div>
-</div>
-</div>
-</div>
-</div>
-<div class="jp-Cell-outputWrapper">
-<div class="jp-Collapser jp-OutputCollapser jp-Cell-outputCollapser">
-</div>
-<div class="jp-OutputArea jp-Cell-outputArea">
-<div class="jp-OutputArea-child">
-<div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
-<div class="jp-RenderedText jp-OutputArea-output" data-mime-type="text/plain" tabindex="0">
-<pre>DEBUG: Reading templates from /data0/sw/desi/code/redrock-templates/0.9.1/templates-iron.txt
-Reading templates from ['/data0/sw/desi/code/redrock-templates/0.9.1/rrtemplate-GALAXY-None-v2.6.fits', '/data0/sw/desi/code/redrock-templates/0.9.1/rrtemplate-QSO-LOZ-v1.0.fits', '/data0/sw/desi/code/redrock-templates/0.9.1/rrtemplate-QSO-HIZ-v1.0.fits', '/data0/sw/desi/code/redrock-templates/0.9.1/rrtemplate-STAR-A-v0.1.fits', '/data0/sw/desi/code/redrock-templates/0.9.1/rrtemplate-STAR-B-v0.1.fits', '/data0/sw/desi/code/redrock-templates/0.9.1/rrtemplate-STAR-CV-v0.1.fits', '/data0/sw/desi/code/redrock-templates/0.9.1/rrtemplate-STAR-F-v0.1.fits', '/data0/sw/desi/code/redrock-templates/0.9.1/rrtemplate-STAR-G-v0.1.fits', '/data0/sw/desi/code/redrock-templates/0.9.1/rrtemplate-STAR-K-v0.1.fits', '/data0/sw/desi/code/redrock-templates/0.9.1/rrtemplate-STAR-M-v0.1.fits', '/data0/sw/desi/code/redrock-templates/0.9.1/rrtemplate-STAR-WD-v0.1.fits']
-INFO: rrtemplate-GALAXY-None-v2.6.fits GALAXY  PCA IGM=Calura12 z=-0.005-1.6997
-INFO: rrtemplate-QSO-LOZ-v1.0.fits QSO LOZ PCA IGM=Calura12 z=0.05-1.5983
-INFO: rrtemplate-QSO-HIZ-v1.0.fits QSO HIZ PCA IGM=Calura12 z=1.4-6.993
-INFO: rrtemplate-STAR-A-v0.1.fits STAR A PCA IGM=None z=-0.002-0.002
-INFO: rrtemplate-STAR-B-v0.1.fits STAR B PCA IGM=None z=-0.002-0.002
-INFO: rrtemplate-STAR-CV-v0.1.fits STAR CV PCA IGM=None z=-0.002-0.002
-INFO: rrtemplate-STAR-F-v0.1.fits STAR F PCA IGM=None z=-0.002-0.002
-INFO: rrtemplate-STAR-G-v0.1.fits STAR G PCA IGM=None z=-0.002-0.002
-INFO: rrtemplate-STAR-K-v0.1.fits STAR K PCA IGM=None z=-0.002-0.002
-INFO: rrtemplate-STAR-M-v0.1.fits STAR M PCA IGM=None z=-0.002-0.002
-INFO: rrtemplate-STAR-WD-v0.1.fits STAR WD PCA IGM=None z=-0.002-0.002
-</pre>
 </div>
 </div>
 </div>
@@ -8747,12 +8409,12 @@ INFO: rrtemplate-STAR-WD-v0.1.fits STAR WD PCA IGM=None z=-0.002-0.002
 </div>
 </div>
 </div>
-</div><div class="jp-Cell jp-CodeCell jp-Notebook-cell">
+</div><div class="jp-Cell jp-CodeCell jp-Notebook-cell jp-mod-noOutputs">
 <div class="jp-Cell-inputWrapper" tabindex="0">
 <div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
 </div>
 <div class="jp-InputArea jp-Cell-inputArea">
-<div class="jp-InputPrompt jp-InputArea-prompt">In [27]:</div>
+<div class="jp-InputPrompt jp-InputArea-prompt">In [ ]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
 <div class="cm-editor cm-s-jupyter">
 <div class="highlight hl-ipython3"><pre><span></span><span class="n">q</span> <span class="o">=</span> <span class="s2">"""</span>
@@ -8776,43 +8438,6 @@ INFO: rrtemplate-STAR-WD-v0.1.fits STAR WD PCA IGM=None z=-0.002-0.002
 </div>
 </div>
 </div>
-<div class="jp-Cell-outputWrapper">
-<div class="jp-Collapser jp-OutputCollapser jp-Cell-outputCollapser">
-</div>
-<div class="jp-OutputArea jp-Cell-outputArea">
-<div class="jp-OutputArea-child jp-OutputArea-executeResult">
-<div class="jp-OutputPrompt jp-OutputArea-prompt">Out[27]:</div>
-<div class="jp-RenderedHTMLCommon jp-RenderedHTML jp-OutputArea-output jp-OutputArea-executeResult" data-mime-type="text/html" tabindex="0">
-<div><i>Table length=50</i>
-<table class="table-striped table-bordered table-condensed" id="table140046316383504">
-<thead><tr><th>targetid</th><th>chi2</th><th>z</th><th>zerr</th><th>zwarn</th><th>spectype</th><th>subtype</th><th>coadd_numexp</th><th>coadd_exptime</th><th>healpix</th><th>deltachi2</th></tr></thead>
-<thead><tr><th>int64</th><th>float64</th><th>float64</th><th>float64</th><th>int64</th><th>str3</th><th>str3</th><th>int64</th><th>float64</th><th>int64</th><th>float64</th></tr></thead>
-<tr><td>2323666519982080</td><td>7940.44324403163</td><td>1.01858912554479</td><td>0.0005063431152249177</td><td>0</td><td>QSO</td><td>LOZ</td><td>1</td><td>1087.1151</td><td>26067</td><td>263.9076617443934</td></tr>
-<tr><td>39627878932942560</td><td>8335.446058448404</td><td>2.084154835064079</td><td>0.0004919943903500216</td><td>0</td><td>QSO</td><td>HIZ</td><td>1</td><td>985.1372</td><td>26067</td><td>501.6483456520364</td></tr>
-<tr><td>39627878932942604</td><td>10689.24974483252</td><td>3.339810398350544</td><td>0.0001490083348571413</td><td>0</td><td>QSO</td><td>HIZ</td><td>4</td><td>4641.9043</td><td>26067</td><td>5881.092526368797</td></tr>
-<tr><td>39627878932942685</td><td>20918.29606822133</td><td>3.188253891582343</td><td>0.0002155015216669195</td><td>0</td><td>QSO</td><td>HIZ</td><td>4</td><td>4553.441</td><td>26067</td><td>5321.518189035356</td></tr>
-<tr><td>39627878932943381</td><td>8048.144335032906</td><td>1.553018226863044</td><td>0.0009553295219897059</td><td>0</td><td>QSO</td><td>LOZ</td><td>1</td><td>1588.0327</td><td>26067</td><td>123.9187949164771</td></tr>
-<tr><td>39627878932943432</td><td>9122.350275153294</td><td>1.904317327483292</td><td>0.0005995273278721958</td><td>0</td><td>QSO</td><td>HIZ</td><td>2</td><td>2521.5537</td><td>26067</td><td>2872.772595795803</td></tr>
-<tr><td>39627878932943978</td><td>7987.874932071194</td><td>1.364028348046452</td><td>0.0004469391317056302</td><td>0</td><td>QSO</td><td>LOZ</td><td>1</td><td>1588.0327</td><td>26067</td><td>460.0579781077759</td></tr>
-<tr><td>39627878932944212</td><td>8004.350115722045</td><td>2.073681407390898</td><td>0.0008730420754907552</td><td>0</td><td>QSO</td><td>HIZ</td><td>1</td><td>776.1867</td><td>26067</td><td>635.2639014068991</td></tr>
-<tr><td>39627878932944261</td><td>28702.7694542408</td><td>2.192523223619755</td><td>4.743985838549377e-05</td><td>0</td><td>QSO</td><td>HIZ</td><td>3</td><td>2940.6423</td><td>26067</td><td>61997.69142409414</td></tr>
-<tr><td>39627878937133282</td><td>7914.727749031503</td><td>1.265982016374455</td><td>0.0007305455225758035</td><td>0</td><td>QSO</td><td>LOZ</td><td>1</td><td>1588.0327</td><td>26067</td><td>54.72999359993264</td></tr>
-<tr><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td></tr>
-<tr><td>39627884964351430</td><td>7880.307208256796</td><td>1.530018797438126</td><td>0.0007701658089210037</td><td>0</td><td>QSO</td><td>LOZ</td><td>1</td><td>1588.0327</td><td>26067</td><td>51.04182653650059</td></tr>
-<tr><td>39627884964351840</td><td>12109.0949293226</td><td>1.724605914607025</td><td>0.0002530880648034863</td><td>0</td><td>QSO</td><td>HIZ</td><td>1</td><td>1046.75</td><td>26067</td><td>14113.81066407263</td></tr>
-<tr><td>39627884964352646</td><td>11419.19160956144</td><td>2.530359882740409</td><td>0.0001210345134363178</td><td>0</td><td>QSO</td><td>HIZ</td><td>4</td><td>4237.8677</td><td>26067</td><td>6898.001569449902</td></tr>
-<tr><td>39627884964352701</td><td>8454.852106619626</td><td>1.993434120662715</td><td>0.0006816445401734544</td><td>0</td><td>QSO</td><td>HIZ</td><td>1</td><td>985.1372</td><td>26067</td><td>1232.56845942419</td></tr>
-<tr><td>39627884968542328</td><td>7950.021198839881</td><td>1.090441838720727</td><td>0.0004893229583096889</td><td>0</td><td>QSO</td><td>LOZ</td><td>2</td><td>2031.8872</td><td>26067</td><td>43.9582922863774</td></tr>
-<tr><td>39627884968542943</td><td>7862.406741758808</td><td>1.369502480002289</td><td>0.0008113573399067251</td><td>0</td><td>QSO</td><td>LOZ</td><td>1</td><td>985.1372</td><td>26067</td><td>17.37617605691776</td></tr>
-<tr><td>39627884968544053</td><td>7930.376330034807</td><td>1.086379223516902</td><td>0.0003497958478828536</td><td>0</td><td>QSO</td><td>LOZ</td><td>1</td><td>1046.75</td><td>26067</td><td>90.67648637853563</td></tr>
-<tr><td>39627884968544592</td><td>8810.533645922318</td><td>1.345892246473962</td><td>0.0004434832754342202</td><td>0</td><td>QSO</td><td>LOZ</td><td>1</td><td>985.1372</td><td>26067</td><td>2182.636438595131</td></tr>
-<tr><td>39627884968544665</td><td>8459.563079636544</td><td>2.466465377286688</td><td>0.0007200640119503051</td><td>0</td><td>QSO</td><td>HIZ</td><td>5</td><td>5171.3887</td><td>26067</td><td>1353.180157978088</td></tr>
-<tr><td>39627884968546458</td><td>7807.179519087076</td><td>2.475831244048027</td><td>0.0006337414625701554</td><td>0</td><td>QSO</td><td>HIZ</td><td>5</td><td>5146.6226</td><td>26067</td><td>359.9049236541614</td></tr>
-</table></div>
-</div>
-</div>
-</div>
-</div>
 </div>
 <div class="jp-Cell jp-MarkdownCell jp-Notebook-cell">
 <div class="jp-Cell-inputWrapper" tabindex="0">
@@ -8824,12 +8449,12 @@ INFO: rrtemplate-STAR-WD-v0.1.fits STAR WD PCA IGM=None z=-0.002-0.002
 </div>
 </div>
 </div>
-</div><div class="jp-Cell jp-CodeCell jp-Notebook-cell">
+</div><div class="jp-Cell jp-CodeCell jp-Notebook-cell jp-mod-noOutputs">
 <div class="jp-Cell-inputWrapper" tabindex="0">
 <div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
 </div>
 <div class="jp-InputArea jp-Cell-inputArea">
-<div class="jp-InputPrompt jp-InputArea-prompt">In [28]:</div>
+<div class="jp-InputPrompt jp-InputArea-prompt">In [ ]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
 <div class="cm-editor cm-s-jupyter">
 <div class="highlight hl-ipython3"><pre><span></span><span class="n">overwrite</span> <span class="o">=</span> <span class="kc">False</span>
@@ -8844,19 +8469,6 @@ INFO: rrtemplate-STAR-WD-v0.1.fits STAR WD PCA IGM=None z=-0.002-0.002
     <span class="n">redrock_url</span> <span class="o">=</span> <span class="n">redrock_path</span><span class="o">.</span><span class="n">replace</span><span class="p">(</span><span class="n">specprod_root</span><span class="p">,</span> <span class="sa">f</span><span class="s1">'https://data.desi.lbl.gov/public/dr1/spectro/redux/</span><span class="si">{</span><span class="n">specprod</span><span class="si">}</span><span class="s1">'</span><span class="p">)</span>
     <span class="n">result</span> <span class="o">=</span> <span class="n">sc</span><span class="o">.</span><span class="n">load</span><span class="p">(</span><span class="sa">f</span><span class="s2">"vos://</span><span class="si">{</span><span class="n">redrock_file</span><span class="si">}</span><span class="s2">"</span><span class="p">,</span> <span class="n">redrock_url</span><span class="p">)</span>
 </pre></div>
-</div>
-</div>
-</div>
-</div>
-<div class="jp-Cell-outputWrapper">
-<div class="jp-Collapser jp-OutputCollapser jp-Cell-outputCollapser">
-</div>
-<div class="jp-OutputArea jp-Cell-outputArea">
-<div class="jp-OutputArea-child">
-<div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
-<div class="jp-RenderedText jp-OutputArea-output" data-mime-type="text/plain" tabindex="0">
-<pre>INFO: redrock-main-dark-26067.fits has already been downloaded.
-</pre>
 </div>
 </div>
 </div>
@@ -8877,7 +8489,7 @@ INFO: rrtemplate-STAR-WD-v0.1.fits STAR WD PCA IGM=None z=-0.002-0.002
 <div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
 </div>
 <div class="jp-InputArea jp-Cell-inputArea">
-<div class="jp-InputPrompt jp-InputArea-prompt">In [29]:</div>
+<div class="jp-InputPrompt jp-InputArea-prompt">In [ ]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
 <div class="cm-editor cm-s-jupyter">
 <div class="highlight hl-ipython3"><pre><span></span><span class="k">with</span> <span class="n">fits</span><span class="o">.</span><span class="n">open</span><span class="p">(</span><span class="n">sc</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="sa">f</span><span class="s2">"vos://</span><span class="si">{</span><span class="n">redrock_file</span><span class="si">}</span><span class="s2">"</span><span class="p">,</span> <span class="n">mode</span><span class="o">=</span><span class="s1">'fileobj'</span><span class="p">),</span> <span class="n">mode</span><span class="o">=</span><span class="s1">'readonly'</span><span class="p">)</span> <span class="k">as</span> <span class="n">hdulist</span><span class="p">:</span>
@@ -8889,12 +8501,12 @@ INFO: rrtemplate-STAR-WD-v0.1.fits STAR WD PCA IGM=None z=-0.002-0.002
 </div>
 </div>
 </div>
-</div><div class="jp-Cell jp-CodeCell jp-Notebook-cell">
+</div><div class="jp-Cell jp-CodeCell jp-Notebook-cell jp-mod-noOutputs">
 <div class="jp-Cell-inputWrapper" tabindex="0">
 <div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
 </div>
 <div class="jp-InputArea jp-Cell-inputArea">
-<div class="jp-InputPrompt jp-InputArea-prompt">In [30]:</div>
+<div class="jp-InputPrompt jp-InputArea-prompt">In [ ]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
 <div class="cm-editor cm-s-jupyter">
 <div class="highlight hl-ipython3"><pre><span></span><span class="n">w</span> <span class="o">=</span> <span class="n">np</span><span class="o">.</span><span class="n">isin</span><span class="p">(</span><span class="n">redrock_table</span><span class="p">[</span><span class="s1">'TARGETID'</span><span class="p">],</span> <span class="n">desi_qso_ids</span><span class="p">[</span><span class="s1">'targetid'</span><span class="p">])</span>
@@ -8903,43 +8515,6 @@ INFO: rrtemplate-STAR-WD-v0.1.fits STAR WD PCA IGM=None z=-0.002-0.002
 <span class="n">desi_qso_ids</span><span class="p">[</span><span class="s1">'coeff'</span><span class="p">]</span> <span class="o">=</span> <span class="n">redrock_table</span><span class="p">[</span><span class="s1">'COEFF'</span><span class="p">][</span><span class="n">w</span><span class="p">,</span> <span class="p">:]</span>
 <span class="n">desi_qso_ids</span>
 </pre></div>
-</div>
-</div>
-</div>
-</div>
-<div class="jp-Cell-outputWrapper">
-<div class="jp-Collapser jp-OutputCollapser jp-Cell-outputCollapser">
-</div>
-<div class="jp-OutputArea jp-Cell-outputArea">
-<div class="jp-OutputArea-child jp-OutputArea-executeResult">
-<div class="jp-OutputPrompt jp-OutputArea-prompt">Out[30]:</div>
-<div class="jp-RenderedHTMLCommon jp-RenderedHTML jp-OutputArea-output jp-OutputArea-executeResult" data-mime-type="text/html" tabindex="0">
-<div><i>Table length=50</i>
-<table class="table-striped table-bordered table-condensed" id="table140046316383504">
-<thead><tr><th>targetid</th><th>chi2</th><th>z</th><th>zerr</th><th>zwarn</th><th>spectype</th><th>subtype</th><th>coadd_numexp</th><th>coadd_exptime</th><th>healpix</th><th>deltachi2</th><th>coeff</th></tr></thead>
-<thead><tr><th>int64</th><th>float64</th><th>float64</th><th>float64</th><th>int64</th><th>str3</th><th>str3</th><th>int64</th><th>float64</th><th>int64</th><th>float64</th><th>float64[10]</th></tr></thead>
-<tr><td>2323666519982080</td><td>7940.44324403163</td><td>1.01858912554479</td><td>0.0005063431152249177</td><td>0</td><td>QSO</td><td>LOZ</td><td>1</td><td>1087.1151</td><td>26067</td><td>263.9076617443934</td><td>0.46278203127056666 .. 0.0</td></tr>
-<tr><td>39627878932942560</td><td>8335.446058448404</td><td>2.084154835064079</td><td>0.0004919943903500216</td><td>0</td><td>QSO</td><td>HIZ</td><td>1</td><td>985.1372</td><td>26067</td><td>501.6483456520364</td><td>0.46900606150188273 .. 0.0</td></tr>
-<tr><td>39627878932942604</td><td>10689.24974483252</td><td>3.339810398350544</td><td>0.0001490083348571413</td><td>0</td><td>QSO</td><td>HIZ</td><td>4</td><td>4641.9043</td><td>26067</td><td>5881.092526368797</td><td>0.3487386921332749 .. 0.0</td></tr>
-<tr><td>39627878932942685</td><td>20918.29606822133</td><td>3.188253891582343</td><td>0.0002155015216669195</td><td>0</td><td>QSO</td><td>HIZ</td><td>4</td><td>4553.441</td><td>26067</td><td>5321.518189035356</td><td>0.7089294177913054 .. 0.0</td></tr>
-<tr><td>39627878932943381</td><td>8048.144335032906</td><td>1.553018226863044</td><td>0.0009553295219897059</td><td>0</td><td>QSO</td><td>LOZ</td><td>1</td><td>1588.0327</td><td>26067</td><td>123.9187949164771</td><td>0.5111103511178886 .. 0.0</td></tr>
-<tr><td>39627878932943432</td><td>9122.350275153294</td><td>1.904317327483292</td><td>0.0005995273278721958</td><td>0</td><td>QSO</td><td>HIZ</td><td>2</td><td>2521.5537</td><td>26067</td><td>2872.772595795803</td><td>1.6841626276509625 .. 0.0</td></tr>
-<tr><td>39627878932943978</td><td>7987.874932071194</td><td>1.364028348046452</td><td>0.0004469391317056302</td><td>0</td><td>QSO</td><td>LOZ</td><td>1</td><td>1588.0327</td><td>26067</td><td>460.0579781077759</td><td>0.8564574006318391 .. 0.0</td></tr>
-<tr><td>39627878932944212</td><td>8004.350115722045</td><td>2.073681407390898</td><td>0.0008730420754907552</td><td>0</td><td>QSO</td><td>HIZ</td><td>1</td><td>776.1867</td><td>26067</td><td>635.2639014068991</td><td>0.7120721064231844 .. 0.0</td></tr>
-<tr><td>39627878932944261</td><td>28702.7694542408</td><td>2.192523223619755</td><td>4.743985838549377e-05</td><td>0</td><td>QSO</td><td>HIZ</td><td>3</td><td>2940.6423</td><td>26067</td><td>61997.69142409414</td><td>4.527475756944605 .. 0.0</td></tr>
-<tr><td>39627878937133282</td><td>7914.727749031503</td><td>1.265982016374455</td><td>0.0007305455225758035</td><td>0</td><td>QSO</td><td>LOZ</td><td>1</td><td>1588.0327</td><td>26067</td><td>54.72999359993264</td><td>0.4284378761846193 .. 0.0</td></tr>
-<tr><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td></tr>
-<tr><td>39627884964351430</td><td>7880.307208256796</td><td>1.530018797438126</td><td>0.0007701658089210037</td><td>0</td><td>QSO</td><td>LOZ</td><td>1</td><td>1588.0327</td><td>26067</td><td>51.04182653650059</td><td>0.25267447913834246 .. 0.0</td></tr>
-<tr><td>39627884964351840</td><td>12109.0949293226</td><td>1.724605914607025</td><td>0.0002530880648034863</td><td>0</td><td>QSO</td><td>HIZ</td><td>1</td><td>1046.75</td><td>26067</td><td>14113.81066407263</td><td>9.99656282009574 .. 0.0</td></tr>
-<tr><td>39627884964352646</td><td>11419.19160956144</td><td>2.530359882740409</td><td>0.0001210345134363178</td><td>0</td><td>QSO</td><td>HIZ</td><td>4</td><td>4237.8677</td><td>26067</td><td>6898.001569449902</td><td>0.9364761348951793 .. 0.0</td></tr>
-<tr><td>39627884964352701</td><td>8454.852106619626</td><td>1.993434120662715</td><td>0.0006816445401734544</td><td>0</td><td>QSO</td><td>HIZ</td><td>1</td><td>985.1372</td><td>26067</td><td>1232.56845942419</td><td>1.0533242226365125 .. 0.0</td></tr>
-<tr><td>39627884968542328</td><td>7950.021198839881</td><td>1.090441838720727</td><td>0.0004893229583096889</td><td>0</td><td>QSO</td><td>LOZ</td><td>2</td><td>2031.8872</td><td>26067</td><td>43.9582922863774</td><td>0.4091075354768971 .. 0.0</td></tr>
-<tr><td>39627884968542943</td><td>7862.406741758808</td><td>1.369502480002289</td><td>0.0008113573399067251</td><td>0</td><td>QSO</td><td>LOZ</td><td>1</td><td>985.1372</td><td>26067</td><td>17.37617605691776</td><td>0.2571714739209084 .. 0.0</td></tr>
-<tr><td>39627884968544053</td><td>7930.376330034807</td><td>1.086379223516902</td><td>0.0003497958478828536</td><td>0</td><td>QSO</td><td>LOZ</td><td>1</td><td>1046.75</td><td>26067</td><td>90.67648637853563</td><td>0.2996873131543996 .. 0.0</td></tr>
-<tr><td>39627884968544592</td><td>8810.533645922318</td><td>1.345892246473962</td><td>0.0004434832754342202</td><td>0</td><td>QSO</td><td>LOZ</td><td>1</td><td>985.1372</td><td>26067</td><td>2182.636438595131</td><td>1.5846460956680948 .. 0.0</td></tr>
-<tr><td>39627884968544665</td><td>8459.563079636544</td><td>2.466465377286688</td><td>0.0007200640119503051</td><td>0</td><td>QSO</td><td>HIZ</td><td>5</td><td>5171.3887</td><td>26067</td><td>1353.180157978088</td><td>0.26766853805066454 .. 0.0</td></tr>
-<tr><td>39627884968546458</td><td>7807.179519087076</td><td>2.475831244048027</td><td>0.0006337414625701554</td><td>0</td><td>QSO</td><td>HIZ</td><td>5</td><td>5146.6226</td><td>26067</td><td>359.9049236541614</td><td>0.11142200735206872 .. 0.0</td></tr>
-</table></div>
 </div>
 </div>
 </div>
@@ -8955,12 +8530,12 @@ INFO: rrtemplate-STAR-WD-v0.1.fits STAR WD PCA IGM=None z=-0.002-0.002
 </div>
 </div>
 </div>
-</div><div class="jp-Cell jp-CodeCell jp-Notebook-cell">
+</div><div class="jp-Cell jp-CodeCell jp-Notebook-cell jp-mod-noOutputs">
 <div class="jp-Cell-inputWrapper" tabindex="0">
 <div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
 </div>
 <div class="jp-InputArea jp-Cell-inputArea">
-<div class="jp-InputPrompt jp-InputArea-prompt">In [31]:</div>
+<div class="jp-InputPrompt jp-InputArea-prompt">In [ ]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
 <div class="cm-editor cm-s-jupyter">
 <div class="highlight hl-ipython3"><pre><span></span><span class="n">include</span> <span class="o">=</span> <span class="n">client</span><span class="o">.</span><span class="n">get_all_fields</span><span class="p">(</span><span class="n">dataset_list</span><span class="o">=</span><span class="p">[</span><span class="s1">'DESI-DR1'</span><span class="p">])</span>
@@ -8969,20 +8544,6 @@ INFO: rrtemplate-STAR-WD-v0.1.fits STAR WD PCA IGM=None z=-0.002-0.002
                                              <span class="n">dataset_list</span><span class="o">=</span><span class="p">[</span><span class="s1">'DESI-DR1'</span><span class="p">])</span>
 <span class="n">desi_qso_spectra</span><span class="o">.</span><span class="n">info</span>
 </pre></div>
-</div>
-</div>
-</div>
-</div>
-<div class="jp-Cell-outputWrapper">
-<div class="jp-Collapser jp-OutputCollapser jp-Cell-outputCollapser">
-</div>
-<div class="jp-OutputArea jp-Cell-outputArea">
-<div class="jp-OutputArea-child jp-OutputArea-executeResult">
-<div class="jp-OutputPrompt jp-OutputArea-prompt">Out[31]:</div>
-<div class="jp-RenderedText jp-OutputArea-output jp-OutputArea-executeResult" data-mime-type="text/plain" tabindex="0">
-<pre>{'status': {'success': True,
-  'info': ["Successfully found 51 records in dr_list=['DESI-DR1']"],
-  'warnings': []}}</pre>
 </div>
 </div>
 </div>
@@ -9003,11 +8564,11 @@ INFO: rrtemplate-STAR-WD-v0.1.fits STAR WD PCA IGM=None z=-0.002-0.002
 <div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
 </div>
 <div class="jp-InputArea jp-Cell-inputArea">
-<div class="jp-InputPrompt jp-InputArea-prompt">In [32]:</div>
+<div class="jp-InputPrompt jp-InputArea-prompt">In [ ]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
 <div class="cm-editor cm-s-jupyter">
-<div class="highlight hl-ipython3"><pre><span></span><span class="n">desi_qso_records</span> <span class="o">=</span> <span class="nb">sorted</span><span class="p">([</span><span class="n">r</span> <span class="k">for</span> <span class="n">r</span> <span class="ow">in</span> <span class="n">desi_qso_spectra</span><span class="o">.</span><span class="n">records</span> <span class="k">if</span> <span class="n">r</span><span class="o">.</span><span class="n">survey</span> <span class="o">==</span> <span class="s1">'main'</span> <span class="ow">and</span> <span class="n">r</span><span class="o">.</span><span class="n">program</span> <span class="o">==</span> <span class="s1">'dark'</span><span class="p">],</span> <span class="n">key</span><span class="o">=</span><span class="k">lambda</span> <span class="n">x</span><span class="p">:</span> <span class="n">x</span><span class="o">.</span><span class="n">targetid</span><span class="p">)</span>
-<span class="k">assert</span> <span class="p">(</span><span class="n">np</span><span class="o">.</span><span class="n">array</span><span class="p">([</span><span class="n">r</span><span class="o">.</span><span class="n">targetid</span> <span class="k">for</span> <span class="n">r</span> <span class="ow">in</span> <span class="n">desi_qso_records</span><span class="p">])</span> <span class="o">==</span> <span class="n">desi_qso_ids</span><span class="p">[</span><span class="s1">'targetid'</span><span class="p">])</span><span class="o">.</span><span class="n">all</span><span class="p">()</span>
+<div class="highlight hl-ipython3"><pre><span></span><span class="n">desi_qso_spectra</span> <span class="o">=</span> <span class="n">desi_qso_spectra</span><span class="o">.</span><span class="n">reorder</span><span class="p">(</span><span class="n">desi_qso_ids</span><span class="p">[</span><span class="s1">'targetid'</span><span class="p">]</span><span class="o">.</span><span class="n">value</span><span class="o">.</span><span class="n">tolist</span><span class="p">())</span>
+<span class="k">assert</span> <span class="p">(</span><span class="n">np</span><span class="o">.</span><span class="n">array</span><span class="p">([</span><span class="n">r</span><span class="o">.</span><span class="n">targetid</span> <span class="k">for</span> <span class="n">r</span> <span class="ow">in</span> <span class="n">desi_qso_spectra</span><span class="o">.</span><span class="n">records</span> <span class="k">if</span> <span class="n">r</span><span class="o">.</span><span class="n">survey</span> <span class="o">==</span> <span class="s1">'main'</span> <span class="ow">and</span> <span class="n">r</span><span class="o">.</span><span class="n">program</span> <span class="o">==</span> <span class="s1">'dark'</span><span class="p">])</span> <span class="o">==</span> <span class="n">desi_qso_ids</span><span class="p">[</span><span class="s1">'targetid'</span><span class="p">])</span><span class="o">.</span><span class="n">all</span><span class="p">()</span>
 </pre></div>
 </div>
 </div>
@@ -9018,17 +8579,10 @@ INFO: rrtemplate-STAR-WD-v0.1.fits STAR WD PCA IGM=None z=-0.002-0.002
 <div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
 </div>
 <div class="jp-InputArea jp-Cell-inputArea">
-<div class="jp-InputPrompt jp-InputArea-prompt">In [33]:</div>
+<div class="jp-InputPrompt jp-InputArea-prompt">In [ ]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
 <div class="cm-editor cm-s-jupyter">
-<div class="highlight hl-ipython3"><pre><span></span><span class="n">qso_flux</span> <span class="o">=</span> <span class="n">np</span><span class="o">.</span><span class="n">zeros</span><span class="p">((</span><span class="nb">len</span><span class="p">(</span><span class="n">desi_qso_records</span><span class="p">),</span> <span class="n">desi_qso_records</span><span class="p">[</span><span class="mi">0</span><span class="p">]</span><span class="o">.</span><span class="n">flux</span><span class="o">.</span><span class="n">shape</span><span class="p">[</span><span class="mi">0</span><span class="p">]),</span>
-                    <span class="n">dtype</span><span class="o">=</span><span class="n">desi_qso_records</span><span class="p">[</span><span class="mi">0</span><span class="p">]</span><span class="o">.</span><span class="n">flux</span><span class="o">.</span><span class="n">dtype</span><span class="p">)</span>
-<span class="n">qso_model_flux</span> <span class="o">=</span> <span class="n">np</span><span class="o">.</span><span class="n">zeros</span><span class="p">((</span><span class="nb">len</span><span class="p">(</span><span class="n">desi_qso_records</span><span class="p">),</span> <span class="n">desi_qso_records</span><span class="p">[</span><span class="mi">0</span><span class="p">]</span><span class="o">.</span><span class="n">flux</span><span class="o">.</span><span class="n">shape</span><span class="p">[</span><span class="mi">0</span><span class="p">]),</span>
-                          <span class="n">dtype</span><span class="o">=</span><span class="n">desi_qso_records</span><span class="p">[</span><span class="mi">0</span><span class="p">]</span><span class="o">.</span><span class="n">model</span><span class="o">.</span><span class="n">dtype</span><span class="p">)</span>
-<span class="n">qso_wavelength</span> <span class="o">=</span> <span class="n">desi_qso_records</span><span class="p">[</span><span class="mi">0</span><span class="p">]</span><span class="o">.</span><span class="n">wavelength</span>
-<span class="k">for</span> <span class="n">k</span> <span class="ow">in</span> <span class="nb">range</span><span class="p">(</span><span class="nb">len</span><span class="p">(</span><span class="n">desi_qso_records</span><span class="p">)):</span>
-    <span class="n">qso_flux</span><span class="p">[</span><span class="n">k</span><span class="p">,</span> <span class="p">:]</span> <span class="o">=</span> <span class="n">desi_qso_records</span><span class="p">[</span><span class="n">k</span><span class="p">]</span><span class="o">.</span><span class="n">flux</span>
-    <span class="n">qso_model_flux</span><span class="p">[</span><span class="n">k</span><span class="p">,</span> <span class="p">:]</span> <span class="o">=</span> <span class="n">desi_qso_records</span><span class="p">[</span><span class="n">k</span><span class="p">]</span><span class="o">.</span><span class="n">model</span>        
+<div class="highlight hl-ipython3"><pre><span></span><span class="n">desi_qso_specutils</span> <span class="o">=</span> <span class="n">desi_qso_spectra</span><span class="o">.</span><span class="n">to_specutils</span><span class="p">()</span>
 </pre></div>
 </div>
 </div>
@@ -9050,19 +8604,19 @@ INFO: rrtemplate-STAR-WD-v0.1.fits STAR WD PCA IGM=None z=-0.002-0.002
 <div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
 </div>
 <div class="jp-InputArea jp-Cell-inputArea">
-<div class="jp-InputPrompt jp-InputArea-prompt">In [34]:</div>
+<div class="jp-InputPrompt jp-InputArea-prompt">In [ ]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
 <div class="cm-editor cm-s-jupyter">
 <div class="highlight hl-ipython3"><pre><span></span><span class="k">assert</span> <span class="p">(</span><span class="n">desi_qso_ids</span><span class="p">[</span><span class="s1">'spectype'</span><span class="p">]</span> <span class="o">==</span> <span class="s1">'QSO'</span><span class="p">)</span><span class="o">.</span><span class="n">all</span><span class="p">()</span>
 <span class="k">assert</span> <span class="p">((</span><span class="n">desi_qso_ids</span><span class="p">[</span><span class="s1">'subtype'</span><span class="p">]</span> <span class="o">==</span> <span class="s1">'HIZ'</span><span class="p">)</span> <span class="o">|</span> <span class="p">(</span><span class="n">desi_qso_ids</span><span class="p">[</span><span class="s1">'subtype'</span><span class="p">]</span> <span class="o">==</span> <span class="s1">'LOZ'</span><span class="p">))</span><span class="o">.</span><span class="n">all</span><span class="p">()</span>
 <span class="n">qso_loz</span> <span class="o">=</span> <span class="n">templates</span><span class="p">[(</span><span class="s1">'QSO'</span><span class="p">,</span> <span class="s1">'LOZ'</span><span class="p">)]</span>
 <span class="n">qso_hiz</span> <span class="o">=</span> <span class="n">templates</span><span class="p">[(</span><span class="s1">'QSO'</span><span class="p">,</span> <span class="s1">'HIZ'</span><span class="p">)]</span>
-<span class="n">tmpl_model_flux</span> <span class="o">=</span> <span class="n">np</span><span class="o">.</span><span class="n">zeros</span><span class="p">((</span><span class="nb">len</span><span class="p">(</span><span class="n">desi_qso_ids</span><span class="p">),</span> <span class="nb">len</span><span class="p">(</span><span class="n">qso_wavelength</span><span class="p">)),</span> <span class="n">dtype</span><span class="o">=</span><span class="n">qso_model_flux</span><span class="o">.</span><span class="n">dtype</span><span class="p">)</span>
+<span class="n">tmpl_model_flux</span> <span class="o">=</span> <span class="n">np</span><span class="o">.</span><span class="n">zeros</span><span class="p">((</span><span class="nb">len</span><span class="p">(</span><span class="n">desi_qso_ids</span><span class="p">),</span> <span class="nb">len</span><span class="p">(</span><span class="n">desi_qso_specutils</span><span class="o">.</span><span class="n">spectral_axis</span><span class="p">)),</span> <span class="n">dtype</span><span class="o">=</span><span class="n">desi_qso_specutils</span><span class="o">.</span><span class="n">meta</span><span class="p">[</span><span class="s1">'model'</span><span class="p">]</span><span class="o">.</span><span class="n">dtype</span><span class="p">)</span>
 <span class="k">for</span> <span class="n">i</span><span class="p">,</span> <span class="n">row</span> <span class="ow">in</span> <span class="nb">enumerate</span><span class="p">(</span><span class="n">desi_qso_ids</span><span class="p">):</span>
     <span class="k">if</span> <span class="n">row</span><span class="p">[</span><span class="s1">'subtype'</span><span class="p">]</span> <span class="o">==</span> <span class="s1">'LOZ'</span><span class="p">:</span>
-        <span class="n">tmpl_model_flux</span><span class="p">[</span><span class="n">i</span><span class="p">,</span> <span class="p">:]</span> <span class="o">=</span> <span class="n">qso_loz</span><span class="o">.</span><span class="n">eval</span><span class="p">(</span><span class="n">row</span><span class="p">[</span><span class="s1">'coeff'</span><span class="p">],</span> <span class="n">qso_wavelength</span><span class="p">,</span> <span class="n">row</span><span class="p">[</span><span class="s1">'z'</span><span class="p">])</span>
+        <span class="n">tmpl_model_flux</span><span class="p">[</span><span class="n">i</span><span class="p">,</span> <span class="p">:]</span> <span class="o">=</span> <span class="n">qso_loz</span><span class="o">.</span><span class="n">eval</span><span class="p">(</span><span class="n">row</span><span class="p">[</span><span class="s1">'coeff'</span><span class="p">],</span> <span class="n">desi_qso_specutils</span><span class="o">.</span><span class="n">spectral_axis</span><span class="p">,</span> <span class="n">row</span><span class="p">[</span><span class="s1">'z'</span><span class="p">])</span>
     <span class="k">else</span><span class="p">:</span>
-        <span class="n">tmpl_model_flux</span><span class="p">[</span><span class="n">i</span><span class="p">,</span> <span class="p">:]</span> <span class="o">=</span> <span class="n">qso_hiz</span><span class="o">.</span><span class="n">eval</span><span class="p">(</span><span class="n">row</span><span class="p">[</span><span class="s1">'coeff'</span><span class="p">],</span> <span class="n">qso_wavelength</span><span class="p">,</span> <span class="n">row</span><span class="p">[</span><span class="s1">'z'</span><span class="p">])</span>
+        <span class="n">tmpl_model_flux</span><span class="p">[</span><span class="n">i</span><span class="p">,</span> <span class="p">:]</span> <span class="o">=</span> <span class="n">qso_hiz</span><span class="o">.</span><span class="n">eval</span><span class="p">(</span><span class="n">row</span><span class="p">[</span><span class="s1">'coeff'</span><span class="p">],</span> <span class="n">desi_qso_specutils</span><span class="o">.</span><span class="n">spectral_axis</span><span class="p">,</span> <span class="n">row</span><span class="p">[</span><span class="s1">'z'</span><span class="p">])</span>
 </pre></div>
 </div>
 </div>
@@ -9079,37 +8633,25 @@ INFO: rrtemplate-STAR-WD-v0.1.fits STAR WD PCA IGM=None z=-0.002-0.002
 </div>
 </div>
 </div>
-</div><div class="jp-Cell jp-CodeCell jp-Notebook-cell">
+</div><div class="jp-Cell jp-CodeCell jp-Notebook-cell jp-mod-noOutputs">
 <div class="jp-Cell-inputWrapper" tabindex="0">
 <div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
 </div>
 <div class="jp-InputArea jp-Cell-inputArea">
-<div class="jp-InputPrompt jp-InputArea-prompt">In [35]:</div>
+<div class="jp-InputPrompt jp-InputArea-prompt">In [ ]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
 <div class="cm-editor cm-s-jupyter">
 <div class="highlight hl-ipython3"><pre><span></span><span class="n">fig</span> <span class="o">=</span> <span class="n">plt</span><span class="o">.</span><span class="n">figure</span><span class="p">(</span><span class="n">figsize</span><span class="o">=</span><span class="p">(</span><span class="mi">16</span><span class="p">,</span> <span class="mi">9</span><span class="p">),</span> <span class="n">dpi</span><span class="o">=</span><span class="mi">100</span><span class="p">)</span>
 <span class="n">ax</span> <span class="o">=</span> <span class="n">fig</span><span class="o">.</span><span class="n">add_subplot</span><span class="p">(</span><span class="mi">111</span><span class="p">)</span>
 <span class="n">spectrum_index</span> <span class="o">=</span> <span class="mi">12</span>  <span class="c1"># Step through spectra here.</span>
-<span class="n">pl0</span> <span class="o">=</span> <span class="n">ax</span><span class="o">.</span><span class="n">plot</span><span class="p">(</span><span class="n">qso_wavelength</span><span class="p">,</span> <span class="n">qso_flux</span><span class="p">[</span><span class="n">spectrum_index</span><span class="p">,</span> <span class="p">:],</span> <span class="s1">'k-'</span><span class="p">,</span> <span class="n">alpha</span><span class="o">=</span><span class="mf">0.3</span><span class="p">,</span> <span class="n">lw</span><span class="o">=</span><span class="mf">0.5</span><span class="p">,</span> <span class="n">label</span><span class="o">=</span><span class="s1">'SPARCL flux'</span><span class="p">)</span>
-<span class="n">pl1</span> <span class="o">=</span> <span class="n">ax</span><span class="o">.</span><span class="n">plot</span><span class="p">(</span><span class="n">qso_wavelength</span><span class="p">,</span> <span class="n">qso_model_flux</span><span class="p">[</span><span class="n">spectrum_index</span><span class="p">,</span> <span class="p">:],</span> <span class="s1">'r-'</span><span class="p">,</span> <span class="n">label</span><span class="o">=</span><span class="s1">'SPARCL model'</span><span class="p">)</span>
-<span class="n">pl2</span> <span class="o">=</span> <span class="n">ax</span><span class="o">.</span><span class="n">plot</span><span class="p">(</span><span class="n">qso_wavelength</span><span class="p">,</span> <span class="n">tmpl_model_flux</span><span class="p">[</span><span class="n">spectrum_index</span><span class="p">,</span> <span class="p">:],</span> <span class="s1">'b-'</span><span class="p">,</span> <span class="n">label</span><span class="o">=</span><span class="s1">'Redrock model'</span><span class="p">)</span>
+<span class="n">pl0</span> <span class="o">=</span> <span class="n">ax</span><span class="o">.</span><span class="n">plot</span><span class="p">(</span><span class="n">desi_qso_specutils</span><span class="o">.</span><span class="n">spectral_axis</span><span class="p">,</span> <span class="n">desi_qso_specutils</span><span class="o">.</span><span class="n">flux</span><span class="p">[</span><span class="n">spectrum_index</span><span class="p">,</span> <span class="p">:],</span> <span class="s1">'k-'</span><span class="p">,</span> <span class="n">alpha</span><span class="o">=</span><span class="mf">0.3</span><span class="p">,</span> <span class="n">lw</span><span class="o">=</span><span class="mf">0.5</span><span class="p">,</span> <span class="n">label</span><span class="o">=</span><span class="s1">'SPARCL flux'</span><span class="p">)</span>
+<span class="n">pl1</span> <span class="o">=</span> <span class="n">ax</span><span class="o">.</span><span class="n">plot</span><span class="p">(</span><span class="n">desi_qso_specutils</span><span class="o">.</span><span class="n">spectral_axis</span><span class="p">,</span> <span class="n">desi_qso_specutils</span><span class="o">.</span><span class="n">meta</span><span class="p">[</span><span class="s1">'model'</span><span class="p">][</span><span class="n">spectrum_index</span><span class="p">,</span> <span class="p">:],</span> <span class="s1">'r-'</span><span class="p">,</span> <span class="n">label</span><span class="o">=</span><span class="s1">'SPARCL model'</span><span class="p">)</span>
+<span class="n">pl2</span> <span class="o">=</span> <span class="n">ax</span><span class="o">.</span><span class="n">plot</span><span class="p">(</span><span class="n">desi_qso_specutils</span><span class="o">.</span><span class="n">spectral_axis</span><span class="p">,</span> <span class="n">tmpl_model_flux</span><span class="p">[</span><span class="n">spectrum_index</span><span class="p">,</span> <span class="p">:],</span> <span class="s1">'b-'</span><span class="p">,</span> <span class="n">label</span><span class="o">=</span><span class="s1">'Redrock model'</span><span class="p">)</span>
 <span class="n">txt</span> <span class="o">=</span> <span class="n">ax</span><span class="o">.</span><span class="n">set_xlabel</span><span class="p">(</span><span class="s1">'Wavelength [Å]'</span><span class="p">)</span>
 <span class="n">txt</span> <span class="o">=</span> <span class="n">ax</span><span class="o">.</span><span class="n">set_ylabel</span><span class="p">(</span><span class="sa">r</span><span class="s1">'Flux [$10^{-17} \mathrm</span><span class="si">{erg}</span><span class="s1"> \, \mathrm</span><span class="si">{cm}</span><span class="s1">^{-2} \mathrm</span><span class="si">{s}</span><span class="s1">^{-1} \mathrm{\AA}^{-1}$]'</span><span class="p">)</span>
 <span class="n">txt</span> <span class="o">=</span> <span class="n">ax</span><span class="o">.</span><span class="n">set_title</span><span class="p">(</span><span class="sa">f</span><span class="s2">"TARGETID=</span><span class="si">{</span><span class="n">desi_qso_ids</span><span class="p">[</span><span class="n">spectrum_index</span><span class="p">][</span><span class="s1">'targetid'</span><span class="p">]</span><span class="si">:</span><span class="s2">d</span><span class="si">}</span><span class="s2">; Z=</span><span class="si">{</span><span class="n">desi_qso_ids</span><span class="p">[</span><span class="n">spectrum_index</span><span class="p">][</span><span class="s1">'z'</span><span class="p">]</span><span class="si">:</span><span class="s2">.3f</span><span class="si">}</span><span class="s2">; SPECTYPE=</span><span class="si">{</span><span class="n">desi_qso_ids</span><span class="p">[</span><span class="n">spectrum_index</span><span class="p">][</span><span class="s1">'spectype'</span><span class="p">]</span><span class="si">}</span><span class="s2">; SUBTYPE=</span><span class="si">{</span><span class="n">desi_qso_ids</span><span class="p">[</span><span class="n">spectrum_index</span><span class="p">][</span><span class="s1">'subtype'</span><span class="p">]</span><span class="si">}</span><span class="s2">"</span><span class="p">)</span>
 <span class="n">l</span> <span class="o">=</span> <span class="n">ax</span><span class="o">.</span><span class="n">legend</span><span class="p">()</span>
 </pre></div>
-</div>
-</div>
-</div>
-</div>
-<div class="jp-Cell-outputWrapper">
-<div class="jp-Collapser jp-OutputCollapser jp-Cell-outputCollapser">
-</div>
-<div class="jp-OutputArea jp-Cell-outputArea">
-<div class="jp-OutputArea-child">
-<div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
-<div class="jp-RenderedImage jp-OutputArea-output" tabindex="0">
-<img alt="No description has been provided for this image" class="" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAABSQAAAMMCAYAAABKQKkcAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjguMywgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/H5lhTAAAACXBIWXMAAA9hAAAPYQGoP6dpAAEAAElEQVR4nOzdd3gU5drH8d+mdzqEEjpIR7rKEbBiwUpXxIJdxIqK7Xg8egB97ShYEFEBGxZ6Uem9907oLT2kl533j7BrlmySzWZLyvdzXXtdycwzz9wzOzu7e+9TTIZhGAIAAAAAAAAAD/DxdgAAAAAAAAAAKg8SkgAAAAAAAAA8hoQkAAAAAAAAAI8hIQkAAAAAAADAY0hIAgAAAAAAAPAYEpIAAAAAAAAAPIaEJAAAAAAAAACPISEJAAAAAAAAwGNISAIAAAAAAADwGBKSAAAAAAAAADyGhCQAlHMmk8mhx9KlS63bfPbZZzKZTOrRo4fD9UZERKh3796aO3duodtER0dr5MiRatmypUJCQhQSEqI2bdroiSee0Pbt223KvvHGG0XGe+bMGfXp08ehY3vjjTckSY0bN1a/fv0KPQ4/Pz9Vr15dXbp00VNPPaXdu3eX/IQX4tSpUxo2bJguueQShYeHq2rVqurevbumTp0qwzAKlP/hhx/UuXNnBQUFqVatWhoxYoRiY2Pt1n327Fk98sgjql+/voKCgtS4cWONGDHCpsyvv/6qwYMHq2nTpgoJCdEll1yi5557TomJiTblli5dWuS5fPvtt23Kb9q0Sf369VNkZKTCwsLUoUMHffzxx8rNzXVrnZKUkpKip59+Wg0aNFBgYKBat26tiRMnFjg/y5cv16233qqoqCgFBQUpMjJSN9xwg1atWmVT7siRI0XG+dBDD9ns+9///rduuOEGVa9eXSaTSd98843d5+fLL79U7969VadOHQUGBqpJkya6//77deTIEbvlLVauXGnd98XP/W+//aa+ffuqXr16CgwMVIMGDTRgwADt3LmzQD3PPPOMOnfurOrVqyskJEStW7fWG2+8oZSUFJtyGzZs0MiRI9W2bVuFhoaqYcOGGjRokPbv319knEX55ptvHHqNFncuinP69Gm99NJLuuqqqxQeHl7gnuaIP//8U1dddZVq1qxpfX1+9913BcqdPXtW999/v2rXrq3g4GB17txZP//8c6nqLImYmBg99dRTatWqlYKDg1W7dm11795dL774os1zet999xW4R3fs2FHvvfeeMjMzreUcudfml5ycrP/85z/q2LGjwsLCFBwcrHbt2unFF1/UqVOnin2953/ceOONqlatms6ePVvgOJOSklS3bl316NFDZrO5QL3+/v5q2rSphg8frsOHD1u3K+51PG7cuFKdf4vs7Gx9/PHH6tatm8LDwxUWFqZu3brpk08+UU5OToHyWVlZ+uijj9SpUydFRESoatWqatu2rR5++GHt3bu3QPldu3Zp2LBhql+/vgIDA1WvXj3dfffd2rVrV6lj37FjhwYMGKBGjRopKChI9evX13XXXadPPvnEppzJZNLIkSPt1vHLL78UeJ1dfM35+fkpKipKQ4YMsXk/bdy4sUPXx7hx42QymfT555/bjeGxxx6Tv7+/tm3bZrfe2rVr68orr9Rvv/1ms11Rnx1atWrlzCm1YXlNFfaeXdhnkfzn2pHPN3369Cl1rABQlvl5OwAAQOlc/OX322+/1eLFiwssb926tfXvadOmqXHjxlq/fr0OHjyo5s2b2637uuuu0/Dhw2UYho4ePaqJEyfqlltu0fz589W3b1+bsnPmzNHgwYPl5+enu+++Wx07dpSPj4/27t2rX3/9VRMnTlR0dLQaNWpks93EiRMVFhZWYN9Vq1bVK6+8ogcffNC6bMOGDfr444/18ssv2xxPhw4dijxH+Y8jKSlJ27Zt09SpU/XZZ59p/PjxevbZZ4vc3hGxsbE6ceKEBgwYoIYNGyo7O1uLFy/Wfffdp3379ul///ufzTE//vjjuuaaa/T+++/rxIkT+uijj7Rx40atW7dOQUFB1rLHjx9Xz549JUmPPvqo6tevr1OnTmn9+vU2+3/44YdVr149DRs2TA0bNtSOHTs0YcIEzZs3T5s3b1ZwcLCkvOvAXsLku+++06JFi3T99ddbl23atElXXHGFWrRooRdffFEhISGaP3++nnrqKR06dEgfffSR2+rMzc1V3759tXHjRj3xxBNq0aKFFi5cqMcff1wJCQl6+eWXrXXu379fPj4+evTRRxUZGamEhAR9//336tWrl+bOnasbbrhBklSrVi27cS5YsEDTpk2ziTM2NlZvvvmmGjZsqI4dOxaZ/NqyZYuaNGmiW2+9VdWqVVN0dLS+/PJLzZkzR9u2bVO9evUKbGM2m/Xkk08qNDRUqampBdbv2LFD1apV01NPPaWaNWvqzJkz+vrrr9W9e3etWbNGHTt2tJbdsGGDrrzySt1///0KCgrSli1bNG7cOP35559avny5fHzyfn8eP368Vq1apYEDB6pDhw46c+aMJkyYoM6dO2vt2rVq165docdYmF69ehWagDt58qTGjBmjxo0bq3bt2iWuO799+/Zp/PjxatGihdq3b681a9aUaPtZs2bp9ttv1+WXX25NJvz0008aPny4YmNj9cwzz0jKS8b961//0tmzZ/XUU08pMjJSP/30kwYNGqRp06bprrvuKnGdJREfH6+uXbsqOTlZDzzwgFq1aqW4uDht375dEydO1GOPPWZzvwwMDNRXX30lSUpMTNTMmTP1/PPPa8OGDfrhhx9s6i7qXmtx+PBhXXvttTp27JgGDhyohx9+WAEBAdq+fbsmT56s3377TStWrCjwnI8ZM0ZhYWF65ZVXbJb37NlT7dq10zPPPKPp06fbrHv55ZcVGxurBQsWWK9RSRo1apS6deum7Oxsbd68WV988YXmzp2rHTt22LyWhg4dqptuuqnA8XTq1Kmw0+uw1NRU3XzzzVq2bJn69eun++67Tz4+PlqwYIFGjRql33//XbNnz1ZISIh1m/79+2v+/PkaOnSoHnroIWVnZ2vv3r2aM2eOrrjiCptE2K+//qqhQ4eqevXqGjFihJo0aaIjR45o8uTJ+uWXX/TDDz/ojjvucCr21atX66qrrlLDhg310EMPKTIyUsePH9fatWv10Ucf6cknnyzVucl/zeXk5OjQoUOaNGmSFixYoN27d6tevXr68MMPbZLn8+bN04wZM/TBBx+oZs2a1uVXXHGFli1bppdeekm333676tSpY123fv16ffHFF3ruueds7neXXnqpnnvuOUl5PwR+/vnnuvPOOzVx4kQ9+uij1nINGjTQ2LFjC8RfpUqVUh2/q1z8+Sa/H3/8UXPmzNFll13m4agAwMMMAECF8sQTTxhF3d4PHz5sSDJ+/fVXo1atWsYbb7xht5wk44knnrBZtnv3bkOSceONN9osP3jwoBEaGmq0bt3aOHXqVIG6srOzjY8++sg4duyYddm///1vQ5IRExPj8LH9/PPPhiRjyZIldtc3atTIuPnmm4s9DsMwjNjYWOPyyy83JBlz5851OIaS6tevnxEaGmrk5OQYhmEYmZmZRtWqVY1evXoZZrPZWm727NmGJOPjjz+22f7GG280mjRpYsTGxha5H3vnZOrUqYYk48svvyw2zubNmxstWrSwWfbQQw8ZAQEBRlxcnM3yXr16GREREW6t86effjIkGZMnT7Yp179/fyMoKMg4e/ZskftOTU016tSpY/Tt27fYOK+55hojIiLCSE9Pty7LyMgwTp8+bRiGYWzYsMGQZEyZMqXYuiw2btxoSDLGjh1rd/3EiRONGjVqGE899ZTDr4MzZ84Yfn5+xiOPPFJs2f/7v/8zJBlr1qyxLlu1apWRmZlpU27//v1GYGCgcffddxdbZ0nk5OQYvXr1Mvz9/Y21a9eWur7k5GTrNVPcfcCe6667zqhXr56RkZFhXZadnW00a9bM6NChg3XZO++8Y0gy/vrrL+uy3Nxco1u3bkZkZKTN+XO0zpKw7H/VqlUF1iUlJdlco/fee68RGhpqUyY3N9fo2rWrIck4efKkYRiO32uzs7ONjh07GiEhIcaKFSvs7v/ll1+2u23btm2N3r172103fvx4Q5KxcOFC67L169cbPj4+xgsvvGBdtmTJEkOS8fPPP9ts//HHHxuSjP/973+GYRhGdHS0Icl49913izye0nj44YcNScYnn3xSYN2ECRMMScbjjz9uXbZ+/XpDkvH2228XKJ+Tk2Nz/z548KAREhJitGrVyjh37pxN2ZiYGKNVq1ZGaGiocejQIadiv+mmm4xatWoZCQkJBdZdfN8s7P3RMOy/zuxdc4ZhGHPmzDEkGV988YXdut59911DkhEdHV1gXXR0tBESEmIMHTrUuiwnJ8e49NJLjcaNGxupqanW5fbe40+fPm2EhoYaLVu2tC7r3bu30bZtW7uxuEJxr6mSfBa52Pbt242goCCjS5cuBe7XAFDR0GUbACqZadOmqVq1arr55ps1YMAATZs2zeFtW7durZo1a+rQoUM2y9955x2lpqZqypQpqlu3boHt/Pz8NGrUKEVFRZU6flepUaOGfvjhB/n5+RXoUuxKjRs3VlpamrKysiRJO3fuVGJiogYPHiyTyWQt169fP4WFhdm0atq7d6/mz5+v0aNHq0aNGsrIyFB2drbd/djr2mVpYbNnz54iY7S0lL377rttlicnJysoKMimBZUk1a1b19ri0l11rlixQpI0ZMgQm3JDhgxRRkaG/vjjjyL3HxISolq1ahXosn6x06dPa8mSJbrzzjttWqYGBgYqMjKyyG2L0rhxY0myu//4+Hi9+uqrevPNNwuch6LUrl1bISEhxR5TYfu/4oorFBAQYFOuRYsWatu2bYFrJCkpSXv37lVSUpLD8eX3n//8R8uXL9dbb71V5NAQjgoPD1f16tWd3j45OVnVqlVTYGCgdZmfn59q1qxZ4LqrVauWrr76ausyHx8fDRo0SGfOnNGyZctKXKckHTt2zG633YsdOnRIvr6+dltGRURE2Fyj9vj4+FjvBSXtJj9z5kxt27ZNr7zyiv71r3/Z3b8z98pnn31WHTp00OOPP66MjAzl5ubq0UcfVaNGjfTvf/+72O0tz0V0dHSJ9+2MEydOaPLkybr66qvtdmd+4okndNVVV+mLL77QyZMnJcn6nmhpzZ6fr6+vatSoYf3/3XffVVpamr744gvVqlXLpmzNmjX1+eefKzU1Ve+8847Nur179+rYsWPFxn/o0CG1bdvW7r2ltC2VC2O5V/r5lbzzXePGjfXGG29oxowZWrx4sSTp448/1tatWzVx4kSbVqiF7bt169Yeuz7cKTU1VYMHD5a/v79+/PHHAvdrAKhoSEgCQCUzbdo03XnnnQoICNDQoUN14MABbdiwwaFtk5KSlJCQoGrVqtksnzNnjpo3b+5U4iE+Pl6xsbE2D0cSLq7QsGFD9e7dW2vXrlVycrJ1+cXxFPbIP06bRXp6umJjY3XkyBFNnTpVU6ZM0eWXX25NUFi2sZfQCw4O1pYtW2Q2myXljU8nSXXq1NE111yj4OBgBQcH68Ybb3Qo2WAZGy5/Fzl7LEnpi5OHffr0UXJysh555BHt2bNHR48e1aRJk/Trr79qzJgxbq0zMzNTvr6+Bb6QWb6cbtq0qcA+k5OTFRsbq7179+rll1/Wzp07dc011xQZ5w8//CCz2VwgTmfExcXp3Llz2rhxo+6//35Jsrv/1157TZGRkXrkkUeKrTMxMVExMTHasWOHHnzwQSUnJ9utMycnR7GxsTp16pQWLVqkV199VeHh4erevXuR9RuGobNnzxa4Rn777Te1bt26wNhsjvj777/19ttvq2/fvho9erTNuuzsbIdfX5bXgSv06dNHu3bt0muvvaaDBw/q0KFD+u9//6uNGzfqhRdesJbLzMy0+9q0d905WqckDR8+3GaYicI0atRIubm5pRqH0pIcy58Ek4q/186aNUuSdM899zi9b3v8/Pz0xRdfKDo6Wv/97381YcIEbd682aFkk1T48aSlpdm9bvKP75iSkuLQtZY/8T5//nzl5uZq+PDhhcY0fPhw5eTkaMGCBZJkHYpk2rRpdseXzG/27Nlq3LixrrzySrvre/XqpcaNGxcYr7l169ZFxmTRqFEjbdq0ye54s65iOW9nz57VmjVr9Mwzz6hGjRoFxk101DPPPKOOHTvqscce08GDB/X6669ryJAh1uE2ipKdna3jx48XuD5yc3PtPtf5h8go7f3I3muqNPeukSNHas+ePZo0aZKaNWvmVB0AUK54u4kmAMC1iuqybelGunjxYsMwDMNsNhsNGjQwnnrqqQJlJRkjRowwYmJijHPnzhkbN240brjhhgJd5ZKSkgxJxu23316gjoSEBCMmJsb6SEtLs66zdHmy97jkkkvsxu/KLtsWli6z27Zts9nGkYe9Lrxjx461KXPNNdfYdFWPiYkxTCaTMWLECJvt9u7da93G0r1v1KhRhiSjRo0axg033GD8+OOPxrvvvmuEhYUZzZo1s+nKZs+IESMMX19fY//+/YWWycnJMerUqWN0797d7rqRI0ca/v7+1th8fX2NiRMnFrlfV9T53nvvGZIKdB196aWXDElGv379CtTdt29fa50BAQHGI488YtPF1Z4uXboYdevWNXJzcwst42iX7cDAQOv+a9SoUaD7vWEYxrZt2wxfX19r99Xiuv5dcskl1jrDwsKMV1991W6sa9asKfAacqRL83fffWe3a/yUKVNK3E3dMPK6hNatW9eIjIy0263e0i3XkYe97p2G4VyX7ZSUFGPQoEGGyWSy1h8SEmL8/vvvNuWefPJJw8fHxzhy5IjN8iFDhhiSjJEjR5a4TsPI60LqyMfuM2fOGLVq1TIkGa1atTIeffRRY/r06UZiYmKBspbus5b768GDB43//e9/hslksuky7ui9tlOnTkaVKlWKjdGeorpsW1he92FhYTbdcy0s18bXX39txMTEGKdOnTLmzp1rNG7c2DCZTMaGDRsMw/iny3Zhj/zDFNx7770OXWv5Y3/66acNScaWLVsKPZbNmzcbkoxnn33WMIy891LLc1ynTh1j6NChxqeffmocPXrUZrvExERDknHbbbcVea5uvfVWQ5KRnJxsXXZxnIVZtGiR4evra/j6+hqXX3658cILLxgLFy40srKyCpQt6v2xsC7b9s5f/fr1jU2bNhUaU1Fdti3WrVtn+Pj4GNWrVzeqVq1qnDlzpkCZRo0aGddff731mt+2bZv1tfnkk09ay1meC3uP/ENeOHs/Kuo1ZXmU9LOI5V58//33F1oGACoaJrUBgEpk2rRpqlOnjq666ipJebM+Dh48WN9//73ee+89+fr62pSfPHmyJk+ebP3f399fL7zwgs0kMJaWhfYmS+jTp491dkwpr6va888/b1Nm5syZioiIsFkWGhrq5BGWnCXu8+fPW5dZuo0Vp23btgWWDR06VF27dlVMTIzmzJmjs2fPKj093bq+Zs2aGjRokKZOnarWrVvrjjvu0MmTJ/Xkk0/K399f2dnZ1vKWSQEiIyM1d+5c68QPDRo00NChQzV9+vRCB8WfPn26Jk+erBdeeEEtWrQo9Bj++usvnT171maSGAtfX181a9ZMffv21cCBAxUUFKQZM2boySefVGRkpG6//Xa31XnXXXfpzTff1AMPPKBPP/1ULVq00KJFi/TZZ59Jks05tRg3bpyee+45HT9+XFOnTlVWVlaRrZX279+vTZs26ZlnnrGZVMNZ8+fPV0ZGhvbs2aPvv//e7mQ1o0aN0o033mgzgU5RpkyZouTkZB0+fFhTpkxRenq6cnNzC8Tbpk0bLV68WKmpqVq9erX+/PPPArNsX2zv3r164okndPnll+vee++1WXfffffpvvvucyhGC8MwNHz4cJ09e1YLFy602z20Y8eODr++StNl/mKBgYFq2bKlBgwYoDvvvFO5ubn64osvNGzYMC1evNjaRfrBBx/UpEmTNGjQIH3wwQeqU6eOfvrpJ2tL0fzXnaN1SnJ4RvA6depo27ZtevPNN/Xbb79p0qRJmjRpkgICAvTqq6/q1VdftRnqITU1tUC33yuuuMJuC8vi7rXJyckKDw93KE5nvP322/rll1+UlpamDz74oNByDzzwgM3/tWrV0tSpU9W1a1eb5Q8//LAGDhxYYPs2bdpY/37hhRc0bNiwYmPL3+rf8l5Q1LmwrLOUNZlMWrhwof7v//5P33//vWbMmKEZM2boiSee0KBBg/T555+ratWqDtWdf33+58QwjGKPQ8qbxG3NmjUaO3asFi5cqDVr1uidd95RrVq19NVXX+nWW291qJ7CBAUFafbs2ZLyJuc6cuSI3n//fd10001avny5WrZs6VS93bt316OPPqrPPvtMEydOtJngJr9FixbZXPO+vr665557NH78eJtyjRs31pdffllg+wYNGlj/Lu39yN5rSpJD11x++/fv12OPPaZWrVoVmAkdACo0b2dEAQCuVVgLyZycHKNu3brGkCFDjAMHDlgflslD8k84YBiGtRXH4sWLjblz5xpvvPGGERAQYNNCyDD+afFhr4Xk2rVrjcWLFxvff/+9Idm2rPT2pDYW9lpIutJDDz1kREVF2bQOTUxMtLaAsTyGDRtm3HnnnYYk62QElufyP//5j02dOTk5hp+fX6EtKZYvX24EBQUZffv2NbKzs4uMb/jw4Yavr6/d1ihjx441IiMjjfPnz9ss79Onj1GvXr1C63ZVncuWLTMaNmxoPUcRERHWiXqKa2GUmZlptG3b1ujfv3+hZV5//XVDkrFx48Yi63JmUpuDBw8aQUFBNpNi/PDDD4a/v7+xb98+67KSvA7i4+ONOnXqGM8991yxZadNm2b4+PgYW7dutbv+9OnTRtOmTY2oqCjr5CelZWkdPGbMGJfUVxhnWkg+8sgjRseOHW1al2ZlZRktWrQo0JL3559/NmrUqGG97iIjI42JEycakmxak5ekTmeYzWZj3759xscff2zUr1/fkGwnqLr33nuNoKAgY/HixcbixYuN5cuXG8ePHy9Qj6PXmLtbSBpG0ZONWFqrvf7668bixYuNv//+29i+fXuB+4y7J7UpSQvJV155xe76U6dOGTNmzDAuu+wyQ5J10qiStpBMSkpy9jAMw8i7D65fv94YM2aMERQUZPj7+xu7du2yri/q/dHyOlu6dKl1WWGT2hw/ftwICgoy7rzzTrt1OdJC0jD+aZltaQ17sUaNGhk9evQwFi9ebPz555/G6tWr7U7eU54mtcnIyDA6duxoBAUFue1zCACUVbSQBIBK4u+//9bp06f1ww8/2EycYjFt2rQCrbYaNGiga6+9VpJ00003qWbNmho5cqSuuuoq3XnnnZKkKlWqqG7dunbHq7KMKVnSyRU8aefOnfL19VWTJk2syyxjLxanSpUqxU7uMmDAAH355Zdavny5+vbta93ujz/+0LFjx3TkyBE1atRIjRo10hVXXKFatWpZJyOoV6+eJBVoKWKZJCEhIaHA/rZt26Zbb71V7dq10y+//FLkJAPp6en67bffdO2119ptjfLZZ5/p6quvLtD69dZbb9Wzzz6rI0eOqHnz5m6rs1evXjp8+LB27Nih1NRUdezYUadOnZKkYlvhBAQE6NZbb9W4ceOUnp5u93maPn26LrnkEnXp0qXIupzRrFkzderUSdOmTbNOjDF69GgNHDhQAQEB1teEZQy/48ePKysry/qc21OtWjVdffXVmjZtmv7v//6vyP3feeeduueee/TDDz+oY8eONuuSkpJ04403KjExUStWrChyn45as2aNXnvtNV1xxRV68803Cy2XlZWl+Ph4h+qsVatWgVbbzsjKyrK2Fs7fstTf31833nijJkyYoKysLOt4pQMGDNCtt96qbdu2KTc3V507d7a2cLRcdyWt0xkmk0ktW7ZUy5YtdfPNN6tFixaaNm2aTatoX19f6z26tFq1aqUtW7bo+PHjXp2ArH379i47pqSkJLutqS8WEBBgnTTJ0sJy+/btuvTSS+2W3759uySpadOmdtfXrVtXQ4YMUf/+/dW2bVv99NNP+uabb6zvl5btC7N9+3bVr1/fbuu7kggICFC3bt3UrVs3tWzZUvfff79+/vln62RCgYGBhZ6ftLQ0SSp2IiUp77PCJZdcouXLl5cqXkfUrFnTZdeHN+5HF3v22We1bds2ffrpp+rQoYPL6weAsoyEJABUEtOmTVPt2rX16aefFlj366+/WrsHFpVge+SRR/TBBx/o1Vdf1R133GHtOnjzzTfrq6++0vr164udRKMsOXbsmJYtW6bLL7/cpgudvZnC7ZkyZUqx3VotX/bszVbcsGFDNWzYUFJeYmrTpk3q37+/db0lUWaZydUiKytLsbGxBbpqHjp0SDfccINq166tefPm2e1Gn9+sWbN0/vz5Qid0OXv2rHJzcwsst8z0ba87tKvr9PX1tUkKWCb6ceQLaXp6ugzD0Pnz5wtc1+vWrdPBgweLTJ6VVnp6us3ER8ePH9f06dM1ffr0AmU7d+6sjh07auvWrcXW6cjM15mZmTKbzQXKZmRk6JZbbtH+/fv1559/2nRvdVZCQoKGDBmisLAwTZ8+vcgk+OrVq61DRhQnOjraOlt4acTFxSknJ6fQ685sNhdYZ0nkWFx83TlTZ2k0bdpU1apV0+nTp11W58VuueUWzZgxQ99//32xk1aVF0899ZSmTp1abLnevXtbk8433nijfH199d133xU6icy3336rgIAA3XbbbUXW6+/vrw4dOujAgQOKjY1VZGSk+vXrpy+//FIrV660O5v5ihUrdOTIEYcmvSoJS5f3/NdQo0aNtG/fPrvlLcstE/YUJycnp9hhIsoab9yP8ps5c6Y+++wz3XnnnXr88cddWjcAlAckJAGgEkhPT9evv/6qgQMHasCAAQXW16tXTzNmzNCsWbM0ePDgQuvx8/PTc889p8cff1x//PGHdby/F154QdOnT9cDDzygv/76q0DLOMPBsa88KT4+XkOHDlVubq5eeeUVm3XOjCEZExNTIEEo5Y3DaTKZ1Llz5yLrGjNmjHJycvTMM89Yl/Xp00e1a9fWtGnT9PLLL1tbqnzzzTfKzc3VddddZy175swZXX/99fLx8dHChQvtxnKx6dOnKyQkRHfccYfd9S1bttTixYsVFxdnncE0NzdXP/30k8LDw+3OAuqOOi1iYmI0fvx4dejQwSYhee7cuQLjFSYmJmrmzJmKioqyO5ahJSl41113Fbo/R+Tk5Oj8+fMFZp5fv369duzYYVO/vRmrf/jhB/3444/69ttvbcY2s3dMR44c0V9//WUzll5iYqJCQ0Pl7+9vU/arr76SJJuyubm5Gjx4sNasWaM//vhDl19+uRNHXNADDzygY8eOaebMmcUmLzwxhuSxY8eUlpamVq1aSZJq166tqlWr6rffftObb75pbbWYkpKi2bNnq1WrVkX+EHPgwAFNmjRJ/fr1s7aQLG2dhVm3bp3atWtXYBzd9evXKy4uTj179ixxnY4aMGCAxo4dq7ffflt9+vQpcH2cP39e48aN09tvv+22GFzNmTEkGzRooBEjRuiLL77QxIkT9dhjj9mUnTRpkv7++289+eST1nvYgQMHFBgYaP2BySIxMVFr1qxRtWrVrPfk0aNH6/vvv9cjjzyi5cuX28wOHR8fr0cffVQhISEFZqh31JIlS9SnTx+bsUYlad68eZKkSy65xLrspptu0ieffKJNmzbZtBRPTEzUtGnTdOmllzr0Oty/f7/27dvnltbm7uStMW2lvPv5gw8+qEaNGlnv1wBQ2ZCQBIBKwNJqrbDB7C+77DLVqlVL06ZNKzIhKeVNdvH6669r/Pjx1oRkixYtNH36dA0dOlSXXHKJ7r77bnXs2FGGYSg6OlrTp0+Xj4+PTcLF4pdffrHbku+6664rdFD7ktq/f7++//57GYah5ORkbdu2TT///LNSUlL0/vvv64YbbrAp70x3sLffflurVq3SDTfcoIYNGyo+Pl4zZ87Uhg0b9OSTT9p0bR43bpx27typHj16yM/PT7///rsWLVqkt956y6ZVVmBgoN59913de++96tWrl+655x4dO3ZMH330ka688kprt3lJuuGGG3T48GG98MILWrlypVauXGldV6dOHZvkpZT3xXf+/Pnq379/oS0pX3rpJQ0bNkw9evTQww8/rODgYM2YMUObNm3SW2+9VSAJ5uo6e/furcsvv1zNmzfXmTNn9MUXXyglJUVz5syx6SZ74403qkGDBurRo4dq166tY8eOacqUKTp16pR+/PHHAjHk5ubqxx9/1GWXXVZkAnTChAlKTEy0dhOfPXu2Tpw4IUl68sknVaVKFaWkpCgqKkqDBw9W27ZtFRoaqh07dmjKlCmqUqWKXnvtNWt99iYBsrSIvPHGG1WzZk3r8vbt2+uaa67RpZdeqmrVqunAgQOaPHmysrOzNW7cOGu5pUuXatSoURowYIBatGihrKwsrVixQr/++qu6du1qk4x57rnnNGvWLN1yyy2Kj4/X999/bxNL/rLffPON7r///mJbAU+aNEm///67OnTooLS0tAJ1Wlhez9WqVXO6u+Vbb70lSdq1a5ck6bvvvrNe56+++qq13PDhw7Vs2TLrDyG+vr56/vnn9eqrr+qyyy7T8OHDlZubq8mTJ+vEiRMFYm7Tpo0GDhyohg0bKjo6WhMnTlT16tU1adIka5mS1tmnTx+bmArz3Xffadq0abrjjjvUpUsXBQQEaM+ePfr6668VFBRkd6IoRxV3r/X399evv/6qa6+9Vr169dKgQYPUs2dP+fv7a9euXZo+fbqqVatWZhKSmzdvtnu9NWvWzJpMbdOmjVOtgN9//33t3btXjz/+uBYsWGB9j1i4cKH++OMPXX311Xr33Xet5bdt26a77rpLN954o6688kpVr15dJ0+e1NSpU3Xq1Cl9+OGH1u6+LVq00NSpU3X33Xerffv2GjFihJo0aaIjR45o8uTJio2N1YwZMwrcm0wmk01LzsI8+eSTSktL0x133KFWrVopKytLq1ev1o8//qjGjRvr/vvvt5Z96aWX9PPPP6tXr1565JFH1KpVK506dUrffPONTp8+rSlTphSoPycnx3reLZPaTJo0SWaz2doVvCxISkoq9H5kudeV5n5UWkOGDFFiYqLuvvtuzZ07126ZsLCwQiePA4AKwZsDWAIAXM/epDa33HKLERQUZKSmpha63X333Wf4+/sbsbGxhmEUPdj9G2+8YXdSiYMHDxqPPfaY0bx5cyMoKMgIDg42WrVqZTz66KMFJtewDApf2MPehBXOTmpjefj4+BhVq1Y1OnXqZDz11FM2g/uX1qJFi4x+/foZ9erVM/z9/Y3w8HCjZ8+expQpUwyz2WxTds6cOUb37t2N8PBwIyQkxLjsssuMn376qdC6Z8yYYXTs2NEIDAw06tSpY4wcOdJITk4u9DgvftibbGLSpEmGJGPWrFlFHteCBQuM3r17GzVr1jQCAgKM9u3bG5MmTbJb1tV1PvPMM0bTpk2NwMBAo1atWsZdd91lHDp0qEC5CRMmGP/617+MmjVrGn5+fkatWrWMW265xVi+fHmh+5dkfPzxx0XG2ahRo0LPqWVyhszMTOOpp54yOnToYERERBj+/v5Go0aNjBEjRhQ7gYNhFD45wr///W+ja9euRrVq1Qw/Pz+jXr16xpAhQ4zt27fblDt48KAxfPhwo2nTpkZwcLARFBRktG3b1vj3v/9tpKSk2JTt3bt3kddJfp988okhyViwYEGR8d97771F1lnU67mkHI3dcpwXmzZtmtG9e3ejatWqRnBwsNGjRw/jl19+KVBuyJAhRlRUlBEQEGDUq1fPePTRR42zZ8/ajcnROrt06WJERkYWe4zbt283Ro8ebXTu3NmoXr264efnZ9StW9cYOHCgsXnzZpuyhU0wcrGS3msTEhKM119/3Wjfvr0REhJiBAUFGe3atTPGjBljnD592u4+XDmpzc8//1xkHZZJbQp73HvvvcXG4YisrCzjww8/NLp06WKEhITY1J9/IiPDMIyzZ88a48aNM3r37m3UrVvX8PPzM6pVq2ZcffXVdq8Hw8h7rocOHWrUrVvX8Pf3NyIjI42hQ4caO3bsKFD2/PnzhiRjyJAhxcY9f/5844EHHjBatWplhIWFGQEBAUbz5s2NJ5980u51fOLECePBBx806tevb/j5+RnVq1c3+vXrZ6xdu7ZAWXuv94iICOOaa64x/vzzz0JjcuWkNhe/x9tTknudM1wxqY0j981GjRqVOlYAKMtMhlEG+9EBAADAawYNGqQjR45o/fr13g6l3Dt//ryqV6+uDz/8UE888YS3w4GTkpOT1bt3bx06dEjLly8vdMIbd5g3b5769eunbdu2qX379h7bLwAA7uRTfBEAAABUFoZhaOnSpdYu0iid5cuXq379+nrooYe8HQpKISIiQvPnz1fNmjV100036ejRox7b95IlSzRkyBCSkQCACoUWkgAAAAAAAAA8hhaSAAAAAAAAADyGhCQAAAAAAAAAjyEhCQAAAAAAAMBjSEgCAAAAAAAA8Bg/bwdQVpjNZp06dUrh4eEymUzeDgcAAAAAAAAoVwzD0Pnz51WvXj35+BTeDpKE5AWnTp1SVFSUt8MAAAAAAAAAyrXjx4+rQYMGha4nIXlBeHi4pLwTFhER4eVoAAAAAAAAgPIlOTlZUVFR1jxbYUhIXmDpph0REUFCEgAAAAAAAHBSccMhMqkNAAAAAAAAAI8hIQkAAAAAAADAY0hIAgAAAAAAAPAYxpAEAAAAAACoQAzDUE5OjnJzc70dCioYX19f+fn5FTtGZHFISAIAAAAAAFQQWVlZOn36tNLS0rwdCiqokJAQ1a1bVwEBAU7XQUISAAAAAACgAjCbzYqOjpavr6/q1aungICAUrdkAywMw1BWVpZiYmIUHR2tFi1ayMfHudEgSUgCAAAAAABUAFlZWTKbzYqKilJISIi3w0EFFBwcLH9/fx09elRZWVkKCgpyqh4mtQEAAAAAAKhAnG21BjjCFdcXVygAAAAAAAAAjyEhCQAAAAAAAMBjSEgCAAAAAAAAbrZq1Sq1b99e/v7+uv3227V06VKZTCYlJiZ6OzSPIyEJAAAAAAAAr4qJidFjjz2mhg0bKjAwUJGRkerbt69WrVplLdO4cWOZTCaZTCaFhoaqc+fO+vnnn23qSU9PV/Xq1VWzZk1lZmYW2E/+OkJCQtS+fXt99dVXBcotWbJEN910k2rUqKGQkBC1adNGzz33nE6ePClJTiUTn332WV166aWKjo7WN9984/B2FREJSQAAAAAAAHhV//79tWXLFk2dOlX79+/XrFmz1KdPH8XFxdmUe/PNN3X69Glt2bJF3bp10+DBg7V69Wrr+pkzZ6pt27Zq1aqVfv/9d7v7stSxc+dODRs2TA899JDmz59vXf/555/r2muvVWRkpGbOnKndu3dr0qRJSkpK0nvvvef0MR46dEhXX321GjRooKpVqzpdT0VAQhIAAAAAAABek5iYqBUrVmj8+PG66qqr1KhRI3Xv3l1jxozRrbfealM2PDxckZGRatmypT799FMFBwdr9uzZ1vWTJ0/WsGHDNGzYME2ePNnu/ix1NG3aVC+++KKqV6+uxYsXS5JOnDihUaNGadSoUfr666/Vp08fNW7cWL169dJXX32l119/vcTHd+TIEZlMJsXFxemBBx6QyWSy20LyjTfe0KWXXmqz7MMPP1Tjxo0lSRkZGWrbtq0efvhh6/pDhw4pPDxcX3/9dYnj8iYSkgAAAAAAAPCasLAwhYWF6ffff7fbzbowfn5+8vf3V1ZWlqS85NyaNWs0aNAgDRo0SCtWrNDRo0cL3d5sNmvmzJlKSEhQQECAJOnnn39WVlaWXnjhBbvbONOyMSoqSqdPn1ZERIQ+/PBDnT59WoMHDy5xPUFBQZo2bZqmTp2qP/74Q7m5uRo2bJiuu+46PfDAAyWuz5v8vB0AAAAAAAAA3Gv79u3KyMjw2P6CgoLUoUMHh8r6+fnpm2++0UMPPaRJkyapc+fO6t27t4YMGVJoHVlZWXrvvfeUlJSkq6++WpL09ddf68Ybb1S1atUkSX379tWUKVP0xhtv2Gz74osv6tVXX1VmZqZycnJUvXp1Pfjgg5KkAwcOKCIiQnXr1nXyyAvy9fVVZGSkTCaTqlSposjISKfruvTSS/XWW2/pwQcf1JAhQ3T06FHNmTPHZbF6CglJAAAAAACACs7R5KC39O/fXzfffLNWrFihtWvXav78+XrnnXf01Vdf6b777rOWsyQTMzIyFBYWpnHjxunmm29Wbm6upk6dqo8++shadtiwYXr++ef1+uuvy8fnn07Co0eP1n333afTp09r9OjRevzxx9W8eXNJkmEYMplMHjtuZzz33HP6/fffNWHCBM2fP181atTwdkglRpdtAAAAAAAAeF1QUJCuu+46vfbaa1q9erXuu+8+/fvf/7YpM3r0aG3dulUnTpxQQkKCXnzxRUnSwoULdfLkSQ0ePFh+fn7y8/OztiD866+/bOqoWbOmmjdvriuvvFI///yzRo0apd27d0uSWrZsqaSkJJ0+fdozB52Pj4+PDMOwWZadnV2g3Llz57R//375+vrqwIEDngrPpUhIAgAAAAAAoMxp06aNUlNTbZZZkomWLtAWkydP1pAhQ7R161abx5AhQwqd3EbKG99x8ODBGjNmjCRpwIABCggI0DvvvGO3fGJiYukPrBC1atXSmTNnbJKSW7duLVDugQceUPv27TV16lS9+OKL2rNnj9tiche6bAMAAAAAAMBr4uLiNHDgQD3wwAPq0KGDwsPDtXHjRr3zzju67bbbit0+JiZGs2fP1qxZs9SuXTubdcOHD9cdd9yh+Ph4Va9e3e72Tz31lNq1a6eNGzeqa9eu+uCDDzRy5EglJydr+PDhaty4sU6cOKFvv/1WYWFheu+996zb7tixQ+Hh4db/TSaTOnbs6NR56NOnj2JiYvTOO+9owIABWrBggebPn6+IiAhrmU8//VRr1qzR9u3bFRUVpblz5+ruu+/W2rVrrRPzlAe0kAQAAAAAAIDXhIWFqUePHvrggw/Uq1cvtWvXTq+99poeeughTZgwodjtv/32W4WGhuqaa64psO6aa65RcHCwvv/++0K3b9Omja6//nq9/vrrkqTHH39cixYt0smTJ3XHHXeoVatWevDBBxUREaHnn3/eZttevXqpU6dO1keXLl1KePT/aN26tT777DN9+umn6tixo9avX2+zv71792r06NH67LPPFBUVJUn67LPPFBsbq9dee83p/XqDybi4c3ollZycrCpVqigpKckm8wwAAAAAAFAeZGRkKDo6Wk2aNFFQUJC3w0EFVdR15mh+jRaSAAAAAAAAADyGhCQAAAAAAAAAjyEhCQAAAAAAAMBjSEgCAAAAAAAA8BgSkgAAAAAAAAA8hoRkJcOk6gAAAAAAAPAmEpKVzIIFC5SQkODtMAAAAAAAAFBJkZCsZHJycpSTk+PtMAAAAAAAAFBJkZAEAAAAAAAA4DEkJAEAAAAAAIAKYunSpTKZTEpMTHR4m8aNG+vDDz90W0wXIyEJAAAAAAAAr4qJidFjjz2mhg0bKjAwUJGRkerbt69WrVplLdO4cWOZTCaZTCaFhoaqc+fO+vnnn23qSU9PV/Xq1VWzZk1lZmYW2E/+OkJCQtS+fXt99dVXBcotWbJEN910k2rUqKGQkBC1adNGzz33nE6ePCnJuaQf/kFCEgAAAAAAAF7Vv39/bdmyRVOnTtX+/fs1a9Ys9enTR3FxcTbl3nzzTZ0+fVpbtmxRt27dNHjwYK1evdq6fubMmWrbtq1atWql33//3e6+LHXs3LlTw4YN00MPPaT58+db13/++ee69tprFRkZqZkzZ2r37t2aNGmSkpKS9N5777nl+CsbEpIAAAAAAAAVlWFIqaneeRiGQyEmJiZqxYoVGj9+vK666io1atRI3bt315gxY3TrrbfalA0PD1dkZKRatmypTz/9VMHBwZo9e7Z1/eTJkzVs2DANGzZMkydPtrs/Sx1NmzbViy++qOrVq2vx4sWSpBMnTmjUqFEaNWqUvv76a/Xp00eNGzdWr1699NVXX+n111936mmwtKhcuHChOnXqpODgYF199dU6d+6c5s+fr9atWysiIkJ33XWX0tLSrNtlZmZq1KhRql27toKCgvSvf/1LGzZssKl73rx5atmypYKDg3XVVVfpyJEjBfa/cuVKXXnllQoODlZUVJRGjRql1NRUp47FFUhIAgAAAAAAVFRpaVJYmHce+RJrRQkLC1NYWJh+//13u92sC+Pn5yd/f39lZWVJkg4dOqQ1a9Zo0KBBGjRokFasWKGjR48Wur3ZbNbMmTOVkJCggIAASdLPP/+srKwsvfDCC3a3qVq1qsPx2fPGG29owoQJWr16tY4fP65Bgwbpww8/1PTp0zV37lwtWrRIn3zyibX8Cy+8oJkzZ2rq1KnavHmzmjdvrr59+yo+Pl6SdPz4cd1555265ZZbtHXrVj344IN66aWXbPZ56NAh3XDDDerfv7+2b9+uH3/8UStXrtTIkSNLdSylQUISAAAAAAAAXuPn56dvvvlGU6dOVdWqVdWzZ0+9/PLL2r59e6HbZGVlaezYsUpKStLVV18tSfr666914403qlq1aqpevbr69u2rKVOmFNj2xRdfVFhYmAIDAzVgwABVq1ZNDz74oCTpwIEDioiIUN26dd1yrG+99ZZ69uypTp06acSIEVq2bJkmTpyoTp066corr9SAAQO0ZMkSSVJqaqomTpyod999VzfeeKPatGmjL7/8UsHBwdbWnxMnTlSzZs303nvv6ZJLLtHdd9+t++67z2afY8eO1d13362nn35aLVq00BVXXKGPP/5Y3377rTIyMtxynMUhIQkAAAAAAFBRhYRIKSneeYSEOBxm//79derUKc2aNUs33HCDli5dqs6dO+ubb76xKWdJJoaEhGj8+PEaN26cbr75ZuXm5mrq1KkaNmyYteywYcP0zTffyGw229QxevRobd26VX///bd69OihDz74QM2bN5ckGYYhk8nk/PkuRocOHax/16lTRyEhIWratKnNsnPnzknKa9mYnZ2tnj17Wtf7+/ure/fu2rNnjyRpz5496tGjh80+Lr/8cpv/t23bpm+++cbaEjUsLEx9+/aV2WxWdHS0y4/REX5e2SsAAAAAAADcz2SSQkO9HYVDgoKCdN111+m6667Ta6+9pgcffFD//ve/bVr8jR49Wvfdd5/CwsJUp04da/Jw4cKFOnnypAYPHmxTZ25urv766y9dd9111mU1a9ZU8+bN1bx5c/38889q3769unbtqjZt2qhly5ZKSkrS6dOn3dJK0t/f3/q3yWSy+d+y7OIEammlpKTokUce0ahRowqsa9iwoUv35ShaSAIAAAAAAKDMadOmTYGJVyzJxMjISJuWjJMnT9aQIUO0detWm8eQIUMKndxGkqKiojR48GCNGTNGkjRgwAAFBATonXfesVs+MTGx9AfmoGbNmikgIECrVq2yLsvOztaGDRvUpk0bSVLr1q21fv16m+3Wrl1r83/nzp21e/duaxI2/8Mydqan0UISAAAAAAAAXhMXF6eBAwfqgQceUIcOHRQeHq6NGzfqnXfe0W233Vbs9jExMZo9e7ZmzZqldu3a2awbPny47rjjDsXHx6t69ep2t3/qqafUrl07bdy4UV27dtUHH3ygkSNHKjk5WcOHD1fjxo114sQJffvttwoLC9N7771n3XbHjh0KDw+3/m8ymdSxY0cnz4St0NBQPfbYYxo9erSqV6+uhg0b6p133lFaWppGjBghSXr00Uf13nvvafTo0XrwwQe1adMmu93cL7vsMo0cOVIPPvigQkNDtXv3bi1evFgTJkxwSawlRUISAAAAAAAAXhMWFmYdy9EybmJUVJQeeughvfzyy8Vu/+233yo0NFTXXHNNgXXXXHONgoOD9f3339vtsizltcS8/vrr9frrr2vevHl6/PHH1bJlS/3f//2f7rjjDqWnp6tx48bq16+fnn32WZtte/XqZfO/r6+vcnJySnD0RRs3bpzMZrPuuecenT9/Xl27dtXChQtVrVo1SXldrmfOnKlnnnlGn3zyibp3767//e9/euCBB6x1dOjQQcuWLdMrr7yiK6+8UoZhqFmzZgW6t3uSyTAMw2t7L0OSk5NVpUoVJSUlKSIiwtvhuM3s2bN12WWXqVatWt4OBQAAAAAAuFBGRoaio6PVpEkTBQUFeTscVFBFXWeO5tcYQxIAAAAAAACAx5CQBAAAAAAAAOAxJCQBAAAAAAAAeAwJSQAAAAAAAAAeQ0ISAAAAAAAAgMeQkAQAAAAAAADgMSQkKyGTyeTtEAAAAAAAAFBJkZAEAAAAAAAA4DEkJAEAAAAAAAB4DAnJSsgwDG+HAAAAAAAA4HZLly6VyWRSYmKiW/fTp08fPf30027dh7OcOQeNGzfWhx9+6LaYSEgCAAAAAADAq+677z6ZTCaZTCb5+/urSZMmeuGFF5SRkeHt0OAGft4OAJ7HpDYAAAAAAKCsueGGGzRlyhRlZ2dr06ZNuvfee2UymTR+/Hi37TM3N1cmk0k+PrTZ8yTONgAAAAAAQAVlGFJqqnceJR0xLjAwUJGRkYqKitLtt9+ua6+9VosXL7auN5vNGjt2rJo0aaLg4GB17NhRv/zyi00d8+bNU8uWLRUcHKyrrrpKR44csVn/zTffqGrVqpo1a5batGmjwMBAHTt2TAkJCRo+fLiqVaumkJAQ3XjjjTpw4IDNtqtWrVKfPn0UEhKiatWqqW/fvkpISLB7LHPnzlWVKlU0bdo0u+st3agXLlyoTp06KTg4WFdffbXOnTun+fPnq3Xr1oqIiNBdd92ltLQ063aZmZkaNWqUateuraCgIP3rX//Shg0bSnQOJGnlypW68sorFRwcrKioKI0aNUqpqal2Y3UHEpKV3Pnz5xUdHe3tMAAAAAAAgBukpUlhYd555MujldjOnTu1evVqBQQEWJeNHTtW3377rSZNmqRdu3bpmWee0bBhw7Rs2TJJ0vHjx3XnnXfqlltu0datW/Xggw/qpZdesnNO0jR+/Hh99dVX2rVrl2rXrq377rtPGzdu1KxZs7RmzRoZhqGbbrpJ2dnZkqStW7fqmmuuUZs2bbRmzRqtXLlSt9xyi3JzcwvUP336dA0dOlTTpk3T3XffXeRxvvHGG5owYYJWr16t48ePa9CgQfrwww81ffp0zZ07V4sWLdInn3xiLf/CCy9o5syZmjp1qjZv3qzmzZurb9++io+Pd/gcHDp0SDfccIP69++v7du368cff9TKlSs1cuRIB58dFzBgGIZhJCUlGZKMpKQkb4fiVrNmzTJiYmKs/x8+fNiYM2eOFyMCAAAAAACukJ6ebuzevdtIT0+3LktJMYy8toqef6SkOB77vffea/j6+hqhoaFGYGCgIcnw8fExfvnlF8MwDCMjI8MICQkxVq9ebbPdiBEjjKFDhxqGYRhjxowx2rRpY7P+xRdfNCQZCQkJhmEYxpQpUwxJxtatW61l9u/fb0gyVq1aZV0WGxtrBAcHGz/99JNhGIYxdOhQo2fPnoXG37t3b+Opp54yJkyYYFSpUsVYunRpkce7ZMkSQ5Lx559/WpeNHTvWkGQcOnTIuuyRRx4x+vbtaxiGYaSkpBj+/v7GtGnTrOuzsrKMevXqGe+8847D52DEiBHGww8/bFNmxYoVho+Pj/XaadSokfHBBx/Yjd3edWbhaH6NMSQBAAAAAAAqqJAQKSXFe/suiauuukoTJ05UamqqPvjgA/n5+al///6SpIMHDyotLU3XXXedzTZZWVnq1KmTJGnPnj3q0aOHzfrLL7+8wH4CAgLUoUMH6/979uyRn5+fzbY1atTQJZdcoj179kjKayE5cODAIuP/5ZdfdO7cOa1atUrdunVz6Jjzx1GnTh2FhISoadOmNsvWr18vKa9lY3Z2tnr27Gld7+/vr+7du1vjdOQcbNu2Tdu3b7fpTm4Yhsxms6Kjo9W6dWuHYi8NEpIAAAAAAAAVlMkkhYZ6OwrHhIaGqnnz5pKkr7/+Wh07dtTkyZM1YsQIpVzIqs6dO1f169e32S4wMLBE+wkODi7xhL/BwcHFlunUqZM2b96sr7/+Wl27dnVoH/7+/ta/LTOM52cymWQ2m0sUa3FSUlL0yCOPaNSoUQXWNWzY0KX7KgxjSAIAAAAAAKBM8fHx0csvv6xXX31V6enpNhPQNG/e3OYRFRUlSWrdurW1NaHF2rVri91X69atlZOTo3Xr1lmXxcXFad++fWrTpo2kvJaMf/31V5H1NGvWTEuWLNEff/yhJ598sqSHXKxmzZopICBAq1atsi7Lzs7Whg0brHE6cg46d+6s3bt3FziPzZs3txmz051ISAIAAAAAAKDMGThwoHx9ffXpp58qPDxczz//vJ555hlNnTpVhw4d0ubNm/XJJ59o6tSpkqRHH31UBw4c0OjRo7Vv3z5Nnz5d33zzTbH7adGihW677TY99NBDWrlypbZt26Zhw4apfv36uu222yRJY8aM0YYNG/T4449r+/bt2rt3ryZOnKjY2Fibulq2bKklS5Zo5syZevrpp116PkJDQ/XYY49p9OjRWrBggXbv3q2HHnpIaWlpGjFihMPn4MUXX9Tq1as1cuRIbd26VQcOHNAff/zh0UltSEgCAAAAAACgzPHz89PIkSP1zjvvKDU1Vf/973/12muvaezYsWrdurVuuOEGzZ07V02aNJGU19145syZ+v3339WxY0dNmjRJ//vf/xza15QpU9SlSxf169dPl19+uQzD0Lx586xdqFu2bKlFixZp27Zt6t69uy6//HL98ccf8vMrOBriJZdcor///lszZszQc88957oTImncuHHq37+/7rnnHnXu3FkHDx7UwoULVa1aNUmOnYMOHTpo2bJl2r9/v6688kp16tRJr7/+uurVq+fSWItiMgzD8NjeyrDk5GRVqVJFSUlJioiI8HY4bjN79mxdfvnlqlmzpiQpOjpau3fv1s033+zlyAAAAAAAQGlkZGQoOjpaTZo0UVBQkLfDQQVV1HXmaH6NFpIAAAAAAAAAPIaEJAAAAAAAAACPISEJAAAAAAAAwGNISEImk8nbIQAAAAAAAKCSqBAJydzcXL322mtq0qSJgoOD1axZM/33v/8V8/U4hvMEAAAAAEDFwfd8uJMrrq+Cc5OXQ+PHj9fEiRM1depUtW3bVhs3btT999+vKlWqaNSoUd4ODwAAAAAAwO38/f0lSWlpaQoODvZyNKio0tLSJP1zvTmjQiQkV69erdtuu00333yzJKlx48aaMWOG1q9fX+g2mZmZyszMtP6fnJzs9jgBAAAAAADcxdfXV1WrVtW5c+ckSSEhIQzTBpcxDENpaWk6d+6cqlatKl9fX6frqhAJySuuuEJffPGF9u/fr5YtW2rbtm1auXKl3n///UK3GTt2rP7zn/94MEoAAAAAAAD3ioyMlCRrUhJwtapVq1qvM2dViITkSy+9pOTkZLVq1Uq+vr7Kzc3V22+/rbvvvrvQbcaMGaNnn33W+n9ycrKioqI8EW6Zw68lAAAAAABUDCaTSXXr1lXt2rWVnZ3t7XBQwfj7+5eqZaRFhUhI/vTTT5o2bZqmT5+utm3bauvWrXr66adVr1493XvvvXa3CQwMVGBgoIcjBQAAAAAAcD9fX1+XJI4Ad6gQCcnRo0frpZde0pAhQyRJ7du319GjRzV27NhCE5L4B7NvAQAAAAAAwFN8vB2AK6SlpcnHx/ZQfH19ZTabvRRR2XT+/HlvhwAAAAAAAIBKrkK0kLzlllv09ttvq2HDhmrbtq22bNmi999/Xw888IC3QytTjh496u0QAAAAAAAAUMlViITkJ598otdee02PP/64zp07p3r16umRRx7R66+/7u3QypTCWowyqQ0AAAAAAAA8pUIkJMPDw/Xhhx/qww8/9HYoZRpjRQIAAAAAAMDbKsQYknBMYQlJEpUAAAAAAADwFBKSlQiJRwAAAAAAAHgbCclKhIQkAAAAAAAAvI2EZCVSWEKSSW0AAAAAAADgKSQkKxFLQpIEJAAAAAAAALyFhGQlYklI0nUbAAAAAAAA3kJCshJhlm0AAAAAAAB4GwlJAAAAAAAAAB5DQhJ2x5SMiYlRdHS0F6IBAAAAAABARUZCshJyZFIbEpIAAAAAAABwBxKSAAAAAAAAADyGhCQAAAAAAAAAjyEhCQAAAAAAAMBjSEgCAAAAAAAA8BgSkgAAAAAAAAA8hoQkAAAAAAAAAI8hIQkAAAAAAADAY0hIVnKGYXg7BAAAAAAAAFQiJCRRIvPmzVNGRoa3wwAAAAAAAEA5RUKykjOZTCUqn5ubq9zcXDdFAwAAAAAAgIqOhCQAAAAAAAAAjyEhWckxhiQAAAAAAAA8iYRkJVLS7tkAAAAAAACAq5GQBAAAAAAAAOAxJCQBAAAAAAAAeAwJyUqObtwAAAAAAADwJBKSlRyT2gAAAAAAAMCTSEgCAAAAAAAA8BgSkgAAAAAAAAA8hoQkAAAAAAAAAI8hIVkJnTt3TtnZ2d4OAwAAAAAAAJUQCclK6ODBg4qPj/d2GAAAAAAAAKiESEgCAAAAAAAA8BgSkgAAAAAAAAA8hoQkAAAAAAAAAI8hIQkAAAAAAADAY0hIVlKpqamKiYnxdhgAAAAAAACoZPy8HQC849SpU0pLS1Pz5s29HQoAAAAAAAAqEVpIAgAAAAAAAPAYEpKVlGEY3g4BAAAAAAAAlRAJyUrKZDJ5OwQAAAAAAABUQiQkAQAAAAAAAHgMCUkAAAAAAAAAHkNCEgAAAAAAAIDHkJBEAbm5ud4OAQAAAAAAABUUCUnYiI2N1cKFC70dBgAAAAAAACooEpKVSP6ZtQ3DsFsmJyeHFpIAAAAAAABwGxKSAAAAAAAAADyGhGQllb+1JAAAAAAAAOApJCQrqcK6bAMAAAAAAADuREKykqKFJAAAAAAAALyBhCQAAAAAAAAAjyEhCbtoQQkAAAAAAAB3ICFZSRU3hiRjTAIAAAAAAMAdSEgCAAAAAAAA8BgSkpXcrl277C6nyzYAAAAAAADcgYQk7KLLNgAAAAAAANyBhCQAAAAAAAAAjyEhCbvosg0AAAAAAAB3ICEJAAAAAAAAwGNISFYip0+ftv5dXAtIxpAEAAAAAACAO5CQBAAAAAAAAOAxJCRhF2NIAgAAAAAAwB1ISAIAAAAAAADwGBKSAAAAAAAAADyGhGQlZRiGsrKyvB0GAAAAAAAAKhkSkpWYvZm0GTsSAAAAAAAA7kRCEmXavHnzvB0CAAAAAAAAXIiEJGzYazXpTbm5ud4OAQAAAAAAAC5EQhIAAAAAAACAx5CQBAAAAAAAAOAxJCRhg0ltAAAAAAAA4E4kJCspEo8AAAAAAADwBhKSAAAAAAAAADymwiQkT548qWHDhqlGjRoKDg5W+/bttXHjRm+HVWaVtdm0AQAAAAAAUDn4eTsAV0hISFDPnj111VVXaf78+apVq5YOHDigatWqeTu0codEJQAAAAAAANypQiQkx48fr6ioKE2ZMsW6rEmTJl6MqOxjDEkAAAAAAAB4Q4Xosj1r1ix17dpVAwcOVO3atdWpUyd9+eWXRW6TmZmp5ORkm0dlcnFLSLPZrP3795OoBAAAAAAAgFtViITk4cOHNXHiRLVo0UILFy7UY489plGjRmnq1KmFbjN27FhVqVLF+oiKivJgxGVPTk6O9u3b5+0wAAAAAAAAUMFViISk2WxW586d9b///U+dOnXSww8/rIceekiTJk0qdJsxY8YoKSnJ+jh+/LgHI/Y+WkICAAAAAADAGypEQrJu3bpq06aNzbLWrVvr2LFjhW4TGBioiIgIm0dlwuQ1AAAAAAAA8IYKkZDs2bNnge7G+/fvV6NGjbwUUflCa0kAAAAAAAB4SoVISD7zzDNau3at/ve//+ngwYOaPn26vvjiCz3xxBPeDq1coLUkAAAAAAAAPKVCJCS7deum3377TTNmzFC7du303//+Vx9++KHuvvtub4cGAAAAAAAAIB8/bwfgKv369VO/fv28HQYKsWHDBrVp00ahoaHeDgUAAAAAAABeVCFaSKLsO3PmjNLT070dBgAAAAAAALyMhCSY1AYAAAAAAAAeQ0ISAAAAAAAAgMeQkASzbAMAAAAAAMBjSEgCAAAAAAAA8BgSknBKamqqt0MAAAAAAABAOURCEk5NavP333+7IRIAAAAAAABUdCQkAQAAAAAAAHgMCUkAAAAAAAAAHkNCEoXOss04kQAAAAAAAHA1EpIAAAAAAAAAPIaEJJya1AYAAAAAAABwBglJAAAAAAAAAB5DQhIAAAAAAACAx5CQRKGT2gAAAAAAAACuRkISAAAAAAAAgMeQkKykEhMTrX+bTKYiW0nm5uYqIyPDA1EBAAAAAACgoiMhiWIdOXJES5cu9XYYAAAAAAAAqABISAIA4CX79+9nHF8AAAAAlQ4JSUjK67YNAPCsffv2kZAEAAAAUOmQkIQkZtoGAAAAAACAZ5CQBAAAAAAAAOAxJCQhKW8cMwAAAAAAAMDdSEhCUt5M2gAAAAAAAIC7kZAEAAAAAAAA4DEkJAEAAAAAAAB4DAlJAAAAAAAAAB5DQhIlZjKZvB0CAAAAAAAAyikSkrBBshEAAAAAAADuREISNgzD8HYIAAAAAAAAqMBISKLESFoCAAAAAADAWSQk4RCSkAAAAAAAAHAFEpIAAAAAAAAAPIaEJGwUNqkNk90AAAAAAADAFUhIwq6DBw/a/E+XbQAAAAAAALgCCUmUGK0lAQAAAAAA4CwSkrBBS0gAAAAAAAC4EwlJAAAAAAAAAB5DQhI26I4NAAAAAAAAdyIhCQAAAAAAAMBjSEiixBhnEgAAAAAAAM4iIQkAAAAAAADAY0hIAgAAAAAAAPAYEpIoMSa+AQAAAAAAgLNISAIAAAAAAMBjsrOzFRcX5+0w4EUkJAEAAAAAAOAxZ86c0erVq70dBryIhCSKRRdtAAAAAAAAuAoJSRTLMAxvhwAAAAAAAMqZnTt3ejsElFEkJAEAAAAAAOBy0dHRdpfTExMkJFGsi28UZanFZGxsrA4cOODtMAAAAAAAAOAgEpIo1+Li4nTkyBFvhwEAAAAAAAAHkZBEidG0GgAAAAAAAM4iIYkyJz4+XkePHvV2GAAAAAAAAHADEpKwURbGhzx79qwOHjzo7TAAAAAAAADgBiQkYWP9+vVurd9sNis7O9ut+wAAAAAAAEDZRUISHnX48GGtXLnS22EAAAAAAADAS0hIwqPMZrNycnK8HQYAAAAAAAC8hIQkyiRm8gYAAAAAAKiYSEjCo8rCpDkAAAAAAADwHhKSKNLJkye1a9cub4cBAAAAAACACoKEJIqUmprq8X2azWaP7xMAAAAAAACe4eftAFC2ubqLtSNjQx4+fNil+wQAAAAAAGUH80aAFpLwKG8kOAEAAAAAAFB2kJBEkZiEBgDci/ssAAAAgMqGhCQAAAAAAAAAjyEhiSKVpuVOcnKytm/f7vB+aCUEAAAAAABQ8ZGQhEOcSRaeP39eR48edajsvn37tHnz5hLvAwDKu5SUFG+HAAAAAAAeRUISRXJnq8WEhATr3+np6crIyHDbvuA5hmEoPT3d22EA5cbhw4e9HQIAAAAAeBQJSRTJkpB0x2zWK1eutNkPM2ZXDImJifrzzz+9HQYAAAAAACijSEjCIe4e39EwDPn4cDlWBIwFCgAAAAAAikIGCGVCUUksElzlW3JysrdDAAAAAAAAZQgJSRTJU8lAumxXPOnp6Vq4cKGWLVvm7VAAAAAAAEAZQkISZQJdtiuenJwcZWVleTsMoMyjFTgAAACAyoYMEIpEC0kAAAAAAAC4EglJFImEJJzF8wk4htcKAAAAgMqmQiYkx40bJ5PJpKefftrboZQLZeHLsNlsdjoOujuWTWXhugIAAAAAAGVPhUtIbtiwQZ9//rk6dOjg7VAqBJJ9AOBe3GcBAAAAVDYVKiGZkpKiu+++W19++aWqVavm7XBQCFrOAQAAAABQeZEXQIVKSD7xxBO6+eabde211xZbNjMzU8nJyTaPysrTN4L8rYEOHTrk0X3Dc3iDAQAAAAAA9lSYhOQPP/ygzZs3a+zYsQ6VHzt2rKpUqWJ9REVFuTnC8sndXQnj4+PdWj8AAAAAAADKlgqRkDx+/LieeuopTZs2TUFBQQ5tM2bMGCUlJVkfx48fd3OUZVdZb8nG+GrlU1m/rgAAAAAAgHf4eTsAV9i0aZPOnTunzp07W5fl5uZq+fLlmjBhgjIzM+Xr62uzTWBgoAIDAz0dKmSbqCLZWHGRkAQAAAAAAPZUiITkNddcox07dtgsu//++9WqVSu9+OKLBZKRsOWuxJGjycaDBw8qISFBdevWdUscAAAAAACg9FJSUhQQEKCAgABvh4JyrkIkJMPDw9WuXTubZaGhoapRo0aB5fC84hKTBw8elNls9lA0AAAAAADAGWvXrlVUVJQuueQSb4eCcq5CjCEJ9ykrY2sahqGsrCxvh4ESoDs+AAAAAACwp0K0kLRn6dKl3g6h3CgrY/0VFcfJkye1fft23XTTTQ5vA/fKzc1VZmamQkJCvB0KAAAAAAAoR0qckJw1a1aJd3LdddcpODi4xNvBM3JyclxW14kTJ9SgQYMSbZOdnS2p6BZ1ZrNZubm5pYoNrnXixAlt375dt9xyi7dDAQAAAAAA5UiJE5K33357icqbTCYdOHBATZs2Lemu4CGWhKArbNmypciEZFFJx+zsbMaSLGdc0UI1IyNDQUFBLogGAAAAAACUB06NIXnmzBmZzWaHHnTnrHjcNTbguXPndPDgQbfU7Q7Z2dmMk+iglJQUnTp1SikpKQXWLV682AsRAQAAAAA8yZInAiQnEpL33ntvibpfDxs2TBERESXdDSqpwm5OF7fES01N9fokNwsXLtS5c+e8GkN5sWTJEm3fvl1nzpzxdigAAAAAAC/YsmWLdu/e7e0wUEaUuMv2lClTSlR+4sSJJd0FUKx169apbt268vPz3rxMhmFUqBaS2dnZMplMLjunF58bfgkDAAAAgMorMzOTiWlh5VSXbcAZFSl5VxFt2rRJO3fudFv9TEoEAAAAAJCKn49g+/bt2rVrl4eigTe4JCG5bt06V1SDCsaRLtWZmZnFliGR6RmM5wEAAAAAKAvS0tKUnp7u7TDgRi5JSA4cONAV1aCcKW52bsuvGZako71fQBITE53at2EYbmvqnZmZ6dKZxx1x+vRpJSQkeHSfhcnOztbSpUu9HQYAAAAAAKigHB4sbtCgQXaXG4ah+Ph4lwWE8mPBggW65ZZbii1X3mZR3rBhg8LCwnTppZd6bJ/79+9XjRo1VK1aNY/t0x6TyaScnBydP3/eLfXT2hUAAAAAKq+SNCxivMmKzeGE5J9//qnvvvtOYWFhNssNw9Dy5ctdHhjKr7S0NIWEhJS6HmZk9qzCkoWbNm1Sly5dPBwNUHmQqAcAAABQ2TickOzTp4/Cw8PVq1evAus6dOjg0qBQfsybN0833XSTzbK//vpL1157bYGycXFxJar70KFDDpVz9Zd5foWxderUKacSkiRZAAAAAACAPQ4nJH/99ddC15W3LrlwnZLMnLx//361aNHCJfsl2QUAAAAAAFA+OT2pDd1p4W3uGudQykt47tmzR/v373fbPgBAolU2AAAAKoeSNCyiEVLF53RC8vrrr3dlHECR7H1hd3dSPDk5WcnJyW7dR1nkzI3fMpN6STEhFgAAAAAAlY/TCUmy1ShKRbg+KsIxlJSzLbUWLVrkULnExESb/1etWuXU/oCKpDLeawAAAABUbk4nJOliVrl48wuzvX07G090dLTS0tKKLMO17T4M9QAAAAAAAJxOSKKcSUtTk9mzFVxGEkJr1qzxyn537typhIQEm2UHDhzQ5s2bbZZZEp4lTU6W55ZOnop99+7dTnfxBgAAAAAA5R8Jycriv/9Vuy+/VO+nn3Zqc1e3GoyNjXVpfcU5fPiwMjIy7K5LT09XamqqS/azcuVKHTt2zCV1VVSHDh0q9LkAAAAAAFR89EyEn7Mb+vr6ujIOuNuyZZIk/2K6KxfG2y3/zp07Z/N/SePZtWuXQkND7a5z5bGlpqYqKyvLZfWVZ0WdV+4fAAAAAICikLSs2JxuIbllyxZXxgF3q1LFo7tzdQLz5MmTpa7fE0nVktwwl11IEldUS5YsKXSdjw+NswEAAAAAqKzclhUgYVnGeDghWZ7lTyq6M4mZnJzstrqdxS9QAAAAAAB34TsnLFyakIyLi9NHH32kjh07qmvXrq6sGqWVLyHpUwEmFHEmUViSG19pEpEl2bYijKX4559/lngbbw8BAAAAAAAAvKfUCUmz2azZs2frzjvvVP369TVp0iTdcsst2rhxoyvig6sEB1v/DExMdHn1GRkZWrt2rcvrrejK0mzTliRhSZOF6enpTu+TX8cAAAAAABejEUvF5/CkNrGxsXrvvfdUvXp1Pf3009q/f7+mTJmi77//XoZhaNCgQcrNzdXMmTPVpk0bd8YMZ+R7MQcmJiq9Th2XVp+ZmamYmBiX1ukod96oSJi5h+U5M5lMRT5/mZmZCgwM9FRYgFfwYQsAAABAZeNwC8mhQ4cqIyNDJpNJDRo0UI8ePXTy5ElNnjxZp06d0ieffOLOOFFKTy+7Q5dqi+bpRre0kCyJkib57H1ZtyxLSEhQdna2zGazS2KTSEJ6iiPP2aJFizwQCQAAAADA3fghHvk5nJDcu3ev7rrrLt1///2Ki4vTww8/rDfffFM333yzfH193RkjXOBIcnVt06U6poZeT0i60tmzZx0uy82vbJk7d663QwDKBH4EAQAAAFDZOJyQfPXVV3X77berd+/eGjdunI4cOaJ27dqpR48emjBhgmJjY90ZJ0qpVvB5SVKMaikwIcHt+3N38s+Z+hNLkIh1dfze6s5eVpEcBgAAAACg8nI4IfnII49o37592rJli55//nn9+uuvOnHihIYMGaIvv/xSdevWldls1uLFi3X+/Hl3xgwn1ApKkXQhIVmGW0i6s6XQgQMHSrxNfHx8icoXFn9hE/648ngNw1BWVpZT22ZmZspsNrvt/Kem+mn16rrKyir1PFoAAAAAAKCcK1F2ICwsTP7+/tb/a9WqpWeeeUbbtm3T2rVr9dhjj+nNN99U7dq1deutt7o8WDivVlC+FpJlOCHpaMs5T7Wwy8jI8Mh+XOHs2bNauHChU9suWrRIycnJpdp/Uc/J++930rhxXfX++52KLQtUNrweAAAAAFQ2Lmuu1KVLF02YMEGnT5/W1KlTlZOT46qq4QI1y0lC0tXS09MdKpe/O3d5Hc/NlRP7OGPdunU6c+ZMgeUpKX7asCFSkrR6dT0lJQV4OjQAAAAAQBlQXr9vw/VckpBct26d9e+AgAANGjRI8+bNc0XVcJFagXkJyVjVVGBSkpejKZqPj48iIyNdUteff/7p1Ha0WHJM/vMUExOjDRs2FChz4kS4zf/791e1bsebEQAAAAAAlY9LEpIDBw50RTVwI5su22V8Upvw8HAFBQV5bH+uVpZicYar4z92LMzm/yNHIty2LwAAAABAxUADlorNz9GCgwYNsrvcMIwST/wBz8ufkPRLS5NvZqZyAwNdUndFTCqdO3dONWrU8HYYFcLx47YtJI8dCy/RNWMYBm9EAAAAAFCJVMQ8A2w5nJD8888/9d133ykszLa1k2EYWr58ucsDg2vVvNBlO1sBSlaEAhISlO6ibtFS+frlwhJrbm6uli1bZjfx6O3xGL3F1c+jj4+PNSHZrl2sdu6sqbi4krV+BQAAAACUD2azWT4+LpuuBBWYwwnJPn36KDw8XL169SqwrkOHDi4NCq4X4pupEKUqTaGKVU0FJSa6NCHpKp5MbObm5io1NbVAQtKTMZT1RO7Ro0cLXefIL1Ymk0lnzoRIktq3j8uXkGTSKwAAAACoaFasWKGmTZsqKirK26GgjHM4Ifnrr78Wum7x4sUuCQZuZBiqpRgdVajHxpF0Rnlulp2WllbmE4wltX37dknOd5s2m6Vz54IlSW3a5A3tEB8fJLM5r8WuI3XSZRsAAAAAyo6ivrenpaUpKyur2O34jgen29GeOXPGlXHA3S4kJCXPTGxTXGKxJDcfdyUpXXkDzMjI0F9//eWy+iqK+PhA5eT4ysfHrBYt8q65zEw/JSfz5gMAAAAAQGXldELy+uuvd2UccLeLE5KJid6Nx0mW5KQrkpTluTWmPWXxF6azZ/O6a9eqla6QkFyFh2dLkk6dKnuxAgAAAACKVxa/e6L8cTohWdGSORVevoRkrGoqyEtdtp1pObl161br33PmzHGq3pIo7c2V18Y/zp7N665du3a6JKlmzUxJ0unTees5VwAAAABQvvA9Dq7gdEKSjHg5YxiqqVhJF1pIxsd7OSD77N3Yzp4965Z9ufIaTiyixWlZvlmvWbPG5n+TyeTSeC0T2tSpkyZJqlYtr4XkunVHbMqV5XMEAAAAAABci7nYK4uLumwHx8R4JYyymMguSTJs7ty5dpdv2LDBqX17+3zExsY6va0jsVu6bFsSktWrZ13Yr5/DdZCsBAAAQFmXmJiovXv3ejsMwCO8/T0WFQMJycriooRkSCkSkhcniFJTU7Vs2TKntr2Yq1voFaWwmb+KYjabbf53NhFZHmRmZha53pHnyTLD9j8JybwWkklJQaWMDgAAACg7EhMTdejQIW+HAXhEUd8FXZmsJPFZsTmdkPT19XVlHHC3ixKS/qmp8ktJcUnVxSWuSsLZZGRRXaYL8/fffztU7uTJkwUSkUXJzMxUbm6u9X97x5TgpTE87SnsnG/evLnUdZ85809C0j85WbV9867BtLQIu+X37NlT6n0CAAAAAICyzemE5JYtW1wZB9zMyJ+QNNWWpFK1knRkf0Up6pcOZ34FWbNmjcxms86dO1fibYvb/+bNm5Wdne3w9kePHtXhw4eLLBMdHV3oOnvnLjU11eH9u4qzv0adPHlSkpSTY1JsbF5CMirotK56/HF1nfGhJOn8+VCbbXJychQfH6+DBw86HzAAAADgJQwzhMqkNC0XafUIC7psVxb5JrWJVU1JUohlquMSKklrQWc4+2aekZGhdevWFVvOmRugo9tYyhV3DJaknT0XzySem5vrcGvO0irsOEvynBw5ckSSFBsbLLPZJH//XLXfNE+Bycmqq9MX1tm2sD569KhWrVpV6n0DAAAAANzL2e9ofLdDfqVKSKanpystLc36/9GjR/Xhhx9q0aJFpQ4MLpavhWSKEaYMBSr82DGnqrp4vEhX3lSSk5OVnJxcZJmcnBy33MiKa9Vokb87dmEMw3AoRmeSo64+dne9KVgmtKldO121du+UJNVR3ozpFyckK8Ibk9lsLlFLWsCirF//27dvL/MxAgAAAChfSpWQvO222/Ttt99KyhvDr0ePHnrvvfd02223aeLEiS4JEC5iGKqiJPn55EjKG0cy/Phxl1S9Zs2aEpVPS0srtJXl2bNni91+/vz5Jdqfo3bt2uVQuQMHDhS6zpKsPHDggFsmvDl8+LBDrUDLgrNnLeNHpqrahbEhI3VGkpSQ4CsH8rrlyuHDh7VixQpvhwG43NGjR0lIAgAAwIpu13CFUiUkN2/erCuvvFKS9Msvv6hOnTo6evSovv32W3388ccuCRAuYjbLJKlaUN5ENrGqqfCjRz0eRkX4UlvUMVhm7jYMQ+np6cWWL6nMzEybVsnu4Kp4z53LayHZIDRGAampyvXzUw3FyUe5MptNSk4OtJbdu3ev2+NxN7PZ7FDrWQAAAAAozzzxHa28fA+E80qVkExLS1N4eLgkadGiRbrzzjvl4+Ojyy67TEe9kOxC4UwXXsyWhGSMains1CmZcnK8GVaZZPm1J6eSnBt3d9mOCjglSUqJilJGvTrWoQMSEwPtbpeRkeGWeABPOXfunJKSkrwdBgAAAACUWaVKSDZv3ly///67jh8/roULF+r666+XlPdlLCIiwiUBwkUuJJ2qBuclJM/415dPTo5CT51y0+68+2tGTExMoS0J09PTHZqYJyEhwdVhFcrb58sdLAnJxj55P06k1amjtDp1rONIJiTYT0jSyhDl3Z49e3TMyTF6AQAAgPKuIn6/heuVKiH5+uuv6/nnn1fjxo3Vo0cPXX755ZLyWkt26tTJJQHCRS5qIXmiagtJKtHENq64qXjqxrRly5ZCZ7LetWuXTpw44ZE4JPcec2ZmZrHJ1dmzZxfZ2tNd8Vm6bDfL3i9JSq9dW2mRkdZxJAtrIekJ7kh68qYLAAAAAIBjSpWQHDBggI4dO6aNGzdqwYIF1uXXXHONPvjgg1IHBxeyJCQvtJA8Gd407/99+xyuYvny5SXYnWeSM84OplvWkkfOHseff/7pUHLV0eN1JI7c3FwdL2ZCpKwsH8XHB0mSWqTtliSl1a6t1MjIYltIusuZM5ZEaKLmzZvn0X0DAAAAAEqGyXMqthIlJNPT0wu0OouMjFRAQIB8fP6pqnv37mrVqpVrIoRrXEhI1Q7NG9fsSFBeC8ma27Y5XMX58+cdLrtz584SBOc8d9ygPH3Ty8jIKFGCNH9rR0e6nhenpMnZtLQ0bd26tcgy587lzbAdHJyjevF5s5KnOdlC0lXJY8us55VlbFAAAAAAKGtIMsLC4YTkL7/8ohYtWujmm29Whw4dtG7dOuu6e+65xy3BwYUuJHXqV4mVJB3JjpIkVTlyRAGJiS7fXWZmpsvrdNahQ4cKLCssyVXS5Y4obtvFixeXqL7MzMwy18LzYpbxI+vUSVdozDlJUnqdOkqrXdvaQtKbXbYBR2zatMnbIQAAAABAheRwQvKtt97Spk2btHXrVk2ZMkUjRozQ9OnTJZW97q+w48Jz1KBKnCTpdGyEkhs1kiTV3LHDa2GVVv5fV/766y+7ZXbv3u1wfWWxK68rX1/Z2dkuq6swJpPJOn5kZK0UBV6YbTitVi2l165tbSGZEBfgUH1r1651T6BAMU45OemXyWTifREAAAC4SEk+I/N5uuJzOCGZnZ2tOnXqSJK6dOmi5cuX6/PPP9ebb75Jk9vy4MKLOepCC8mEhCAda9tdUsm6bZc+DNfeVFw9hqQjXaBPnTqlxHytSksytqY3ZWZm2oz1apH/XLiqZaulhWT9KnkzlecEBionNFTZYWGqGZAoSUqO83OorqQLCU0AAAAAAFAxOJyQrF27trZv3279v3r16lq8eLH27Nljsxxl1IWkU3hQusLCsiRJ2xr0kiTVdMPzV54mtbk41uLqTEtLs2k5VVjCzJ3nwJm6Lz4uy5iK+eXm5tp9PZdkf3ktJPPGkKwXeFqSlFmtmmQySSaTqlbLS3omJAU5XCcAAAAAoPKg4VvF53BC8rvvvlPt2rVtlgUEBGjGjBlatmyZywODi1kSSiaTIiPTJEn7IjrK7OOj0DNnFHz2rBeDs8+RJJg7blKJDoypaW9cysJYjmPPnj3OhlTA3r17S7zNxecqOTlZku15zs3NVUJCgt3yjjKbzdYWkg0D8mYAz6he3bo+LK+htZLSQpST4/k3mc2bN3t8nwAAAKj4SKAArkOX7YrP4YRkgwYNFBkZaXddz549XRYQ3OSuu7RvyBAlN22qunVTJUnHYmoosWVLSZ7ttu1KrmgheXEd9rotr1ixwqn95Hfw4MFS12GRlZVV6LrDhw87XW+tWrWc3jY/S0KysY5KutBC8oLgugHyVd5M14mJjo0j6UrumnApJSXFLfUCAACgfCCBAgCOczghebEzZ864Mg642113af9ddympWTM1anReknTkSIRiO3aUJEXa6b7rDmVlDMn8HOmynZ6eXur9OKuk52zXrl1O78vPz7FxHYty/ry/kpPzZtBubt4vybaFZGadWqqtvJm34+P9C2yfnZ2tv//+u9RxOKM0ydz83fjT0tJcEQ7KKSa1AQAAAICiOZ2QvP76610ZBzyoSZO8MQ+PHInQySuvlCTV3rhRAUVMHlLSL9cZGRnOB+iB/XgyWeDovqKjo13SEtMRlm7ZUsnPhaX8jkJmZz95MkySVLNmumok5yXp8ick02rV+mem7YTAAtvv2LFDqampJYrJVZxJ5ubk5BRY9tdff3k1iQ0AAADPo8s2UDrHjx93W482lD1OJyRp/VF+NW6cN3bg8eNhio9srMTmzeWTm6v6ZWy26LI2KYwnODJ+pSusXLnSbR+YTpzIS0jWr5+ioAuJz/xdttNr11Yd5Y1ZmphYMCHpznPg6uc9NjZWCxYssJuU5AMpAAAAADhu69atHvtODO9zOiHJl+3yq2bNDIWFZcls9tHx4+E6fvXVkqSoP//8Z/KbciwhIaFUv6oUdm2XNJl1/vx5nT9/3uk4XM1TkwSdPBkqKS8hGXghIdk+X4vq9Nq1/2khaafLdnmSm5srwzA0f/58b4fiMjExMd4OAQAAoNwpqw0egLLGlbmk3Nxcl9UFz3M6IYnyy2SSmjXL6569b19VnerVS7l+fqoSHa1Lpk+3m5R01U3DE2/Ua9eudUscziQXMzMzy/wvPIWdC2dv7idOhEuSGjRIUVB8vCTJLyrKuj6jWjXVNuUlvc6fdmoXZUZRr4vy+qPN2rVry90H6mXLlhU50RNcx1PDcQAAAADFfaeaN2+e3d5qKB9ISFZS7drFSZJ27KiprIgI7b3nHklSyx9/VMNFiwqUN5vN5SZJUdYSQevXr/d2CE6Ji4tzajtLl+2GkYkKsCRx69b9p4CPj2qE5i0/H+PZW1B5uYZRMsnJyXwQ8YDU1FQtXrzY22EAAFAmlbXvIIC3eLoxE9/xyi+nswG+vr6ujAMe1r59XrJp584aMgzp8B13aO+wYZKkNlOmKPzoUW+GV2G44ubo7husI/U7GkNOjklnzoRIkpqEnZQk5fr5SfkmtZGkatXyutQnlqDLdnZ2tg4cOFBgudls9tokOEUpyx9KzWZzketdec0tWLDAZXWVFxc/92Vp6AYAAACgIinL37tQNKcTklu2bHFlHPCwFi0SFRCQq6SkQB0/ntei7WD//kpo0UL+aWnq/uabRc667SxHEx1Hjhxx+b4d5ckxLZxN/Njbrri4PfHL0alTocrN9VFwcI7qm49LkjKrV88bJyCfKjXzWrPFJoU6XHd6err27t1bYHlMTIz+/vvvUkTtmJiYmAoz49vff/+t06c9018+OzvbI/spy5YuXVrken7VBQCg/OP9HHAtEo0VX6n7S2ZkZGj9+vWaM2eOZs2aZfNA2eXvb1br1nnj++3cWUOSZPj6av2//62UunUVEhOjDp995s0QS/2mnpaW5qJInFdcS7SyIP953rp1a6nqio6OkCQ1bpyikKS8CW0y8s2wbVGjYV6i9lRKTZV2HGJPffhbu3atzp4965F9uVt6ejqJQjfjSwkAAABgK/9n5OI+L/N5uuLzK83GCxYs0PDhwxUbG1tgnclkYsajMq59+zht21ZLGzfW0U035XXRzoqI0KaXXtKVzz6rumvWKHL1ap254gqvxJfkZAtNyy8px44dc2U4TikrrwFP3cyPHMlLSDZtet46w3amnYRkaKswBfyRqSwjULGxwapTJ90j8eEfRSXLefPHxbgmAACAu8TFxSkiIkL+/o4P5wRY0JKy/CpVC8knn3xSAwcO1OnTp2U2m20eZSURg8Jddllel82tW2spJeWfm39ykyY6dMcdkqRW06ZJ5aCVX1nlrjEkT5w4Uep6i6rfWfkTkpYZtjMuGj9SktKaNFRTHZYknT4Z7LL9F8fdSZXy9Ga4Y8eOQteRfAIAAICnrF692m4jJ3ieq3r48X0CjihVQvLs2bN69tlnVadOHVfFAw9q2DBFjRolKyfHR2vXRtqsO9i/v7JDQhR+/Lgiy+ks0WVBWboRFxbLxo0bXbYPS5ftJk3st5Ds0qWLJCm1Th01M+UlJOP3Of/jRUZGhtPbAu5SnhLTxTl58qS3QwAAAF5QFieNhPvNnTvXY/uqSJ+Z4ZxSJSQHDBhQ7GD9KNv+9a9TkqQVK+rZLM8JDdWRm26SJDWbOVNyUWLNEwm60t7YCts+JyenVPW6gitu2rt27bL5v6RjbcbFxRWyPFDx8cHy8THUtGnKPy0k7XTZlq+voiJiJEmxh0q0exuLFy/2+AzG9mb6rmhc9TotSwl5OMebE4yhaLy+AADu5IlJIwFUbqUaQ3LChAkaOHCgVqxYofbt2xcY82HUqFGlCg7ud+WVpzRtWitt21ZTyckBiojIsq6LvuUWNf39d1Xft0/Vd+9WfNu2XozUfRzt/rxq1aoS152SklJgmbe/RB4+fNjm/5LGs3PnTrvLDxzISzxGRZ1XSIjZmpDMrFHDbvm6dc5LSdKZU8GSih4vNDY2VgEBAXbXefp87t27Vy1atJBUdILY03HFxcXJx8dH1ewlgFFipX3+vP06L62dO3eqXbt2jOVURiUnJ2vZsmW65ZZbvB0KAAAuUd4/O6HkeM5RqoTkjBkztGjRIgUFBWnp0qU2X85NJhMJyXKgXr1UNW2apMOHq2j16kjdcMM/E8FkVqumE1dfrUaLFqn5L79ofQVNSLrTxcm/sqQk3TAsbxZFjQ27f39VSdIllyQoIyNDQRdaUqbbGUNSkuo0yZH2S8fjakg6U+T+16xZo969ezscb2Eq8pve/v37FRgY6LaEZG5urtauXauePXu6pX4ULzMzU4GBgQWWz5492+WJqejoaLVr104+PqXqSAE3YZxuAABQXpWk1x/duiu2Un3TeOWVV/Sf//xHSUlJOnLkiKKjo62PspyIga0rr8wbI2zp0gYF1h3s31+Gj4/qbNqkKgcPlnpfFTkh5C6Wc1aac+eq8z5v3rxC11kSki1aJMonK0uBycmSpIyaNa1l8r+h1GrrK0k6lB6l7OyCbzTnzp1zRcguVVavX8Mw7LbGLU19F8vKylL8hVav+Z0+fVqZmZnF1ulMC+OScPVzUxaf60WLFpGIAgAAAFAhlCohmZWVpcGDB5eJFhRjx45Vt27dFB4ertq1a+v222/Xvn37vB1WudC790n5+Ji1e3cNHT4cYbMurW5dnezVS5LU4qefvBFeiblrDElXKWmiY/HixU7vy5FWkK5IvJjN0oEDVSVJLVsmWLtrG0FBumHo0ALlW7VqpeDONRWhJOXIX2f3FTzn69atK3R/hY1jWVklJye7dIIfe9dEYYmwjRs3FjorYv567CUzSyo1NdWlkzCVR2UxUQoAqJiio6O9HQIAFIvPx+VXqTKJ9957r3788UdXxVIqy5Yt0xNPPKG1a9dq8eLFys7O1vXXX8/sYA6oWTNDPXueliTNnNm8wPoDAwfKMJlUd+1ahTPBgUutXbvWrfXnH4zanTfqo0fDlZ7ur6CgHDVsmKKgCwkqo359yU6CNzw8XDkR4WobsFeSdG5D8cm0DRs2WP9evXq1U3GW9BwYhqFTp045ta+Kxmw2ezsEpaWl6fTp03bXlaXuHGUpFgAAnFXYuOGAO5BUAiqfUo0hmZubq3feeUcLFy5Uhw4dCgx+//7775cquJJYsGCBzf/ffPONateurU2bNqnXhRZ+KNyddx7UypX1tGJFfd1222G1bJloXZcSFaXTV1yheqtWqc2UKVr3xht2k0zlSWne8ALj4tRk7lwlN2miU//6V6nORXp6utPbWjiS/IiNjdXx48ftrnPFm/+2bbUkSW3bxsnX17COH6l69YrYSmpR67TWnJRO7PZT52L2UdLZwEvr0KFDio2N1blz51SvmOPIryRdzXNycrRz505deumlTkRYkKsSYWXpA6FhGDp69KgaN27skf3l5ubK19e3TJ0DbyK5CsAdDMNQYmIiE7EBQCVTks/YfB6v+ErVQnLHjh3q1KmTfHx8tHPnTm3ZssX62Lp1q4tCdE5SUt6svdULmVAjMzNTycnJNo/KrFmzZF11Vd5s05Mnt9XFr/29d9+tXH9/1d6yRQ3ytborqfJ+U6m6b5+uHD1aLX75RV3efVfNfv3V2yE55Pz584qJiSlVHX8X8bxv21ZbknTppXktI4MvJCSN+vWLrLNhi7yWkYdO2J+J25syMzOtLawdvW7zj+XoyDbZ2dk6fvy49u3bp82bNxdbPi0tTTk5OQ7F4qjk5GRt27bNpXW6Uk5Ojnbs2FFsOU+Mk+oIwzCsDwCAfZmZmVq5cqW3wwAAAF5UqoTkkiVLCn0UlbxwN7PZrKefflo9e/ZUu3bt7JYZO3asqlSpYn1ERUV5OMqy55579iogIFd79lTX6tV1bdalNmigfXfdJUlq+9VXCnRyPDif8+dlcvOkDI606Dl//nzJtjcMNVy4UFe8/LKC842Xd8n06SU+F95IVLhin4UNf5Cd7aOdO/NaOHTsmJf0DHIwIRl5ZbAkaVtqa/klF/6clNaxY8eKL3QRe9dBcefRMAynWpTt379fJ0+eLLbcsmXLdPTo0RLHVZiEhATFxcU5dX4c4cqJdjzN2XN6+PBhl4yXWRgSnQAqAlpfo6Li2gYAx3l/Nho3eOKJJ7Rz50798MMPhZYZM2aMkpKSrI/CurNWJjVqZOjOO/Nm0p427ZICrSQP3367Eps3V0BqqjpMnKgCBYpQ5dAhXfnss7q0Tx9d8+CDqu7lMWlKmjBo9uuv6vjpp/LNztaZ7t01/4cfFN+qlXyzs9W4lC2qpKITpBalSUQcdMEM6YXZu7eaMjP9VLVqhho1yjuOEEu35Qa2M7eHh4erSZMm1v/rXuqrAGUqXjWUsexEqWM5dOiQ3eWOtAC0d34tSVhXt0p0lqs/5K5Zs8ZuItRVSa9ly5YVuu7EiRM6fPiwS/bjTrGxsSUaLqC4GccTEhJKG1KR0tLStGbNGpfUVZLrYPbs2S7Zp7OKmgQLAAAArkPiHa5SqoTk2LFj9fXXXxdY/vXXX2v8+PGlqdppI0eO1Jw5c7RkyRI1uCgZkl9gYKAiIiJsHpBuv/2wgoOzdeJEuLZurWmzzvD11dZRo2T281PkunVqO3myfLKyiq2z9qZNumLMGFW9kBQLjovTZW+8oUg3T+hSlJJ80Q47cUKtpk2TJO296y5tePll5YSE6PCtt0qSGi5eLJODCauKOMnStm1510nHjrHW4TTDLrS4M1q1sikbFhZm02rZ399Q62pHJEnHV5cs6WcvkbZ79+4it3E20XbxGLXe5IkWcs5M/lNS586d05kzZ9y+H2dZ9rVx40aXTmzk7i6KGRkZhc567oziEqxlRUnGbgUAAIDzGAcSrlKqhOTnn3+uVhclHCSpbdu2mjRpUmmqLjHDMDRy5Ej99ttv+vvvv21aYcFxISE5uvbavNaic+YUPIfnGzfW7vvukyQ1nTVLVz73nMJO2G/ZZsrJUZPZs9Xtv/+VX0aGYjp21M45c3Sme3f5ZmWp67hxqr5rl8uPwZFfbEpyY2z75ZfyycnRmW7ddGDwYMkn72VzpkcPZVStqqCEBIeTq3///bfHbsonCnleXG3r1rwJbS69NK+7tm9mpkIvJJqMtm2L3d4ygdL+g9VL1Or24jEXS9vt+OLnxd51dPFYsxeXubgOs9mspUuXOrxPT8st5fAJ0dHRLoqkcGXhHPn5lXz+t6SkJJ04ccLh1s+LFy8uMy1xLQzDUJxl+AU71zYAAADKvy1btng7BFRSpUpInjlzRnXr1i2wvFatWjp9+nRpqi6xJ554Qt9//72mT5+u8PBwnTlzRmfOnHHJLMaVzU03HZEkbdxYR6dPhxRYH33rrdrw8svKrFJFEUePqtdTT6n7m2+q5fTpqrp/v2pt2qSu//ufrrvvPrX78kv5mM06ftVVWvf664o2m7XxxRd16oorZDKb1fm99+TvhXHmikpy5E8yhZ04odpbtsjw8dGuBx+0mVHb8PfXsb59JeUlZ70pJyenQDLDE28sKSn+OniwqqR/JrQJO3FCJsNQVni4VLt2sXU0uizvnK7L7KLwI0eKLb969Wq7y13d/dfeNZKYmFjiOopKSP31118lqq+wZHtpknbZ2dlO17ezFEMvONPVw942pU2q5peRkVFgmdlslq+vb7HbXhxHSkqK9uzZ4/A5ysjIKFdJvrlz53o7BAAAALhASRuyeLLLtiv2lZqaqj///NMF0cDVSpWQjIqK0qpVqwosX7VqlerVq1eaqkts4sSJSkpKUp8+fVS3bl3r48cff/RoHBVB/fqp6tLlrAzDpLlz7bc0PXPZZVr20UeKbd9evtnZqrNxoy754Qdd+fzzuuw//1HdtWsVmJysjKpVtfPBB7X16adl+PtLykvkbX3qKaXUravg2Fi1L+F4lMVxZQvJjhfGJTvbtavS7CTfj9x0k3L9/FR9715V3bvXoTrd0eLLMsu9p23fXkNms0kNG6aoRo28ZE74hZaKyY0ayeRT/C2m7aVJkqRN6qKwv4s/BkuLLXezN+5mccmvstidujiOTjzj7ZaK9qSlpZV6VmyL5ORkLV682Pp//uP1KeY6Pnv2rM227uSq5+H8+fMuS4A6Mn5keUq2AgAAzyuLnzVhX3HPVVkbYzI7O5uGamVUqRKSDz30kJ5++mlNmTJFR48e1dGjR/X111/rmWee0UMPPeSqGB1iGIbdx30XuhejZPr1OyJJ+vvvBsrOtn+ZZFavrjVvvaXl772nvXfdpaQL3eSzQ0N1/KqrtP7ll/Xn5MmKvvVWm5aFkpQbHKwtzz0ns4+P6q9YoQZFdGuVJP+UFLX46Sd1+OQTt3Tzzs9yAw1ISlK1336TJB290BLyYpnVqulk796SHG8lWZI32/zjtxWVDCvsy76r3gwKi3nLlrwWkJ06/ZMktIwfeb5hQ4fqrlEjQ42qn5MhHx36O1dyY+KiqHPvyPNSklmjLfcgFH5uSztWpSuTXEXFUtw4ijk5OdaWpqV5zXnyelm6dKlLxpp0JOaYmBgtWrSo0PW0tiy5svZBHygprmEAqLxc/R7Ad67yq+QDY+UzevRoxcXF6fHHH1fWhclNgoKC9OKLL2rMmDEuCRDeceml51S9erri44O1cWNtXX55IZNPmExKatFCSS1a6MCQIVJurkxms7U1ZFESW7bU/rvuUqvvv1e7SZN0PipKSc2bFygXkJCgf734onVcwoZ//aXd996rw7ffXiDR6ShHblrNfv1VpuRkJTVtqnNduhRaLvrWW9Xwr79Ub/Vq7T92TCnFJOJKcsPM/yV+wYIFatGihcPbulturrRuXR1JUo8e/yQ2Io4eleR4QlKS2nU7r6MLa2vl+W4aumOH4jp2LHE8jozV56jSTJCR/w3W1W+OnvoCV9bf1M1ms+Lj4xUYGOi2feQ/B7t27VLTpk0LLZv/eck/dEJGRoZCQ0NLFYM7n/Pi6s6fiM3MzNTaC2Pl7tmzx275tLQ0hYQUHOYjf8LWnosTyxkZGQoKCioyNgAAAHiHu7+TFFf/mTNndP78+TL13RjOKVULSZPJpPHjxysmJkZr167Vtm3bFB8fr9dff91V8cFLfH2l3r3zZjFesqTw2crtbehIMtLiQP/+imvTRv7p6er54otq8scfNi3kqu7bpyteeUWhZ84ovWZNneneXSazWW2nTFGnDz5waJZve4pKuOTm5sovJUWNLsys/N0Vr+n+Edfr8cf76JtvWuvNN7vrrbe66dChvJnZk5s00enLLsuLy86s8yXZd0kcvZD4K4o73yz27auuxMQghYZmqUOHeOvy8BK2kJSkDp3ztp+rm9VwYeEtqRyRv/toSVo0WpjNZq270FW/MDExMXaXF/bcXtyl9cyZMy6dCdmitM+3I9dUWZCUlKQ1a9Z4bf9Ftcw84sA4qI6aM2dOgWWeTBYnJSVZ/87MzFRaWpok+8MZSK6JzTLBD1DWuLJFNrPCAwBQuOI+U8bGxurkyZMeigbuVKqEpEVYWJi6deumdu3aubXFCjzrqqvyBrfduLGO4uLc1FrF11frX301b+bt7Gy1mzxZfe+5R93eekvd/vtf/euFFxR+4oQyqlXTmv/+VxteeUU7Hn5YZh8fNVi6VFe8/LKCC0kOFaWom1xaWpoaLVwo//R0pbTppv/MH6y4uGCdOBGuX39tro0b62j9+ki98cZlSkwMkCTtvu8+mf38VHvzZtUpZsZtR760O1Jm+/btkvImWvHGDXn58rxxYrt1Oyd//7x4g2JiFHLunAwfHyU3buxwXZ06xSjQP1vRaqpzq1IVUoJJsYqaXXvJkiU2/xd1XhdcSEA7Yq2Ds6pf3MrO4tChQzp+/LjD+yuszqKWOSM1NdUl9VzMVfG5MsFe3IRCRcVcWBdje9skJCQ4HJOnW6YWdj6zSvBDjyMxb9q0qdgyu9w8FAdQWq4cWmDdunVlviU6AEhlv9cMyh9X/YDN0B8Vg0sSkqiYGjc+rzZt4pST46NZs+xPbuMKOWFh2vDKK9r+6KPKCQ5WwPnzily/XpEbNshkGDp+1VVa+sknSq1fXzKZdKRfP639z3+UFR6uavv3q8/IkYpavNg6MU5pb04+2dnW8SD/r8Xnio0LVkREpoYN26M+fU5oyJB9qlcvRUlJgVq0qJEkKa1ePR267TZJUsdPP1VAvpZFF3P1G3tycnKh69x1o87M9NHy5fUlSX36/DMrW+0LE+sktGypnLAwh+sLCspV5655LQZ/Ne5QswtjdzrCFQMU//XXX9bWLyWdSTu/op7bmJiYUs8IXZLns6gusq6ov7zYu3ev3VaLltZ+rlDUeXP1ZC6uvH/k5ORor53JuCwTR7lqX47Uc/jwYZfuEwDcKTs7W7t37/Z2GECFwmcAXKyocegr4veWyoiEJIrUv39e17yFCxspNdX5IUdnzWqioUP76uGHr7aOO2jDZNLRm27Swu+/18p33tGu++/X/kGDtPKdd7T1mWeUHRFhUzyuY0etGjtWic2ayS89XZd+8om6jh1bZCLQUfWXLlVQQoLOVG+iD5ZcKkl69NEdGjTooJ59dovuumu/Bg8+IElatKihtYf5/qFDldywoQKTktT53XcL7U5eEd5sV66sp5SUANWunaaOHf9poVpr82ZJ0rnOnUtc5xVX5LWKnKn+ivrrLwXGxxezRckV1iouf3IqOjq62HocfQPM/1yfP3/e4ZaVhw8f1tmzZ4utsyiWFp9Hjhwp9czkubm5NmMjOhtTfs58iDCc+NEhLi7OoSRz/mM4d+6cQ4nEM2fOlCrhaDmnF/+oEB8f73SX9JI8F2lpaTpw4IBT+yntvlHQjh07imzxDaDsSE9P16FDh7wdBuB2vLejtNxxDRmGIR8fUlkVQakmtXn22WftLjeZTAoKClLz5s112223qXr16qXZDbyoS5dzioo6r+PHw7VgQSP171/yD1/bttXUV1+1kySlpgbo3Xe7aMKEJYqMLNiyzezvr4RWrZTQqlWx9aY0bKgV//d/avb772o1bZrqrl2ranv3av/zzyulQ4cSx5kXgNnaOu/Tlv9R8lqToqJSrMkyiyuuOKVJk9rp3LkQHThQVZdckihzQIC2PPecer70kmpt364u77yjTS++KPNFY2p68o3dXb8czZ/fWJLUt+9R+fpe2Fdurmpt2yZJiunUqcR1dut2Vn5+udqb01q7slup9bffauvTT7so4jyOJI8cacVoOa8Xn9/8z62959nRmZiPHTumgIAAZWdnq0GDEozhasfhw4dVt25d1ahRo9iylriWLFmiK664wrrNjh073DLmpauGLyisXGxsrHJyckr8mlu3bp169uxZbLkNGzbo2muvLTIGe3Jzc2UYhubPny8pbxKX/NLT0ws930VN+FLS5Ghx16Ernx8ULy4ujl/7KxFadwAVD++JgGs48hm1JO+hvDbLrlKllbds2aLJkyfriy++0LJly7Rs2TJ9+eWXmjx5sv766y89++yzat68OV0ayjEfH+nOO/NaSc6c2VzJyY5PWCNJaWl++vjjvBmTe/c+oVat4pWV5avp04tPODrE11eH+vfXivfeU3LDhgpKTFSHV19VjzfeUIQDLd0u1njePIWfOKGskFBNP9NPknTTTcd18Q8wgYFmde2aNyj92rWR1uXJTZpo/auvKtffX5Hr1+uKMWMUeFHrtPKekIyODtf+/dXk52fWtdf+05qn6r598k9NVVZ4uBLtzJZenJCQHHXvntcq8DM9rqi//1aNHTtcFrejimoJaFHUec2/bt++fYWWK+w6iI+PV25uruLi4godV2/FihUu7XJsT/5xBHNychw6L4Xx1oeANWvWFDmkgSv8+eefJX6d7d271+7ESY6cp8JmuJZKPsadKxKSZUF5ibM4JKeA8qOi3HcAoCwq7h5rNpvd9rnJbDYr3g099WBfqRKSt912m679f/a+O0xu4zz/xWJ7v94r78gjeazHTooiRVFUY1wUq7jEsmM5SmLFcdxiJ7Id27/Ylovci2Q5LoltuSU2qUaxiEXsvZPXeP1ur9/2AuD3BxYgFgtgse3uSO37PPvsLspgMJgZzLzzft93993o7+/HqVOncOrUKfT29mLr1q147LHH0NfXh40bN+JjH/tYpvKbwwxg06Y+1NRMwePR41e/mp/UuT/72QIMD5tRUuLFP/zDefzd310EABw4UIH+fnPG8jhVV4eD3/oW2t7xDtAkieLTp3HnRz+Ktf/2b6jbsQPOa9dAKCjfiHAYFfv2YcF//RcA4E/bPouOG3kwGBhs2dIvec7ataxq8vDhMgj7zNFFi3D8c59DyGpF3vXr2PjxjyNfQMpPh+oomwPlPXvY6NmrVg0iLy/EX6/80CEAgGvZMnCySbkXhdz2Bx64AQD4Ffl+TMKOpd/5DvRZJpTEUKMyk8u/sNxHRkZSilr95ptv8mSjOLgIQRDo7OzExMQEgsFgwnzt3r076esL8dprr6V1fqaR6sCDYRhMTk7KRoeWO0ct1KQr9HVKUZSiElfpPjPZtnt7exMfpIBsmeDkkEMOOeSQw62I23FhKfdezmGmIdWuklVIJnOsx+PBm2++qfr4HNJDWoTk17/+dXzpS1+CXeDfz+Fw4Atf+AKeeeYZmM1mfO5zn1MVYTOH2QuSZHgi8bXXarBrV5Wq8w4dKsOuXTUgCAYf/ehZmEwU5syZxIoVQ6BpAn/8Y/IqOiXQej2ufOAD2PeDH6BvwwbQGg0KL1xA8/PP445PfhJb/vZvseI//xOLf/ADNP3iF6h5+WVUv/oqWr76VWz94Aex/NlnQYbDGFy1Cs+Nvw8A8M53AjabdHCQ5ctd0OkoDAxY0d1ti9k3smTJTdXm2BjWfvazaPrFL0CKTDOzjUwNjLjBSCikwRtvsMFstmy5GSWaCAZRuX8/AKB38+aUr9PcPIqqKjd8lAnP2Z6C2eVCy1e/CiJJdd7g4GDKeVADNWrBc1HzdSGEzyPVAZ5UsBqxr0rOf2SyAX/E9SWZaMvJIh0fksnuA1jlqZJiNdn0hOAiaR84cED2mN27d8Pj8aSUfjLHJ1rR3bFjB/9bLgI4d61ELgg8Hk/WJirZVrbOVuQmfjm8VZCr6289ZDrI22xErl6nh1z55cAhZ7L91kFahOTk5CRcLlfc9uHhYX4y4XQ6szqpzWF60Nw8ine9iw1+8MMfLsbu3cqk5I0bNnzve0sBsCbfzc03J8kPP8yms3dvFYaHTRnPq6+8HKc/9Snsff55XHnvezG4ciVCFgtMY2MoO3oUNa+9hsY//hGLf/xjLPnhD1F++DAMk5MI5OWh9a//Gr9/6Mt4Yz/rt++jH5XvvMxmCkuXsgFdDh8ui89HWRkOPfMMejduhIam0fjHP2LTRz4Czc9/DiKFCMjJIF3lkxwOHSrH1JQBhYV+LF9+M5hNyaFD0Lvd8BcWYnjpUn47yTmYVAmCAO6//wYA4Fv6T8FjdKDw4kU0P/dcUukMDAyoHviK1W3JvLAOHz6c9LlutxsA0N8vrbzlYBcFchJD7lpvvPFGHGmZjDIwG5jpQUCi60cikbj6IqVATZQW92zlIHwuUoSbXNAehmGwc+dOyeuLlZZSUbNTxUw+t4GBgcQHRTHT9WsmcDuqcHLI4VaCXOC5HOSRrFsRIaTcnOSQQw5vXeT8MN8+SCuozdve9jZ88IMfxDe/+U2sXLkSAOvk/xOf+ATe/va3AwCOHz+OuXPnpp3RHGYe73nPVYyNGbBnTzW++92lOHmyGI89dh01NbGT8DffLMN3v7sUfr8WixaN4L3vjVUlNTWNY/HiYZw/X4Q//nEOnnzyYlby6y8qQtvDDwMAyEAABRcvwtLfD53HA53HA/PwMMhAAOPz5mFk8WKMLVwIWkPi+X9fBoYhsHFjL1auLMeuXfLX2LChHydOlGLPnio8/PB1iPk3ymzGmY9/HP0bN2LRj38Ms8sFfPSj2FJYiLaHHkL33XeDNhji0u3t7ZWcZKudeHNkRyY7aoYBduyoAwDcd98NkOTNvFRHyZKubdsgLIRUrn/33T34/e8bMThqx9P3/Abfev0B1L76KtzV1bjx4IOq0ujt7cVkNOK6XJlxwUHSjUCdLN544w0UFhZmLL329vaM+ZOc7hf7+Pg4XC4XiouL0dnZibq6urhjuOeXrg9LpXvr6+uLIyDPnDmT8vXkoCZgks/ni8urUMkors8vv/yy5PZbFdx9aLVpDU/i0swNWnOYbbhd2uxbFWLF/aVLl7Bw4cIZys3tDykBTA7Tg9nUV+3YsQMPPvhg7p1+G+Ct9AyDwSAuXryIlpaWmc7KrERaI/6f/OQn+NjHPoZHH32UnyxqtVq8//3vx7PPPgsAaGpqwk9/+tP0c5rDjEOjAZ566hwKCgL4wx8acPhwOQ4fLseqVYNYtGgELpcZly4VoKPDAQBobh7Bpz99Koa44vDww604f74Ir79ejYcfbkV+vrQaKVOgjEa4VqxIeNzxYyW4cKEQOh2Fv/mbqwDKFY9ft24Azz8fgstlxtmzxWhpkRgwEQSGVq3CyOLFqHn1Vcz53/+FaWQEi37yEzS++CJ6tm5F38aNcFdVgYueI2XumwwSKbVSwenTxWhvd8JgiGDbtpvBbArPnUPelSugtVp033NP2tcxGCi8+93X8P3vL8ELR7bgkUefxJrf/AjNzz8PWqdD97ZtqtLhzJXlzJYPHDiAeyTyO5sGXmrQ19enSHRx95+IlJFTBGYCXJmGw2FotdqYfExOTqK4uBgXL16UJCQ5nD17FtXVrP9Sqfu4cOEC1q1bF7ddeCxN0wiFQtDr9XH5EyskperBa6+9hq1btwJgAwulCrk6xjAM9u7dyy/wJXNuNpDoWgzDJDTrFmJwcBClpaWKx3BIVl2thJ07d2L79u0ZSy+Htx5utfdCDtmF0PUFh46OjhwhmYMiaJoGRVHQ6ZILEJrD7EDu+U0v1Lx3bxVSMxgMor+/P0dIyiAtk22r1Yrnn38eo6OjOHPmDM6cOYPR0VE899xzsFgsAIClS5diqcCEM4dbGxoN8N73XsM3vnEIK1eyfvqOHy/FCy80Y8eOenR0OKDR0HjooVZ86UtHYbdLm+svWjSKpqYxhMMk/vSnxL4k+/os+N//rceJE8XI1rxgdNSAH/xgMQDgr/6qA8XFif3vGQw0Nm9mzaP//Od6xWMpoxEdb3879jz/PM4/+SR8RUUwTkyg8fe/x6annsK2970Py595BsWnTgEqlFRKGB5mzakz2VH//vfsc7r33q6bz5Vh0PSrXwEAbtx7L4J5eRm51pYtPaiqcsPt1uM/PR9H5wMPgGAYLPnBD9D0y1+mXT4Aq7gLh8Nx5C2nrEwEOXOtTJW52nQSEY3cC72trQ3hcFiWvNy3b59kOqkE5pHDrl27UvbvOTAwAK/XK7tfTulKEETMoEbq/hmGQWtrq+L1GYZBKBTin/vExISKXMenoQaZbLdKZZYNKF3v+vXrCc9PhvjJKWZyyCGHHHK4VdDR0XFLBsrI9oJMd3f3tFsrpYL29va0FqNzSA1q699sXji8VYjTmULKhGQ4HMaWLVvQ2toKq9WKxYsXY/HixbBarZnMXw6zFA0Nk3j66RP4znfewEMPteKOO/qwcWMvnnzyPH760z14//uvSiojORAE8Oij7OR0585atLc7ZI89eLAcTz11J/7rvxbiS19ajeeea844Ken1avGVr6zExIQRNTVTeOQRZXJCiO3bO6DR0Dh7tghXriQm5Gi9Hl3334+9P/kJTn3ykxhasQKUXg+9242KQ4ew+j/+A9ve9z4s+8Y3UP3qqyg6dQr2jg6YhofRef58OreZMnbs0ODy5QJotRTe/vZ2fnvJsWPIu34dEYMBbe96V8auR5IMPvQh1pT/pZfq8Yc7P43WaPqNf/gD1j79NKxp+smkKArd3d1JB37hkE7gnJGRkZTP5ZDsCzoUCuHEiRO4cuWK5HFSwXIA4Pz58wn9+anNC03T0GhiXzvJ+Dy8eJGtE0rBY8RQMwhQk3/OX6hawloJ3d3divuVyNFkB1x79+5N6vh0rsVdT868PpX0pJRIAFuXsulTTO66bxXI9QdvVeQiymceb/X7z+GtB4qi0nI/c7uio6Mj68EoMwFOIZmDeqTTzwvH79NN6GX6/SSe++QQi5RNtnU6Hc7PEDmSw+xBXZ0bdXWpBVFYvnwYGzb04dChCnz720vxla+8Cav15ouaYYA//WkOfvGLBQCA/PwAxsaMeOmlOmi1ND74wcvIRP/kcpnw1a+uQFubExZLCJ/5zAkYjepfOKWlftx1Vy9272Z9az777AFV5zNaLfrvuAP9d9wBIhyGo70dFQcPovKNN6B3u1F54AAqJYgXT1kZpurrMVlfj6n6emiWLWMZXonCyEQH7vFo8clPsl3F297WgYIC1rRX6/NhUTTYzI23vS2hOjJZk8lly0Zw55292L+/Et/4Rgsqv/0BuKuqsOT730fhxYvY+E//hPZ3vhOdf/VXCCkEgMkE+ZcppPs8pF6QU1NTsNlsEkfHnxsMBhXzMB0DrWR9A6YyKOjr60NFBRsNnqKoGNPiVJ9BoujVmQDn+1Uc/ToT0dmTgVSU7WTwyiuv4N57782qWZNSmYTDYbz++uu4//77s3b9bECs5p0p+Hw+7NmzZ0bN3IeHh0FRlGoT/xxyyCGHHG5NJPvuy/mFvvWR7PO+1ZGrr8pIy4fke9/7Xrzwwgv46le/mqn85PAWw9/93UVcuFCIri47PvaxjXj88SuYP38MHR0OvPRSLU6dKgHAmlB/4AOXsG9fFb773aX485/nQKul8Z73XINWm1xHxTCA261HX58Fe/ZUYe/eKkQiGthsIXzxi0dRXp58gJDHH7+C06eL0NdnxXPPNeOf/ik5H5CMToeJpiZMNDXh8uOPw9nWhtKjR2Hr6YFxZATGsTFofT6QkQisAwOwDgygXGD2QWm1CObnY6quDmGzGZpIBGQoBIPfD/j9CDqdcFdXY2jVKozPn59U3p5/vhl9fQTKyz149NGocothsPD552EaGYG3tJQPHpQs7Ha7ZLRhDk8+eQFXruTD5TLjhz9cjE9+MoKxpiYseu45lJw8ibm/+x3m/N//YXD1avRu2oSxBQsQibqL4NDR0ZFS3hJB6gWZyWA1Qrz++uu870Kl6ydS3lEUpeibT60yT0j4qYFUXhO9nIeHh9HV1ZW0Ty6apnH69OmY/KnxhTgbkAx57na7YTQa+f/ZVnDJmUfLXVdtlHsh3G63pFm3lO9JpfulKErWNN/n8/EuZXKQxmxoD93d3QiFQjlCMoccVMDr9eb6tVkENW50biXcCguh04EcqTS7MJvrihi5uqOMtAjJSCSCn/3sZ9i9ezdaWlriXobf+ta30spcDrc/HI4QvvCFo/jqV1dgaMiCr30tNvCMVkvhgx+8jAcfvAGAjcDs8ejws58txB//2IgTJ0rwnvdcw5o1g5JqyWBQg/PnC3H2bBEGBiwYHjahr8+KSCRWOr1o0Qg+8pFzKCuLJSPVdiB2ewgf//gZ/Pu/r8Xu3dVYunQYGzf2qy8IARidDu5FiySJQ/3kJOwdHXB0dsLe0QFnezssAwMgIxGYXS42ircMSk+cQOMf/4i+O+7AjQcewFhTEx9ERw779lVg374qaDQMPvrRszAY2En+nD/9CdV79oAhCJz7p38CZTQCKRAQK1euxJ49e2T3WywRfPKTp/Cv/7oehw5VoLbWjYcfBo4//TRKjxxB4x/+AGdbGyoOHkRF1K+Lt6QE7upquKurMVVbi8iyZXDbbJIK0kQw9/ej5MQJlJw8CYYk0fnAA3DJBBwpLCxUpVRMBYFAIG7bkSNHklYw0TSd0Fei8Fg5SBF+w8PDGB4exoIFCxTTVTuA8Hg8GBoaSpqQnM3+fVIhRr1eLw4dOsT/n5qawrVr19DW1pawrFPNhxTa2tokt9+4cUN1GkqLDwBLSPb3x/ebQkJybGwM+fn5qq8pxMTEBA4dOjTrAtyMjIxItnEO4XAYJEnmTH5mELfSxCeHtx727t076/q1HG5vDAwMwOVyYcmSJRlLczaQNsPDwygqKprpbNx24N6hiYQRcpgNdSMd3Or5zzbSIiQvXryI5cuXA4h3Vp8r+BzUYs6cKXz72wfw4otz8fLLtQiFSJSVebBw4Rje+c42VFbGBkl4+9s7kJcXxHPPNaO7246vfGUl6uomcdddPSgsDICiCAwOWnDxYgGuXMlDMChdzfPzA2hqGsP27Z1YuDB9c8xFi0bx8MOtePHFufjud5fCbg9h6dLUzIUrKirgcrni/BuGHA6MLFuGkWXL+G0FNht87e0wu1ywd3RAE4mA1ulA63Qg8vPhB2AaHkbelSs8cVdx8CAC+fkYaW5Gz5YtGFmyJI6cvHgxHz/4ATvQePjh65g/nzUjLT16FPN/+Uv2mCeewGhzM4gsTtbmzZvA449fxgsvNOO//7sJNA08+mgrBtetw+DatXC0taHyjTdQevQozMPDsAwNwTI0hNITJ/g0KK0WgYICBPPyELZaEbZYELZY4KirQ73Ph7DFgojVCq3XC9PwMCwDA8i/fBnmaHAgDsWnT+P4Zz+LoTVrsna/ycDnYwn0bPS3Z8+ejfmv5PfI5/PxLjwWLFiAgYEB5CUR4IgbqPT29mJoaAgtLS0pm+RwpJfQB54SmXD58uW4qNuZwNiYAcEgGbPIkQoheerUqbhtHo8nrWd+8uRJVcepIWGuXbsmub2npwf19fUZJ9HefPPNuIm3mnxK1SeapkEQxIyPV/r7+xWDJO3fvx9z5sxRjEKfScx0eXCYLfnIFnIkZw455HCrYmpqKmOB5WaLuxIAOHr0aI7cF6Cvrw96vT5jJO3LL7+cdPnOlrqRQ/aQFiG5b9++TOUjh7c4LJYIPvjBy/jABy4jFCJ5JZ4c7ryzDy0tLvzv/87BX/5Sh85OB154QTowTmGhHytXDqG+fhKFhX6UlPhQVOSHwZC8oi8RHn30Ojo67DhxohRf+tIqfPzjZ7BunXJAEDmoncgzOh38xcXwFxdjtLk5Zp/ZbOZJqxsPPICOt78ddTt2oPToURjHxng/lb7iYvRs2YLue+5BoKAAJ08W45lnWhAKkVixYgiPPMIuOBSdOYPlzzwDgmHQtW0bbjz4IJuHFF8W3IRzy5YtikrJt72tE6EQiV/9aj5+/esm0DSBxx67DoIgMNnYiMnGRlx64gno3G7YOzth6+mBrbsbjvZ22Ds6QEYiPFEphpLWiiZJjC1YgKFVq+Bob0flG29g2Xe+gwO1tUBVVcr3mykolZkYyT6jRCa3QoJSfF9iwkt47a6uLphMJsk0z5w5A4PBEJNuqsE1Xn31VVXHtbe3o6mpSXKf1CBZzTM8erQUX/taCyhKgyeeuIjt2zsBpEZIKp0j3CcOPDQ0NISSEtblxc6dO/FgtK0CN4nsTEOYnytXrqCysjLGrHwmIUVIvvHGG5g3b16c+4FUI5MPDQ2BIAgUFxcDYNWjtbW1qs5VmpBFIpGUTOBvR0QiEYTDYZhMJskgWbcycn7Rcsjh9sat2r7l3k2BQABtbW1oaGiYFfm53a89E+jo6IDdbk+JkMxkfZdL61ZtUznEIi1CEmDN437yk5+go6MDv//971FRUYFf/epXqKurw4YNGzKRxxzeQiAIJCQjOVitYbzvfVfx9re3Y9euapw/X4hgkARBsCRkY+MEFi8eQU2NOyPBb9SAJBn867+ewte/vhxHj5bhq19dge3bO/C+911NKlBOV1eXan9AyXTGkw0NOPuxj0ETDCLv+nWUvfkmKvfvh9nlwrzf/Aa1L/4Jn6v6Lr7e9QAYaLBs8SA+93d7UHDpBioOHED166+DYBj0r1uHC08+qfq6iWA2mxMe8653tUGjYfCLXyzAb387D62tTjz55AWUlNxUkYZtNowuXozRxYv5bUQkAuPoKEyjo9BPTEDn9ULn8UDn9aLEYIC7u5vfFjGZ4CspQaCwEOPz5mF83jxQRiM8Hi08LSQeGhxE/tWraHnmGdz41a9i8kcQBHw+H+wKAXZmEjRNZzRy7iuvvJLSef39/YoDG2FUcEDZBDuVgWEy7SUV35derxY/+MFiUBRLlPz85/OxZs0AiooCaROSer2eLxdxPsT+J8+dO4d77rknJo3XX39d1T0o5SeZ/XIYGhrCyMhInDm+UqCaVMkazoes1Pk+n0+yTahVkIrR2dkJrVbLE5IXLlxQRUimG3DpdoTw+XMRz7dv347Ozk50dHRg27ZteOmll3DPPffELGJMR36ygVAohNdeey2nzHmL4+DBg7jjjjtm5NoURYEgiKRJ/r6+PthstrTHPrfbAsPtDOGiptvtTju92aSQzGH6kKmx6K2A2+Eesom0CMk//vGPeN/73of3vOc9OH36NIJBNvru5OQk/vM//xMvv/xyRjKZQw4c8vLy4iLQ2mxhPPRQOx56qH2GchULnY7Gpz99Cj/72QLs2FGPHTvqcfJkMf7hHzqweHFXxsnRVCaxtMGA0UWLMLpoES5/4ANwHDyNU3/Q4nv9f4P2Lnal8+/wY3zn/EdheCIUc+7QihU4/fGPg0nBB0gi5OfnK0YzfuihdhgMFH72swU4daoEH/lIAd71rjY8+GAHzGZpwpfRauEvKYE/qhYTglywAJcvX5a9HkUR2PnnOvz61/Pg92tx4K9+jRf67oSzrQ1Njz0G6qGHMLRqFaio4m9oaGjWBmFIFPAmHSSqg8m+iK9cuYK2tjbodDpFZdjhw4eTSleM0dHRlPKnhD/8oQGTkwZUVHhgtYZw7Vo+/vKXevzt315Om5DkylmN83epfUp+CtWmkS6uXLkCjUaD/v7+OEJS6Xo7d+6MIWuExyqdd+nSJQA3zbPVIFVikGGYtCfUMzVo9Xg8sFqtSZ0j9AVF0zQuXbqERYsWZSN7MRA+n9tFOXq73EcyUKrr586dy6hvuplCKBRCKBRS3baUXDdkG2fOnIFOp0u63C9duoS6urq0CMlAIIDXX39dlpDv7e2V3N7W1oa8vDwUFBSkfO1UQdM0GIZJyR/erQZxW92zZw8aGxszlr7SYuRswltx0TAUCqG7u1uyX5jNzyqHWwtpjZy//OUv48c//jGef/556HQ6fvv69etx+vTptDOXQw5iTIcSIhMgSQZPPHEJn//8UTidAQwMWPH004vx2c+uw9GjpYhEEr/UkiUPpCD38mQYwOUyYc+eSnzmi5uw+Ydfxj/3fxHtaEC+fhI/sv8zfoS/hwEsGRmy2dC9ZQuOfe5zOP5v/wZG0N4zmb+ampqE5zz44A1897sHsHDhKIJBLf77v5vwd3+3BT/5STMuXsyHRHDdlNDebse//MsdeOGFhfD72bWb/9mxFP/9vm8j6HDAeOMGWr75Tdz32GO48yMfQeNnP4vF3/senF/6Eub+5jeo//OfUfX663BevcoWONKbbNzKL35Omcfh3LlzCnWTiQmgojTYF6vbEgVNEYMjo5MpWyV/k+Pjeuzcyfr5e/zxy3jkETaA0K5d1fD5yJQISY/HI3lsIkVBOvUlm3Wtra0tbdPUsbExDEm4X+AgJm7Fv7MFOdIzEAjE1E2xb2A1kHMdMDIyErdIlwr27dvHk2Jqno3X641ZdKYoKqkAR4kw28yXsx3FPodYZHMBLRHGx8dlg3gli46ODhw9ejQjaWUbkUhE0Ve0WjAMgzNnziRFslMJBm5nzpyR3N7R0cEvLE43rl27huPHj8/ItW9HJNMf3g59Z7oL6tOFbLn4SQZy4wEpS5qZwGwOpnmrIC2F5LVr17Bx48a47Q6HY0ZX+XLIYbagpWUYP/rRPvzhDw3YsaMely4V4NKlAjgcQWza1Iu77+5BTY20uUOiAVoi0DRw+HAh/vSnZrS1OaHRMHA4gjCbI+jpscLrjSVWSkq8uO++Ltx33w2YTFuwa2olGI0GlF4PWqtNGJF7OlFZ6cH/+3+HsW9fJV58cS4GBy146aU6vPRSHazWEBoaJtHQMIGGhgk0NrK+Q9XMbWkauHChEK++WoMjR0pB0xpYrSG8//1XcOFCAQ4cqMS3D/4VSn9kxtJ9e+HYsQOWwUHYu7uB7m5wa/RincBYUxMuffCDmJDxVagGt8MATAghKSO8NzHJqNFoVLeF/fv3JzwmEonwCxuplKmc/0sA+M1v5iEY1GLu3HGsWjUEhgEqKjzo67Ni794qVFR0Jn09IYQDsmRVqcLo6mqJnlSIs3Qgzpfcc+/p6VE1xhgcHOR/TwfBJTQ55MyMAdaUe2BgAHfddRcAYPfu3XFKoFRN1lpbW2EwGJIKIiWH4eFh3u9oIojJBqWyjUQiIEkyK+WfyTQpioJGo5lVRGgO04/R0dGk/OIJlcKDg4M4efIkli9fjvLy8llHrA8PDyMSiaCsrCxr19i5cycAYNGiRWkrxnfs2IHt27fL9o8zWb7hcDijbnDeyphNbWS6MFNEeg6ZR47zSh9pEZKlpaVoa2uL85F06NAh1NfXp5N0DjncNrBYInj/+6/ir/96GL/7XTH27avExIQRf/7zHPz5z3NQUzOFFSuGsHjxCObNG5c1PVaLcJjA6dPF+O1v56K93Rmzb3LypsJUo6FRXz+FlSuHsGlTL0pLfTGkXSiLvhAzMfjQaIAtW3qxcWMfzp4twuHDZTh6tBQejx5nzxbh7NmbfgodjiCqq90oLvbBbg/Bag1Dp6Nx4oQD3d1zEAqRuHHDjrY2B4aHb/qzXLeuH08+eQFOZwjLlg3j8OEyXLhQiP1nG1D0xByc2r4dhtFRODo6UOLzwT80BL3fD9Lrhdbvh97tRsGFC8i/ehUb/vVf0f72t+Pau98NOoWozkpqg1txMCecXMjdWzb8Cu3duxdbtmyRzUuquHw5D6+9xip8P/KRHpScPoXikyfx2CIC3+h7EC+9VIf779+nyOurzYeUybb4XC74B4erV6+qvRUemVS8CaF2EskFJhoWRbsnCIKvM0plJqxXDMOoLt9U2lMwGJT1gaZWzSqnrkx20sswDILBYEYCCk1MTMBkMvEkvs/nU+XzV4jdu3djyZIlaZMg2V6U2bdvH+bPnx8X5ChdhMPhGCuiHG4viAlJhmEwNTU1KwnJ3t5e+Hy+jBOS2W6bWq02R/7NIKZjQXy2tRU53G7igFsFt0LdyCF1pEVIPvHEE/joRz+Kn/3sZyAIAv39/Thy5Ag+8YlP4Omnn85UHnPIgcet3CGVlATxgQ9cwfvedxWnTxdj9+4qnDxZjK4uO7q67PjjH1l/LPX1k1i2zIWqKg9sthBCIRI6HQ2TKQKTKQKjkf0OhzUIBLTo6bHjyhUT+vqs6O214vLlfF79aLFEcO+9ndiwYQAkSWN83AivV4uKCg8qK73Q6TLjt0qn06U9WFy/fr2sImrevHm4du2azLUZrFzpwsqVLvzjP55HV5cdra0OtLU50dbmRFeXDZOTBly4IGfuXxjzz2wOY9OmXmzb1o26uptmlsXFfrzzne343e/m4nvfWwqC6MGaNUMIFhTAVVAApqgIw8PDCARIdHfboNEwsNtDqNT2Y+HP/wuVb7yBhj/9CSUnTuDChz+M0QR+miYnJ2P+K/nWvNVx/fp1ye3pRNlWAhcYJhVIDUa7u6145pkVYBgCW7Z04/7On2POs88CAD6H/fix3oW+PivOnClCS8tw3PlKacuBC6KkhIsXL0pul2pnR44cwYoVK2aUOBE/F45Q5NxXcJHEUyGqxce7XK6MTix27doFu92e8XeUnGm6Ehntcrlw/PjxlAOkCNM7duwY5syZw6vF9uzZk3S64XA4bcX/dCAQCMiarKZaV3LBat7auFVIlmwgk/2rHCH5Vi7ftzJypODswXS0v9zzvv2RFiH5r//6r6BpGlu2bIHP58PGjRthMBjwiU98Ak899VSm8phDFlBeXo7+/v6ZzsZbElotg1WrhrBq1RA8Hh1OnCjB6dNFuHSpACMjJnR0ONDR4UjrGnl5AWzc2Ie/+Zt+6HQT/Pba2vSj4UnB6XTC7Xan5fcyPz8/LlIwB7VmP1otgzlzJjFnziQA1gdVKKTBjRt29PZaMTpqwdQUCY9Hh0hEA6vVgUBgHCTJoKLCg9raKcyfPy4bEf3RR6/j6tU8nD9fhK99rQ5mcyXmzJlEUZEfbrcBIyPz0d1t4yMsA6wp/Mc/Xo87172CxT/8IWw9PVj39NMYXLUKlx9/HN7KSsV74iL+Ck1uZxJdXV1x24SDBTnn82IIBzFyJAAXKC0TEE5mxL4jkxnscFGb2fOAQ4fK8f3vL4Hfr0V19RT+X+lXMefZHwEAfMXFsLlc+CD1PL6Lf8LOnXVpEZLCMguHwwn9rMkpT6WiYo6MjMDn88HhUN/3pGrSLXefiXwhcv2LRqOJUz8CrAq0ScYtglghKXyOYmRjgK3m2WYqanwy6UxNTSn6/JbLl1IZ+f1+dHZ2YsGCBarzAbDPX2h67nK5kjp/NkCshlTr55X7/dJLL2HTpk2wWCwYHByctUHSclCG0I/tbIscHQgE4PV6YbFYVJ+jRPxlm5BgGAZarfR09VYgJFtbW+F0OlFUVHRbRZPO5H3cTuWSgzTS9fc429t5IuTqtzLSIiQJgsC//du/4ZOf/CTa2trg8XiwYMGCpCM15pDDbEUmO0CpzshqDWPz5l5s3sySOGNjBpw5U4SrV/PR329BIMCqI0MhEoEACb9fi0BAC59PC72egtFIwWajkZ/vQU2NG8XFfsyfP4Y5cyZBkgwsFgu83ozdQsYxHS8YvZ7G3LkTmDt3AlqtNob8WpAgyrYYWi2Dz3/+GF59tRYvvjgXU1N6XLhQGHec0xkASTKYmDBgaMiCz352LT7/eRJjP1iIub/5DWpffhmlx4+j+NQpdG/diq777sNUXZ3kNTlV2GxRGJ0/f15xv5zzeSVIkZyZhlBhK/bdk8xAgTt3fFyPH/5wCY4dYwmDRQtdeKH8Y1j5P78GAFx/+GFce/e7sfbpp/FPF76D7+EjOHWqBJ2d9hjlbTL54AhAr9cbRzZKnZvsotOBAwd4P4dqcOLEiaTS5yDMqzDgUU9Pj+J5nOJTPHnhnklXV1cMITndA0C5683mgXQ4HJYkqDkIy1qNmTzABmJqb29PmpA8dOgQryRMFHF+uslK7tojIyMoLIzv8wHWvP3gwYNpqSFpmub7+hMnTswqZeXRo0exZs2ajKU30xM0mqZx4cKFrEbzlgt0NZPw+Xw4c+YMNmzYkNXrZPL5ypG6M0lIqr3ujRs3UF1djaKiosQHz1Jku62Ko2wPDg7ixo0bGe1vcsg8pqsPn853xUy/l96qSIuQ5KDX65MeeOaQQw7xyM8PYsuWXmzZoqwyYxjw/h4LCgreks6RWbJVPdtaUlKiGJlXLXQ6Btu3d+K++26gp8eG9nYHxscNKCoCzGY3amunUFTEBtHxeLR49tllOHGiFP/5nyvwH/8RQfjDH0bX/fdj/s9/jtLjx1H76quoffVVjDc2Av39MJEk/MXFNx9wFLOFkMwUpnMSkchEO9kByMCAGf/2b+swMmICqaHwj7W/xVdu/CPMl1gze9e//AuubdoEADj71FPY9NGP4mH/7/AiHsVvfzsXn/nMybTyoUQgpYtkfC1KnasW3PNPRVUtVEgyDMOriFOJYq6Ut1RAUZRktHelawvbttvtxtDQUFxwmWxFVJeKYi+nZHjppZdUpSn1PspEew8Gg3xb5vr+c+fOYfXq1WmnrVTvOzs7+XLq6elBYWEhjh49ipaWloQuDlK5b7fbDXvUh7OcX9KZgNiX660OmqbR3d2dNUJyx44dqK6uVl0HpnMinGy9zDbxxy22dXd3Iy8vDzabLebatxJutfyqwXT5kOTg9/szOq8Jh8M4e/YsVq5cmbE03+qgaTotq7hMIdP90okTJ5CXl3dLLyDcilA9yvnLX/4y7RE3c8hBDZxO50xnYdoxyxbcJZGNQb5dEGhnU5TwUYtMv7S0WgZ1dVO4++4evOtdbfirv3Jh1aohFBffjOhttUbw6U+fwqJFI/D7dXj66bU4daoYnspKnPj3f8fh//xP9K9bB5okkdfaCjz5JO5+4glsffxxrHn6aSz60Y9Q/+c/o+TYMVjPnYO1sxPWnh5Y+vpg7e6GvbMTjtZW2C5eRP6lSyg4dw5FZ87A0doKw/g4GzZ8GjDbB+Bif5zpwO3W4T/+YzVGRkxoJNtwhl6K73S8F2bvJLylpTj+2c9i7Ikn+OP9paW49MEP4nP4IgjQOHKkDB0d2QsYlQqme1CZbn0hCCJpP6A0Tcu6BsgkBgYG4qK9S/U9NE3jwIEDAGKVrOPj47hw4QIAdnKeSDUKsH4mk1EMhsNhPgp4IrIrFZPtRO4laJpWDNIlh2PHjvGm9lyepO5bygT94MGD6OvrA8MwOHfuXNx+pXLu7u7mF7O4+x4eHo6rg6m+YxiGiXFXIsy/nH/dmYaSe4WBgYGUnu90Y7YpF2f7e1QJiRTNicC1yXPnzqkmvkdGRkBR1Iw9x1v5eSWLvXv3xm3j7j8Tfr5TIciTQSgUwuDgYFLnSCFnWn4T3Lt3utrfdF3H7/dn1F1UDuqgWiH56KOPwmq1YsuWLXjkkUdw//33Q59CpNgcckgHUh1SQUEBJiYmpj8ztwCE5VVbW5u1qLlSUBMcQ+4FYzabYwJ2EAQBnU6HJUuW4ODBgynlR+pamRigKKUPsCbjTz99HF/96gqcPl2ML395JT7ykXPYsqUXo83NGG1uhn5iAlV792LBlSugT56EcXwcxvFxFElMnJMBTZIIFBTAX1QEb2kp/EVF8BcXI5CfD0qvh87rhXF0FIaJCfYzOYmwxYKxBQvQv24dqCSj6d6qUDPAZAPsAM98bTn6+62owQ0coDYg3+JB17qt6Nu4EaPNzQBJQkw3dt9zD1YfOYJHTr+I3+Ix/ObXc/Fv/x6vkkxnoJvOuUIlwnQrIeSQyIw4mbQAoK2tDX19faqOTQdq1Wyc2pALViXVfwwMDCT0q8lFHO/q6kJxcbGqawvJIqX8Hjt2THIhev/+/XFKk2T8sV65cgVerxerVq1Sld9k0dfXh2XLlvFl+sorryASiSAUCoFhGElVnBJZrXYilKySkSsrv9+Ps2fPSh4zGyMLMwwTY14vxsmTJ3H33XfDZDIBYBXAGo1GdTlKkR/TCS6fnZ2dqJNxpZJKerMB3OJTunlSo5hMR2nv9Xol26TwutyCgNBf52z02Xm7Y2hoCJFIBOfPn8fy5ctTTudW8Aeaw01k4lmpnbvL9SWziRyeTdYMtyJUE5Lz5s3DoUOH8Je//AW/+MUv8OSTT+Kee+7BI488gm3btsk6HM4hh9mA+vp6xSAGbwUsWrRoWgnJdLBlyxacPXtWUbWS7MtQ6kWRycjVSi8io5HCv//7cXznO0uxf38lvvOdZbh4sQAf/vBFmEwUQk4n2t/5TizYvh2v/uEPsHd2wtrbC0t/Pyz9/TC7XND7fCB9PhAUBYKmwWg0oEkSjFYb+63RQD81BePEBDQUBbPLBbPLhYJLl1TfS/Xu3Wh+7jn0r1+PnrvvxtiCBYqy3Nk0KMgWCILAz56bi3Pni2GFGzuwHe53bcSphx8GbYiN4B5XHgSBc089hX/9h2/gd/6Hcex4Gc6dK8SSJSPK593iSOd+lPyKyhGSDMOgs7NT0tdhOBzOumpLbjKspKrgzM1TuZbS/1TTEW7jiGpxsDEhWRwKhWLGf8L0+vr6JNVOHDmoBKn9yfT5DMPg9OnTaGlpUaWMFea7u7sboVCIjyzOkb4cuGcmzo9U/sTPl6bppKyNZmOfIM7T1atXMW/evJj7F7aDo0ePoqSkhC/PRBC6Yjl27BhaWlpmZI5x8eLFjBCSYrjdbjAME2PxAWT+WZ87dy6OeOfacjqKNL/fj927dyf0b5rO/bS1tfGuL4TpnD9/Pu6euHtpb2/H0NAQ1q9fn/J1c1AP4XMJhULo6+tLmZDMEZEzj2TdQqkl35T6gdnqBiSV+jgb39W3ElS/4QmCgMViwWOPPYbHHnsMbrcbf/7zn/GTn/wEH/rQh/jACznkkE2k2uDVqPVmGxwOhypT09u1E5R6IaQzaMnUyhVJkpIv7kQTJq2Wwcc+dgZlZV68+OJc7NlTjUuXWFKypcUFgmAHBJTBgPGmJoyLogUbjUYA6s1rCYqCYXwcxpERWAYHYXa5YHK5YBoehmFiAmQohIjJhEBBAQJ5eQjm5SFkt8MwPo7yQ4dg7e9H9Z49qN6zB/78fAwvXw5XSwuGly5FRBSd81atg1y+E0WrBoDdLzqw89VGEKDxS/JxhP7lPty44w7V1woUFID6h834x2/+AN/DP+H5bzfi2efGoNPFR4ueScwWhaQShG1ZTDJ2dXXFTfTF16QoSnbwnY5KI1mySQi/3w9DlNjO5mCYUwkmAymVJhfcau/evViwYAHKysri8uHxePgJRygUwtjYGB/0UCkPoVCIv6awv0vWTL+/vx8tLS2y+3fs2CEZRGd0dBQ+ny+GkOT2EwQhO97lnptQKSH2gzY6OoqjR4/GbLvV/QO3trZi7ty5MfVW+HtiYkLSH5e4HEZGRvj3HAeXy4VIJJIVQnKm+tvr168jFAph7dq1Wc1PtvxjiutrJvKtNg2pe/J4PABifcxOB24XEo1hGFy9ehXz58+f8Xxw37dL2d5KkFu4MxqNkvMO7h3HLdilM8dSa6WUiXTUItO+2mfD+H42Q/UbXlyQNpsN733ve/He975X0oF7DjncbigsLORXl4uKimbtyo4SampqshLRONUBhPicRLL8dAYpmRrgWCwWyT5PKjiEGBoN8O53X8fixaP41reWYXDQgi9+cTWWLh3GI49cB8O8nDH/oAxJIlBYiEBhISZE5GYiXHvPe5B/5QqqXn8d5W++CdPYGKp370b17t2gNRq4a2sxWVeHqbo6TNbXg8jLy0ympxlcvVIkBCgKh78VwncOPgAA+ILhyyj64mr0pzB479u4ER8+9QJ+98bD6B4txa9/UIn3//NNMnQ2DFguXLiA0tLSrF4j3QmHkkLS7/dLmi4Ljzt9+nSMOpphGPT398f5HgwGgzxJyGHHjh0wGAxYt24dAOD48eN8ZHKlxYJEz9bn8/FuKpIpG6G5otQ1hWkNDQ3h+PHj2Lp1q2KaauohRwJEIpG4ZyAFLkJ6c3NzwmsKfwujsCfj61RtAJ5XXnkFa9euTSkgUjLtdXJyEpFIRJLcfeONN5K67q0A4UKBMNI0TdMYHR1FUVFRXFC68+fP88Q2oP7eBwYGkJeXF0dmitHa2orGxkbZ/R6PhyfMs42ZJlySvX4wGITJZAJBEDHntra2yvpbS7XucsGGOP/wcgGnuHx0dHTwgc5yJpMsGIZBT08PqqurEx5L0zTa2trSIiTTdS2RbR+SiSD1rs+BfeeWlpbGvLcOHTqE+vp63iUHALz22mtYvXo18vPzs5KP6XwPctfiFl2TPS+H1KCakHzxxRdl90mpEXLIIRvQaDSw2Wxwu908KThdAzvhQCcvLy9tQlKn0ym+xLMxsCosLMwKISmFdFWpUhMD8bOuqKhQ7RcuU+UpNylWQ0hyaG4exXe/+wZ+//tG7NhRj7Nni3D2bBGKinxoaXFh+fJhzJkziYICP7Ixvtbr9QiFQqAoAm1tDpw7V4S+PgvCYQ3Kyny4885eYMECjC1YgAt///couHQJxadOofjUKVj7+uDo6IBD5AKh0WKBr7gYIYcDYbMZlNGIiMmEiNGIiMWCybo6jM+bh4gKhVS2YBweRl5rK7ReL0AQ0FkssEVVqYHCQgTtdlAmE4yjo7D29cHS3YNf/N9yPOP5ZwDA3+b/Gmu/VoHxEnW++uJAEOh66v34VvsX8Z6eH+KPe5egrtGDjQ+w5NhM+ZAUYmxsLGOBwrL1jJV8SFIUhfb2dsXrC/vd3t5eVFRUSAZCGR8fjyFnOeJaKtpzovxmO6COGkLy+PHjSaWh9Pzk9gl9IQaDQck0Z5qMESISieDgwYNoii7aSN3X+Pg4CgoKEqalVH6dnZ3wer0xRHgm6kRPTw+qqqoUj/H7/ejr61NtMp0Iatr166+/jqVLl/J549qOx+PB0aNHJc19xelypKbH41EkG0+ePInly5ejoqJCMU9Xr15VJCT37duX0AxZDsn0dbeCPzQx9uzZgzVr1qCoqCgmn21tbbLnpFom3G85/3KTk5MYGxuLUR+3tbWhuro6R0hGEYlEcO7cOVWEZLJ4+eWXM54mkPn6H4lE4HK5UF5envDYXbt24YEHHpCsP0KF9mx6d00H2tvb456L2+1GIBCAWeBjPhKJZH2MczuVPUVROHfuXFo+V283qCYk586dK7vv2LFjWL16dUYylEMOSiAIAna7HW63Gw0NDapJwUx0ZFwat3JU7+ka8N55550pLVQI8zdnzhxcvnw5Y3nK1EBVri4lm77VGsEHPnAF993XhT/8oQEHDlRgeNiMV1+txauv1gIA9HoKZWVeFBb6YTAAej0QDNIIhzUIhTQIhUiEQiT/PxLRQK+nYDRSMJkiMJkiMBgoGAwU7PYQrNYwAgESwaAVvb1aXL/uhM8XTxz//veNaGiYwDve0Y61awcwvGwZhpctw6UPfQim4WE42trYCN9RYtI0MgKd1wtHZ2fC+/ZUVMBdVQVq4UJoCgoQdDoRtlgQzMtDxGQCrddnLIw86fOh4NIlFJ09i6IzZ2Dr7VV97gU046P4FnaDVZN9ZPn/Yeu/mxHQ2tLKE63ToeD/rcXHnvwenvU9hWd/shoO4nUsuT8yY8G5pMi4VKC2f+FIqVQjGQoDXgkXCOSUNEp5Uwoaw5lfc6a9lxL4YVW6/1T8V0qlNzY2Jqnk4I4VlqmcYog7tqurC3kS6map66qdbAjfyUqLX+JrCKNlq3lfSz0LmqZ55aba60ptl7q+kkJL7tidO3cq5mXfvn0JA/skqlNnz55NSEhOTk7iypUrGSMk1UJoPutwOFJO58iRI0kThaOjowiFQjGKSzHSVb0qQU3grbGxMZw+fRp333133D6OzE+k+kwEiqIkF0tTGRP39/dLmt4DmS3La9euKaZz4MAByfNuFYXkbCae1YBbXMjkfWQjevXY2BhOnTqF8vLypMYmYrzyyispL1TcqhC7PuCeD0EQvBpZjFSsDNQi3brh9Xqh1WpnTdsLh8Np+Vy9HZERpyzvete7VPngyiEHKeTn56sOLpLNziRRPrgB3MKFCzNirp1oQJgJElU8Oct0+RUXF8dMJDmkOihUyh9BEDGqyWTLJ9ura6mmX1rqw0c+ch5PPHEJ584V4vTpIly4UIj+fgtCIRJdXXZ0dWVPhW6xhLB48SgaGiag11O4eLEQJ08Wo63Nia9/vQUORxCrVw9i4cIxNDaOo7wc8BcVYVDg/4oMBmEaGoJ5aAh6jwdanw9kIACt3w+t3w/91BSc16/DOjAAa18frH19wNGjqJTID0MQiJjNrLLSbEbQ6YS3vBye8nJ4KyrgKS+Hr6QEjEiBq/V4YOvthbW7G47OTuRfuQL7jRsgogOnfpThT8T7ccm5AhO6AlDQgKQp5BHjKKJdKPH1wBDw4jSzDEc1a3GQ3gAaJHSaMJ780Dncsz29wYxWq+VJnZDTifuf8cD18d/if4KP4ss/3oyvD/83at9fknL6mUSq93nw4MGkjt+9e3dK1xH2L4cPH5Y9TkjOKd3Tq6++KrldHNQiESknd41kyUgp5TyX9tmzZ1FWVsYTLUKT7VAohF27dvERsBORb+fPn8edd96pKk+JgsIl41ZD6hihejPZ+ufz+aDT6TA+Po5jx46pOqdTtHiSSB0qdX+jo6PQaDSqSSOp+8p2oKV0EQwGcfr06Th/h8lCzZhAuNAAJFcPxHWqt7cXU1NTsoTk0NCQqgWRYDCIiYkJlJTc7JvV5EtMqkkhEAjE+JwVpnv+/HnQNJ222OPSpUtYvHhx3PZUxitS/htTUVGne2wi+Hw+mM1mvm3NNEkp51s10xgbG+NNZrMxV5IKkpRJJKOeV3N/6ZqRp3PtZDEbyHThfXELtdwir9frxc6dO7F9+3ZZQlIOclYkiRYBxZA7Rs25x48fR0lJSVruiI4ePYo1a9bI7p8tZOetCtWE5MMPPyy5nWGYjEaqzeGth2RMXXOIRzLtTziozgSWLFkS4+MrXWTTh2S2FZLpwmCgsGrVEFatGgIAUBSBoSETBgasGB01gCB0YBgDIhEf9HoaOh0FvZ6GXk/x/7VaBqGQBoGAFn6/FoEAiUCA/Z6a0sPj0cFkomC3R2C3+9HYOIna2kkIm+Db3taJyUk9XnqpFq++WoOJCSN27arBrl01AACLJYyGhgk0NEygqsoDozECiyUCmq7E8LgRg4MWdHfb0Ndnhc0WQkmJD/PmjeOOD/WjiHHB0dkJa08PSvr6QHZ2Qu92Q+d2wxD1y0kwDHReL3ReLzA6CltPDwovXIgrL4YgwESjijMkCa1EMJF21OMFy9/jT8RDuOapAxgA8oK4m4iOtdav78f7338ZpaV+pDvWsNvtMW3VX12J9/xwHOP/vAcvu7fg43/8G3z76ldR/9kGhG3JqzBn42BofHwc+/fvj9vO5TVVMka40KLkv1COQJxuEkjoo/Tq1asJj+fUCXILX0Il6ODgYNw2rnzk6sSePXskt584cQLbt29XNZETp61W7Xrp0qU4xYrY7UaydfnQoUOoq6tLSoWnxtQ+UZ7Onj2LBQsWYM6cOTHHKKkpxa5aEr1PMkX4qIGUqjAYDMZEWe/u7uZNIPv6+hL6kOfMarm8cnVarr4I2+z169cT5pk7XqocpRTnnNq5u7tbMg8Mw6BXoKR3uVw4e/as6ojSap4JR7yI+6Fs9OHZSPPIkSOy6SstXOzYsYP/ffLkSbS0tGR8PDU2NoY9e/bg3nvvxeXLl8EwDJYuXZrRa8xWvPnmm1lV8g0ODsYQkkoLcK+//jq2bdumKt29e/eCIIgYE+BMINn3/EyOoV566aVZqcLkykQ4hhH3XUp+rNUqAdUuCMqBy8/BgwcT+sgWIhmSPZNxI24n8/NMQTUhuXv3bvzqV7+K8+vGMIysfD6HHLKJ6W7Q9fX1/OQv0xCqpzhk4/5mW7RxtUFtMoGZXn1MFiTJoLzch/JyVjWi1Wqh1WqTCuyQKhyOEN797ut4+OFWXLhQgFOnSnD9uhMdHQ54vTqcO1eEc+ekTbfEuHo1H/v3V+K55xahqsqN+fPH0NQ0jvptZoyNjSMYZM3OgwFAE6FAhkNg/BGY4Ee5aRhzNJ2od1+GfZBVVlr6+6ENBEAwDAhRm+nLm4ODefdiD7EFb3pW4spQJRDlHQiCQWPjBOrrJ2G1hqHRMKBpAh6PDlNTerjdeoRCGtTWutHYOI4FC8ZQWZkcaaEESd9ERXl44mceMP9yGK/0rMM/XvocPvPBZ/DI33Sg9957QM9Qe81UO5QzBe/t7YXVak16pZ2DsB9We77U6n86cLvdsESjzSuVVyQS4Y+jKAqtra1pX1sKwjxwUaBTeY6XL1/mfXAKIaf4YhgGly5dSipStNgcLNlolmIiSaPR4MaNG5Km7EIyDZAnjrj/Fy5ckDSBVipLsXKCU6tKoaamJsbvXqqE5BtvvIENGzZI7uvr6wNBECgvL0coFMKJEycUr8Ght7cXbrebJySHhoZiAhcA7ASOM9sdGxvjF1m4fMqVNwfODYscKX7jxg3+dyLS+NKlS7IEmJq6L1X2brcbU1NTkmOlQCCAvr4+1NfXJ0xbDKmJb6K+K5tjXJ/Ph1AoBL1en/S5SmMQoSsFhmFiItkLMTAwgFAoxLfZTBDv4j4oFApNO8k0PDyMK1euzPhYOxvq1GTUi8lEO/d6vdDr9Xxfk4xSMlE+soXZoGjMJpRIRo1Go+geJ9t5EoLLAzeGSHZ+JKX6Btj32Gy3XrjdoJqQ3LRpE2w2GzZu3Bi3T8ocIIccpgvpSL2TQU7JmX1k8wWnJigBh6VLl8YEZ5gNmA6n0WJotQyWLRvBsmUj0TwQ6O62obXVidZWJ1wuMwIBEl6vDhoNg4KCAEpKfKiqcqOqygOPR4e+PguOHi1DW5sTPT029PTYeLWlWphMEcyfP4a6ZZMo2uqHjfSAoCgEfKzys707H619xRh0WWMUkBoNg8WLR7B5cy9aWlyw29UPkjMNucEradDgw98dhfWbJ/H7QyvwleCncOz5PfjG758G+egS9N51F6g0/YjNRng8Huh0uowO+sT9hxo/bonAkXuRSCRGyXf+/Hk+EIpQMSSG2+3mHeKn035bW1sVfXlLKUXVlK24XIRkpNL5wvOERIBahVgmlX8ajQZer1dyMuKXUE4nuqaw3nB+MJXyJKWcUGsuKDc2uXLliuJ5brdb1m9fb28vSJJEeXk5XnvtNVX5CAQC6O7ujvEpevz4cb6OC03c+/v7AUhPyoVt4fLly7I+MoV1prOzU/LZKSmwNBpNTFCTTEXp5QhR7vkJ052cnMTly5clfVsnGi+IJ76cyiidPsrr9fKLHdz5kUgEJEkmJEvcbjc6Ojr458uhv78fTU1NMekqgctzd3d3XFqJ7icSiagiJKempuLM+aXA9dVArPl/JBIBwzBZIQnF+U6kGJ4uzEaLCSVkSx2spl/g2rqa47kAdbNV0ZhpyKn9aZpGT0/PDORIGulYGkghlXZ8q7W52QbVhOSf/vQn2X2ZNNnM4a0HtY24sLAwyzlRRqZXqxP5lZG7ntFonBaV3ExgthCSSs9auK+0tDRrqtlMYMWKFTh58mTG0tNqGdTXT6G+fgrbtqn3G/zww22YmtLjypU8XLmSj9ZWJ0IhEyKRMB90R6+/SX6QJA2/XwuXy4yhIRP8fi1Ony7G6dOJo1uXlnqxaNEIFi0axZIlI8jLSy1wSjpQMtnksG3bNp4sIEngfZ8aQMXSk/jRjxZjL7UFqyY24p9//G185r/+Eb41C9C/fj1Gm5v5KOVqrpkqhCqlbOJWUBhw7UeJTFRScqVKOIgDwiQiF+XIqVSunQ6Suc7p06clTbkSBQ8SQ6m/Fubn4sWLvPoxUT65/ZwCj/svfi5SzzeZMpBTEnEqSqW0hIQch507d6K4OHE/yYFLnyPZxOphzsWA8JlweaNpOmEgLk7NqnQfk5OTksGI5Op8KmSAlCJWbfAiDkpBjMRuB4RQKiOCIGRVhImwd+9e3HPPPTHK4MOHD8NsNvN+ZJUgd68jIyNJE5Jy5u9S4Mhttf3TmTNnkl7MOXDgAO8v7tKlS/D7/Yr+37KFoaEh1YsiYoRCIQSDQdhScOGSKSg9o0y+U5L195iMawSp7Z2dnbzSWSlS/FsVSgpJbh/3LlRzbLLIRl3LtlUlRVG8/9qZzsutiJSD2gwODqblHDSHHG4VTMdELpnOqb6+Xjb6tNg/FYdEUTgzgTVr1mDfvn1JnZOMyfZ0duC5l0XmYbeHsHr1EFavZn1kygVE4sDVZYoCurvtuHQpH/39FoyMmODzaUEQrHLSYgmjutqN+vpJzJkzBas1O47MU0VeXp6kibBUHbvrngEsWDyJF56fj2MnyvENfBI/Cv49Ht3/W7xv/6+wlXgGnjm1GF24EONNTRhvakIgCaJ9tkHOj5xcmaWDbPTjnDIuG2mfP39ecrvX60V7e3tcsA4p1eGxY8dgMBiwfPnyhIq76QSXVznfUkKlkxooEdtyfvrUTniUJlvJoLu7G06nM27ymypZAUC1KTaH4eFheDyemEBNFy5cAEVRqsyHlcrs6tWrWLBggez5PT09ihGvpaBU5jRNx5BUSmOJXbt2xfU1cmSFuByEx6j1k5oIXN6EZZqqCaT4nGAwiKmpKVULpWqul05gELn0ORJeWNbyaljg7FkT/H4bamunUlpgpGk6KZcSYvT19aGioiKlczk1sRyUVHnt7e3o7+/Hli1bYrZfvXoV9fX1iub26Zps79q1C3fffTdeeuklVWmk048J85HJsbdcGVAUhUuXLsW5XpgJM+TZjlQWbrIFtUIROQwMDKTkokIIJe6ru7sb7e3tuP/++yX3c2U2E9ZutwJSJiTvuece2QFzDjnc7lCavGSqo56OF3Mm0xf7l1WCktIgme3ZIg7TffFlCna7PS0ToNlMrKqtkyQJ1NVNoa5udphCJYtkVYClpT7829OncPJkD/7rv+ajp8eOF/AhvIAPwcmMY2PbAdzVthdb/rwTd+NrCBQWYnzePERWrkSwvByTc+bMmO/JTKG0tDQjhGQmFYJSfhWlFGpiZPKdIFTTHTp0KGaf2+2OMx32eDzweDyKViypDozliIra2lrJslKCsHzEPgjVQKmPVFv2ahWT6aQltT1RkCPxOeFwGPv37wdJkjzJwjAMKIrij3W5XJLk3/DwMIaGhlBdXc27oOFULsJJltqyEBJKHR0dmDdvXtyx3d2skn5oaEg2Pbn3lBJJ2tfXF6NMVnrXiYlEr9cre49KpsFyZtmZmFyKyZBU+wyuzMRktdQitvAae/fujbt3r9eLvXv3Jn1ttfB4PLDb7bL7u7ut+MY3luPGDQcA1g90S8sU3vWuC5g/PzMLVhcvXoRWq40zNxfi9OnTsoRkokX1RMr1AwcOoLGxkQ8UJUQ4HObdmvT09MDtdqO5uRmtra0oLS1Nm5AcHByUVV8Gg8Gk6mCyiyNS4K43OTmZ8P3vdrsxPj6O8vJy/p0htqJjGIavk8J3ZzrktBIyTagCiC7KUzBm0W1POBzGuXPn0NzcHLdPTvWYqF6L4Xa7Vd2DnFqcYRiMjIygpoZ19zQ1NcX3HQRBqCp3r9cbE7AsFXCB/6Sgtr2cPXs2R0hKIGV7qdwqQg7pYjb7ZBQOTriOTk2HJ+VjlYNasz4OYmfy6UDK2X+ySIZYSfWlrNPpYuTunPN8Oajth5JVZqjN/2wm/IDZnb9EK+qZqLPTBfGkSo0LhkTPZsUKF77//f346lffxJYt3bDZIphAHv6Ct+Gf8R0swkWUYAgfGPkedr65AKFv78D6T30K9z72GNZ95jNo+uUvUXboEBytrdBNTQG30Ds7U0okIdIdsyhFj1VCJttgokmalNlrIhw+fDjV7EgiFQJQqBpMNsBNsvnh7leJOEjlmQknvJmcmIoncRRFwe/3x72PX3nlFbz66qv8f7nrezwevPzyy3HbxWq1nTt3xuyXMk0XE1BS7VZYZ5VcQUjVbSWCKxGpoFQPx8bGZJ+RXBtTel8pBfaUm3gSBIGpqSlVZv4Mw8DlcsWkxdU3MYkpFdjl8OHD8Hg8smPQo0ePxpC0XDrJkJFAvKo7UV9w6tQpHDlyRFKZ1t7uwKc+tQE3bjhgNEZQWekGwxA4edKBz352HV55pUZ1vpTaosfjQW9vL44dO6a4kHL06FHJBahk3yvivHg8HsX3HUEQCAQCOH/+fIwf10SQy5ff7+f7idOnT+Ps2bP8c+7r61NcIFGrKk/3XTsyMpLQZ2h/fz/vRqKzs5N/PweDQf5cYT7OnDnD/5ZzCZJuvnfu3JnUM1KDq1ev4tixYxlNU4xgMIiBgQH+/gOBQMLxebLK6TfeeCOp46WeBac2pigK+/fvj9mXTMClbEHte5+iqBwhKYGUFZKzeaKbw62Bu+66a9b6H81EMAQxnE5njC8hJR+SDodDlR8KtZg/f37aaZjN5pQmvMmgtLQ0xv/VmjVrsGPHjqTS2L59e9w5K1asSCoNu92OpqYmycGZXN+XjT5RKs1kIhPP5n46UV3iAoHMVggVSjabLUal1djYqOgDTik4iRAEASxYMIYFC8ZQWjqKgwfdOH++EOfPF+LSpQIMh4rxIh7Fi3gUAFBJ9GBLaA9aLp1C46VW1ON/sRA9MCGAsNkMX3ExQk4ngnY7QjKfoMOBkMMBcIQHw7B2c9O4gJRMhE4lTNfCqVoCVex/MFkkmiTMhoViNX3T2NgYH2BCnOeLFy9mND/Xr1+P+c+1U7VlxfWhiSI+nz17VlIhKAR3zWRcEogtD7j8GAyGmGAMctdSCzXms+L94mediMC6cOGC5HZORamUJ7k8cEjG6sLv9yf9/Hfv3i17jNLkUspk1+v1wmQyxRC0p0+fln0ncuTw2rVreRWY1NhZqAjjQFEURkdHUVxcHEdic2UgFZQpFbJJzj2CUhpcNFvhtp4eKz7/+dXw+XSYP38Mn/nMCTidIbhcJrz44nK8/no+fvSjxfB6dfjrv07s/48LaiMHv98Pv98Pl8sFgiAko6gPDw+DYRhUVVWhsrISp06dwsjIiKLqq729PWWl/65du1BaWpqydZDceZFIJCZgk5DAHhsbw9jYmKJaNFPg6oqwTiarQud86Q8ODqKkpAQAS+BNTU3hjjvukFQcC8+TS5f7FpYxZ6qbaCGkp6cnxiVGpjEyMoKhoSEsXLgwa9e4du0a3ydLkWzJWrhlGlILamqvnc3I2WoJydkwTpuNmN0zvhyyhtlMVGQDs+F+k1F8KXVsqdzLbLh/KcgRbqmeL+WPLBWYTCY0NjYmNKeTg9FoRGFhYdrmAVLIFCG5fPlynD59OlPZyjhmGyGp1WpjJp6rV6+WVZdxeV+8eDH8fj/GxsZi9peUlCTdJrVaoLFxEo2Nk3jooXaEwxpcv+7kCcpr1/LQG6nCL/A4foHHY84twAgKfSMovDECKzywwAsrPLDBzX/sGIAN16FHCKSGBmwG6BxaVHZfgA1uDDz6AKi5paBqixAqyGfZ0iyBU89TFDA2ZsLUlB6hkCYq8iRgNEbgdAZht4eg1Sori6R+TyeEz1lMjiWLRP7IOIXP5ORkWtdJB2r7JiUyLZOQU3KIrytUtnR1dSVtoSB8b124cEHSnJIjQ5Np+8J8ColvoYWJ3D2KVb1SZBUHoTJV6hmmG7wnFUilzyltxIsWw8PDkhYVUuTDtWvXkJ+fr+o5JKt4SqR8CQQC8Hg8cfVLjc9H4fPinlGiPk5twCe1+8TKWaVzhAsoSmS1UCE5NGTC5z63BlNTBjQ0TODznz8Gs5kt0+JiP771rQF85Ssu/PrXTfjlL+ejoMCAzZulFW+Dg4Mx5L9UVHgxpHwLchgZGYFWq0VlZSWGh4cRDodhNBoxNTWFQCAQs5hOEARaW1sVlWRcfy31jILBYEJ3H/39/TCZTMjLy+O3nT9/HosXL5Y9T9iHiNMXzzuy2b4vX76MUCiEZcuWxe3LFKkjdYxS/Q2FQjzBvHv3bmzdupXfd+LECdxzzz2Sln3Hjx/HqlWrVOUn3bnY5OQkuru70yIkPR6PpIstrg8S5pGm6Vk7f0wF2VZI5pA6ZteML4ccVEDcORYVFaG1tTXtdOUGdul0xnV1dbID2kTXmO6XwKpVq3D8+PGYbcmQX9mGmvJI1c/K3LlzY8gCqTompSKQy1NhYaEqQrKsrEwxgEOiiWEiKB0rHphn0tddJjDbXDq0tLTEmM6oeQ4VFRXo6emJ255K2xY/G52OxsKFY1i4cAyPPXYdgQCJK1fyceFCAXp7rRgYsMDlMsPv12IUhRhFIa6pvRgNYDL64fBb9ksDCg5Mwql1w2H0wmYOwmILw2RjYMuLwJrPwFJEwFhIwmSmYTRGoNdT0Q8NmiYQCmkQDJIIhUgEg+xnfNyIkREjRkeN8Pny0dVVh8FBMyIR5Xpgs4XgdAbhcAThcLC/i4r8KC72weMxIhzWw+nMjOJSDcTEdSAQkFWGJcKSJUtw7tw5/r8an5VCzESbTkeZN5vAKaYS+fDl2vLk5CRvussRIXJIZtFNSLzt2rWLn4gK+5CjR49K5ks89hD+F/sHFBIVas3xMm1eL4ZU3eCuKSb329vbY4LqcPVQTtmolhwQLyYlghpiMRkIy6C3txfj4+MxCjav16toTSOn+OIgp0ZX044TPX9O8dnV1aWoMOZ8c46OGvD002sxOmpCVZUbX/jCTTKSg16vw6OPXkMkosHvfjcXzz5bD5qexJYt0mMt4X10dnairKwsofVRR0cHDAYDKioqZM2UhdtbW1sRCoXiotsnql+XL1+GRqNRVEHSNC278Hn9+nUUFRXF9DV9fX2ShGRHRwfq6+tx5MiRmPSF/VsiQjIVdxxy4CKIp/p+UqMcTTbty5cv8wSp1ELGkSNHJFXwQv+4StfcuXMn7r777qQXu4TPKBPv9H379kn6QZSy9JBb5JDa3tPTg6mpqYxY5CVb16SO7+7uRkVFBUiSlHRxIZWWz+dTPSahKCpunjIbTMdvVaRMSM62yWIOb104nc6spp/pjkMqEvZsICSlcDt0mg888EDCYxobGxUJyZUrV0qaCaSLgoICWUJSr9enFeGypaVFceIrZYZxOzxvIbIZZErJ5UIq6aULo5HCsmXDWLbsJnHOMIDXq4uSfGYUFjbh/Pl2BIMkAgEt/H724/Pd/KbCBOgABTpIg3Z54Qka4YEVbthAQQsaJMaRj/FIPuAB+5EPlp42dAihiBiBCX4QYJ/lFGHHCF0AGiTcbj3cbj16eqSd8wNzoNdTKCjwo7AwgIKCAAoL/cjPD8DpDAr+B0GSma//Ho8n5XY8G94BySJZglF4vNitSaowm80JfZCp6RfUuCjhVKviCaxSOSTj+uT69euYN28e74aEu56wb5erX0oqcyXTQymzeamJfjZ8vQohzCPDMEmZ8yd6vreC8mdoaCiGMBwZGcHk5GQMIXn06FGeXJC6Z+FCqnh/MBiUJQrVtA8xWS8+hxMKJHpuAwMDcLlM+I//WI3BQQtKS7344hePwG6XX0h6z3uuwe/XYseOenzve0thMFDYsEF+cRdgCVQuuM8dd9whO3cYHBzE6OioJCHJgWvfU1NT0Gq1km0t1folVFL7/X7Ztup2u+NUwXLXFCs/29ra4o5Ntk0kKpvu7m6UlZXx7jnUpCe+fn9/v2TAH+7aUn2pnEuJdJGJsaTagDrhcBiTk5NJL4ikAjGpJ1xQ5cpQPN6V62uGh4d5QlLsViKV8nO5XDFEvzCNHTt2oKCgQDbtc+fOoaCgABaLRZVFxvDwsGp/nWNjYzh8+DAefPBBybxJ4XabX2UaKROSQgexOeSQbQgJ8Jky5VTzos7UAHdqampWDJZT7UAznfd0OnIpUs5ms8Ws7nP5lZsQC+/HYDDA6/UiPz8/5TypwR133IGurq6YgA/JgCRJVc+Bu+dUnpnRaFT0xzPTmC6StaCgICnz/Olq2wQBWK1hWK1h6PVBtLSEUFSkPp+6qSls+NSnMLh6NS4//gGEQiT8EwzojnEEBwII9/nhH47AN0HA5yEx4bdgPGDDKJWHSTjghg0eWBGAET6Y4YcZWoRhgh9m+GK+SzCESvSiEr2oQg8q0YtGtKIKPdCInyED0CAwhny4UIwhlMCFYrhQjAGUoRvV6CTqcIOowwBdilCIxMCAFQMD8WZKHDQaGgUFAZSU+FBR4UV5uQcVFV7k5QVgtYZhs4VhNoeRZND0tHwipltPZmIAnOwk8LXXXuN/Z2qhW80EWE3ZqFEyyk0Yk/G1lwjCIAyc+Wk2TSuVImJPJ4TvFoqiFIPiCKGmfIVl1tHRIRvoItNI1txdWAYcYSMVMVvtdYUYGBjgo9YK4fP5VLmXUNtepYhQIVpbHfjSl1ZhYsKIggI/vvjFIygokCa7bwaZBD70oUswm4vw4os2fOMbyxEOn8XmzX2y+RAqzLu7u+F0OiUXLoT3JaUS3L9/f8x2t9stqYhW6r+lIsRPTU3h+vXrMWlrNBpFEkutSwoxrly5EmdRxBGScipftf3Wrl27ALCEkNVqVRwrS1mmCcvt1KlTMYQkV/e5Y10uF/+/u7sbXV1dcDgcSeVX7Rhb6FogXSRyqzI8PIxTp07FbU9lTBsMBjE5ORlD7LW1taGhoQHAzbLk3i19fTfbkPieOTcMwm1yixqBQEB2vp7ITzhHinZ2dsYoLpO9d3EfpVQnkokUL+WXNhlCP9GC6VsROZPtHLKCwsJCjIyMKB6TzGTr7rvv5jvnpqammIHpbCDu5JCO8lE40VFrOp1OWWQyYI3afKSS3/z8/JQmgUrX5f5LvTxXrVoVMzHljl2/fr2iD8bS0tKk8iEmSc1mc1oTdIIgVJVvOtewWq0xE6ZMmvhnol1Pl8uB6urqGNNaKTgcjhgfPdPdb6VyvbDdjn0//jF7PgCDgYKhBECJA4BD/loRN/RTfZj/y1+iKmoWOjZ/Pq4/8ggIigJB0yAoChqKgiYcZqWcBAGGJEGTJErLl6HfVYE+82Z0mc2g9HowJAlGo4EmHIbe44HO44HO7YZhYgI14+NonHLBMH4NxrExWPr7oaEogAFC0KEXlehDBXpQhV5UogdV6NdWoV9fiT6mAgOBIkRoLYaHzRgeNuPixUKZMmRgsbAEr8kUgcHAmqKbzRHk57Pqy6KiMJxOL/LzA8jPD8JiCafsbnM2v9vkkM6ETWySzjAARRFR034NwmGS/+3z6dDRYcfUlAFerxY+nw5aLY2KCg/mzwdMJholJf44k08OSq4yOCRjWi2+b6UJl06nSypwk1SE90R5S+RvNFkI62JNTY1qcjBTSKYff+mll2C32xWPmZqagsViAZA4YFGmcPny5aQX1KXakzgatFqSU6o/kTL393q9qkzPxcS/3PXF228GzAD27q3Ej360GKEQidraSXzuc8dRWCi/yBmr1AL+539scLl6sG9fFZ59djl6emx4z3uuSsZgE/q0VCorYdsSkxQMwyi6ceDSDYVCMaa5169f5/8zDBPjLoE7x+v1YmBggA/QwplsS6XPlUNPTw8qKyt5pRhBEOjp6eGVsTt27JA0zwWkVd0EQfBkmbgPoWk66cWKdMaXQj+p3P1y80opMkg851TTZygFqwIQZ9IuB27f1NQUXnnlFaxfvx7BYFBWwZrKQj5FUapV6X6/HxqNBgaDAcPDwzhz5kxMPbhy5QoaGhpA0zQfsVrKJYy4DN944424vlUqWF+ivujQoUOK+69cucL/Fvu0lEImiOJk3jHC63F1RFgOwWBQMW5EpgI33k5ImZAcGRnBz372Mxw5coR/cZWWlmLdunV4/PHHJZ1L5/DWwdq1a5OOjqwWyUwSbhVIdaaZGiRv2rQpI+lIDWbV+HHJBLRaLd+5r1+/Pmt1Kx1w98wFM1BrpiI+Xy3UkG1Kad5UGhAJj71VoBTJPhVUVlait7cXK1eujNuXTNoajQZz587FtWvXMpKvVDCdJvmMVotgfj4mGhp4QtLV0oJhlUGnLA0NGEpRGdzY2Ii2y5dhGh2FaXgYtq4uGMfGUOn3o6n3Mqy9u2AaHQUiYD8AKGgwhBJ0oQataMQl23JcNixBG1WPsYgD7qAZ/pAeDEPA49HD44kPWCIHrZbiCcxwmEQ4zL6/NBoGgQAJkgR0OgomUwQWSxgWSwRWawhWaxgNDXb4/fVRcjOAvDyW5DQa1Zl9AWyA9Ol8ZXLjQdZdgBYUpYHfr4XXq4PHw35zH49Hh/FxA4aHzbz/0FCIBE0T0GgYMAxA06lmnvUn6HCwPkUdjiCvcjWZIjAa2TK/+aGi2yP8d0/PKMeVJ4S4bSlNOGPNrQmMjJgwOGjB4KAZQ0NmMAxgs4VRVuZFdbUb+fkBmM2RmHyk24ckM74wGAwx96eGzM001PRdly5d4n1szkbfpEIiUW1fLOWDWAypADdiJNP3q50sc74fU8HAgBn/9V8LcPRoGQCgpWUIn/zkKZjN6vs2ACBJ4KMfPYsVK6rw9a8Df/hDI65fd+Lv//4CKipi67iwDLq7u3klnRhcHzYyMhLnO1xOrahGfOB2u2E0GiVNYsX5A6RVWFILn0eOHOFNRwmCwPj4eIzKjYMaNxbCvkmKlBb6mc+EylyskJSqexRF8UQ+R3CKiVGapuPagbBspZ4PTdMxJLU4P0A8iS2lWhSfF4lEEAqFYtwpCHHjxg3er/TRo0d537fhcBiRSAQmk0kyvx0dHWhtbVXV9x87dgxutxvbt29XfAaJFpbGxsZiFKpqFz8SmaYnUpsKiVcpFa0Y6RB8XLtUgvC6FEXF/Be3yXA4jF27dskuBOQgjZQIyRMnTmDbtm0wm824++67MXfuXABsB/Hd734XX/3qV/Haa69hxYoVGc1sDm9dJOoE7XZ73KqlWnXUmjVrJFeJxUhmArBp0yY+GqT4/HT9zSV7vs0m51stfUyX+Xx9fT1qa2un5VqJoEaFMB3ETzZILal2NB15UKOoVgNxuWcqf6WlpZJBjcSorq7m1R9K109FIXkr+p+hBaQ8nYRSItmyMZlM/MSBJEkwOh18paXwlZZidNGiuOPJQACWvj5Y+/pg6e+HYXISxrExLGlvx1rXUcD9K0AUryEEHcaRhzHkYxx5mCDz4DYXwE+YMWwoQ6+uBn2aCgxQZRgMFmI44ITbZ0QkQmJigoSya0QdotZSEoiPpmkysSpNs5klMRmGAEURPMnn82nBMERUYaiBxRKGRsPWH52OQlERqxxkP2H+N6f4LCgIwG4PwevVYWJCj8lJA6am9JiYMMDv18JgoDA8bAJNs9eIRNgI6IGAFuGwBlotjfFxllxMFRQVXwduBkeiYDBQqK72oLjYx5O5wSCJ7m4bRkby0NenhdvN5n1yUl6pkAgazVKepOSITJ2ORiBA8vdNEABJ0tDpaGi1DAiC4UlVjYYBQbDq2lCIhN+vRSikg89Hwu8nVZcRQTB8YCiDgYLFQsNkCkafHQONJgytloFWS0c/7O9wWMMTwIEACYoioNPR0Otp6PXLo7/Ze2LzT8ds02ppFBbaEAp5AIT49NnjWXWw0UjxZaTTZaefUtP/dXR0SAb9kQNHrM4EeZkoQBV3v0LVTSKffUplNDo6KumLTwpq/daJCS41qsrubitefrkWr71WA4rSgCRpvPvd1/DOd7ZJqhrFkHquGg3wzDMARZ3G97+/BOfPF+EjH9mEu+/uwQc/OAS5GCKJgo0JA8BwkKorDMPA7/fjzTffjIu0nehccTrATbJtcHAw7hwxgcaBs65RChSzZ88exetzCslk3QooIVE7VHMNISEpR65JEVyJyvull15KeG3h9ZIh/Lnz/H4/3G53TL0QWkJx6kWAde/S29uL7du3SxKF4ufCPWspMo1bEOOitUvB6/Um3fdxY1clpWx/fz+/+C4sF2GfJ8yTuE57PB7Z8bZUficnJ+MIeOFxUv1Sa2srGhsbAQBvvvkm/1sNXn755Rh+S07FfOHCBRQWFqKsrEx12m9lpMQmPPXUU3jXu96FH//4x3EVnWEYPPnkk3jqqackO/McckgVatRe6cJqtWbUdPl2xvLly3kVIDcJ4JBpk22CIKYtkNaaNWtUH5uKSb44oneqWLhwIc6fP694zHSTWMLrJdOWampq4gjJVNq0zWaL8c2TTSWiVNrNzc0xhGSm86HkriARZkKVSQsWLJgstt9k740yGjE1Zw6m5syJ26efnISjowPO9nZYu7pgHhyEzusFGQzCGQygyNcGTSQCUIgjLcXwwYTuogXod86BlzaBKs8HaSDgKytFxGIHYSOhCQThthRixF4B/5QGbp8BXj9rhmw2V+HatQmMjRkxNmbA2JgRwaAWfr8Ofr96BbbXG3vs2FhyUT7ThdEYgc1GwWQKwmLhlKDsh4uKzgYc8sNopECSDCIRAhoNeJJUp6NjFIKNjY180Awx1q5diwsXLsDlCmBgwILRUSMmJ/XweHR8ICfhJxAgo2UaG+wJAGiagM+ng8+XnOI9Gej1FEpKfCgt9aKkxAeSZDA1xQZq6uuzwO/XgWEIBINaBIOA2w2w3aUla3lKFVotDYuFVaKyRCVLVhqNN4lkIbHKbTMYbipWLZYIHI4gHI4gTCYKBIGkgx0l0yeoDTQxXXjzzTeTOl5t/qd7POD3k+jttaK724bubhvOnCnCjRs3VYnLl7vw/vdfRl2dfEe6du1ajI2NqbIu2LSpD3PnjuOnP23GyZMleO21GuzaVY3m5lGsX9+PFStcKC6WJvTUQq4eBoNBTE1NKb6fpYK2KCGZoFHChWSpMYgaiBWSao5PhP7+fkQiEV4FKIQckSNGJBLhLaSUyk9MPCmpT6UgdYza8hCqXoGb+RwYGMClS5dgtVr548SLEWIRwNWrVxMu0EciEVy8eBH9/f3Yvn07uru74XK5sGLFCgwPD/P5cblcvNWWGO3t7QkjzgNsuXB9DE3TCRdTQqGQ5Nhf7p4GBgZi3BuIzxWad4vrzOjoKO96QwhhEBspP95Xr17lSchEdYOmaXR2dsZsEysmOej1en7f4OAg9Ho9T0jmODFlpERInjt3Dj//+c9lJ+Mf+9jHsGzZsrQzl0MOYmR7Us29fDh/LMmCy5/Yz0tzczPfGadCYqm577lz52bcr5OaaKUA4kxfZrv5r1L+0nU3kUmXAkr5LCsrkyQkhcpgpQj0Un40MzlhSTWtVPw+rl+/Hm+++SZsNhtvZg3MTD0UK5KlyoHLV0VFhaRplRzScVdwKxKSFotl2vy7cQg5HBhetgyjLS3S9ZBhQAYCMExMQOf1gohEYJiYgGl0FMboxzIwgLxr12Bm/GgaPoWm4aiZV3t8chxojQYamkbEYEAgPx+MVgvd8uUYtIbA2DWg5urhzy/AcH4N2spb4Kas8Hp18Hs1gEYDjYbhTb1Z815WmafRMPB6deCqod+vxfi4ET6fNvrR8b+DQRLBIAmXywyfTwuzOQKnkyWG7PYQnM4gdDoabrceVVVu6HQ0NBoGJMkqAfV6GhoNDZomeB+aJEmDJFOPoF1aWqpKeRX/mBiYzRHMmTOJOXOUAwgA8epwmgaCQVJAWnJEJWt2zyklCYIBwxCIRIioYlKPSISCRsOSqmxeCNA0oNfTMJkiKCgwwGymQFGTMJkisFqV/YyyPjPZ58P60CTBMDaMjkb47ZGIRvAhEA6zv3U6mncFYDRGoqpJEqGQBuGwBqEQ+zsUIvlzwmENnyZFkQiHwe/j9kci7DEsmatFOMy270hEk7YqVQiNhoHJxObfbN7Iq4I5VS/n05X7RCKT6OpyoLa2EBMTQZ4UJcnMBRnKNsbGxiQtW+QILW5CnOidm4mo6AwDuN16jI4aogslRoyPG+JcMQwMWOByxZMdWi2N5ctd2L69A0uW3CQ2hO/tdFBe7sPnPnccly/n47e/nYuzZ4tw4UIhLlwojO73YMmSESxdOoxFi0ZgtUr7mM0ExM+qq6tLMogQh2TGTFJioHRB0zS0Wi2/0JOJNNvb20EQBMrLy+PGo2NjY6oVkhzEx3OL+3Km3slCnL7QLYG4nzhy5AjWrl0reS1uHsDljyPZ2tvbYxSSUpBbaBNCTNpRFAWXy4Xu7u44E2IuL6OjozHEH03TMb4apSB2PaWmr1SjKhXW39HR0Zh3vJigTeTHUzznmpiY4O9z9+7dMfcshUgkojg+bm9vx9WrV2O2cfNir9cbk6dQKMRbRxIEgeHhYTQ0NIAkSb7/VWNt9VZESoRkaWkpjh8/jqamJsn9x48f553y5pBDJpGqz8JkJ+NSK0rCNBoaGlBbWwuaphOaQVitVtTV1SVtkup0Onm1l5r8KznQTRUrV67kHR4ng0ySH3L9DAdxMBi1EE+Q1UbN1mq1aG5uBpBe0CIOGo1GdUTsZKA2vcbGxoyYS6cDYV5Jkkx6gihcIRWmtW7duhjn8dkGQRCqfLZyeayqqlJNSKY7OZgRQjJNk+1sBsdKBL1eL+0HkCBAmUzwJRjk6qamoPX7kXf1Khu8JxKB7cYNaAMBVnXp98M0NISwxQLj2BjI6Iq+NhiElfPR19ODWom07wIQstkQdDphHhpCyGZDyG7H0MqV8BcXg6BpGEdHoXO7+QBCgcJCGMbHQWu1iJjNGG1uhm9BKYyjo5icMweUyOxL6/OB0unAJOkLNylQFIzj49C53aANBkQMBlDRj97thtbng1avh87jARXNh87nQ8hmAzk6CtuNG9C73dBPTUHr80FDUYiYTNDpdNCGQjCaTKqDB4jrkEaDqF9JCoB6Iken08lGvuXABQWYmlKn1jIYaBgMsRNuiyUyLWS92A2FHCIRgidtPR5WxRsIsIpT9puMkp8kKEoPn4/hCdZQSBOjTPV4dJiYMPD+RL1ePbxe9X5bgY3R75uqLK2WJSY5kp4zOddqGZjNGjDMHJ7E50zsuWPF20mS4dWcViur8i0v96Ky0h1VuCZXxlKQIlPk3gHcOy6RAkdOvRcOE5icNGB83IDxcSMmJlhCmXXXoMfUlAGTk3q43XpMTOgRiai/QaczgOpqN6qqPGhomMDq1UOwWqXbx8KFC/lo59u3b+cX34T3XVxcrCoi+oIFY/jiF49icNCEI0fKcPRoGa5dc6K/34r+fiteeaUWGg2DhoYJzJ8/hoaGCdTXT6G83KtIXktB7rlILU4rLfCnouIrLi6Gy+XKCHk4NjYWY16aiTQ5pd7Bgwexfv165OfnY//+/TzhrsY/oJoo4+K+kGEYnuTq6OiQNXUXwuVy8ZGmOQiflzh/wnGzXN7F7wKl8V6yhLzYbyVFUXH1S0iojo+Px4yt1Y6z04lsLbyG8F0sfN+KFxwTkYNiiI8/ePAgtm7dyv+Xq2OJyFgOYjJSmM7evXvjVKZCcnx8fByDg4OKqtLz589j8eLFqvJyOyMlQvITn/gEPvzhD+PUqVPYsmULTz4ODQ1hz549eP755/GNb3wjoxnNIQclJJqQCsm6++67D6+88kpa19Nqtar9J6b6Um9oaJCMXjYTxEJdXZ1EBFT5+0qUR6PRqFqFmsi3R7LBYzg4HI4YQtJoNKpyjEwQBOrq6hT33wrg8llYKB1RWA4OhyPGLDqTaGpqgsfjQW9vr+pyVHqRJ1oZzQRSWQyZrkBCasiRdHHvvffi1VdfldzHpKmQnElCcuXKlTh48GDS53FlHrbbEbbb4Y+Oj2w2G7oFCyfr16/H6evXMTw8DK3HA/3UFMJ2O+wdHSBoGtpAAPPNZvRdvAhtIAAyEIB+agqFFy6wJFz0A4AN4DM6CofIrEgRv/sd/5PSauGuqUGgoAARkwnW3l44BQP/qepquFpawGi1MA0Pw9HWhrH586Hz+WDr7sbknDmofOMNTDQ0wF1VBVtPD3zFxQg6nSg5cQJanw8ESbJ+vjQa0DodaK0WxtFRnohNBbJvhm9+ExsBMASBsfnz4Ssthbe8HN7oN0OSCFssCFutiJhMAEFkTNkunIAJfZsKoeRbVu14YbqVw4mg1TK8SjGRkYHRaExIFDMMq1DlVLxcJHX2+6ayl1PksR8970OVJThJPihSJELC41HqgzJj/q7XU6io8KCiwoPSUtYMv6zMh4ICNjCV2oBUSiQM6xuWAE0T/DdNE5iYCIOmDYJ9Gt7368QERzgaMDpqxPi4EW43W2Zilw5q4HAEo4G2gsjLC8BmCwtcMURQVORDdbUbdru69t3c3AydTidJNpIuF6p27YJhagrWyUnU6PXoMhj4aF1KwSNKS/14xzs68I53dGDDhvvxzW8ex9mzRTh3rhC9vTZcv56H69fz+ON1Ovb51dS4UVPjRnm5B2VlXpSX+2AwyD8TtepTqcVzqSAscuCO4VRYVqs1ISGZqiIrkWmuFJTcDfT09CA/Px9TU1M8ISk0dU4UpX3v3r1xptFyEB7HmfurQZtCMD2psRQ3ZxD7I822ewRh+jRNS5JmYtA0HdOvZEsZLvcuFRKPqbpgk7IClDr+2LFj/G+5+xQ+68uXL8teUwqJAiYJ4fV6JefyHFKJuH47IiVC8h//8R9RWFiIZ599Fj/84Q/5Ck6SJFpaWvDzn/8cDz/8cEYzmkMOHFKZfApXMNRMPDL1MlHKq5rgKGrSmQ40NzcnpZRMlF+bzYZ169almy0edXV16OzsVPXc9Ho9amtrYTQaY14SFotFlcp0kUSQjJmA2jqxbds2vPbaawCAkpIS3hm12CcnSZKq/HTm5+fzhKS4vNWsdkuBu5fGxsakI3eKFwYy1W44J+Ryylk16lg5gmG6CMlFixbh3LlzWfWRprQgICQh6SQCYMmVixwZnum+ctu2bSmbN8qRwOJBcX5+PpxOJ+vvyWpFJOpjalRAsNeuWYPr4oBrNA19NAiPs62NJfsYBrROB0dbG/RuNwiKgq+kBBGTCVq/HwRNQz81BcpohGFsDEUiVw9kJMISkBLqAwCwd3fDLlLJ2QRqDls0ErCzrQ3O6CDfqTJKOq3RIGyzQRMKQRsMguACdBAEaL0epMxzYAiCVYY6HAjZbIiYzWBIElqvF4VRn1EEw6Dg8mUUKEw2GI0GYYsFlM2GoNnMEpVRsjJstcb/tlhA6/WgdDpELBZEzGbopqbYbXo9YDBAE4mAoChAxncXEK2nDAOt1wv91BT0U1Mwer3QTk6izuHAoNuNKaMRQacTIacTQYcD1DQssCRCU1OTqsmvEtS0UYIAb26dn59aW7RYrBgf9/Gm5YGAFgzD+gUNhzX8hzNFZ7tq1ryeCwrFmdsLt3NqUI4QHR01oq/Pit5eK0IhEp2dDnR2Skdw5gIwcQpLYX5CIdZMXkw0islHhsn8e4Mk6SjJGOTdNDidnKuGEOz2EOz2IJzOEJzOQMaDF8W9RxgGBRcuwPbTn6Lg5ZdBcATTL3+JxQAaiotx4777gLvuAkQ+5FpaWiSjITscBFavHsLq1ewYaHjYiIsXC3HtmhMdHQ50dtoRDGpx44Yjxtclh/x8P8rLvVGCkiWay8o8KCvzIUGQXh5S5AM3RkjkExyIJ6q5tqRELqlRlHLgAj2pgdTYRsmHprDdc2IANYRkf38/8vPz4fV6Vc/fwuEw7wYgmcWmZMdKnOm0mPRNZTFTCeFwOGZxS07pqDTuFkYizybUlHc6c2M1aQnNvNU802SvqaYc1bzn/H7/rFtcnCmkHCL3kUcewSOPPIJwOMzLlgsLC1NWK+Vw6yMdX0/pHpOJSG5KqK6uTut8YR5SUf3MFCGZ6ktjuvM7f/78OKfDcti2bZvk9kSm4RyEqjupZ5TqvSdznpIfIjGE7geUFIPz5s1DaWkpT15KoaKiAs3Nzejs7IROp1NcrTYajar8j8qhoKAA/f39cdvlVEdA4jLcsGEDenp60NXVhaKiIkXlwOrVq3HmzBnJNFtaWiQHXYmu/+CDD2Lnzp38uXLOxjOJmYzOTQt9CaWgQEumrywoKFCl6JAjNYW+S/V6fcqEpFyepQaw8+bNU/QXJZmWRoNQXh5CeXmSQXnkIIxkf+dTT8EeXYx547vfBRgGppERmF0uaCIRUHo9hlasQMszzyA/qi7p3bQJYbMZhslJTNXVwTQ8jIjRCJ3Hg2qB25LWhx4CM38+Ij090LvdmGhowFRtLZwOBybHx0EwDMhIBEQwiLDVCk9FBXgbV4aBVa9HcHwcxoICWPPzQUUiKC0sxOVTp0BEIghbLNB7PKhZuhStMn3+Pb/6FQy//z0AYHjJEowuWoTC8+dRKJjwUzodyHCYJWvdbsDtRjboPipKXjIkCRAEGIIAodGADAZBRsliKTgltkUMBoQcDgSdToStVlB6PSImEyJCItViQURAnlJGIyitFiBJMACg0bDfURtkhiQRMZnYBQMV7S0TqvPpGh8QBKLRxGnYbPGLBKm6e5EDRREYHDSjv9+C3l4rhobMGBiwYGjIjLExY1zApGyAjexOQ6NhSUabjTUpz8sLRr8DvH9Xuz0EqzUU/Q5zgsOMkM7pwHbjBrB1K9YJ+pWxefPgLS9HVSgE6uRJmF0uLPjFL4Bdu4AvfAH44Af5YwmCiPMJK4WiogA2b+7F5s3s4gpNAy6XGT09Vty4YUd3tw0DAxb091vg8egxNmbC2JgJFy/GW5VwitHCQj8KCgIoLAygpCQMh0OPgoIA8vICsFgikk2MM7cFEvttF98TFyxF6T2vxvInFahVK3IQtnuOhFFDSHZ2dqK+vh6Aeh/j4XCYFxgkQ8IlqjNiJBuAKlW0trbGuM44fPgw/1stIckwTExdUEs+JzuGTJeQTCXytxKysSCfKWL36tWruUC6UaT9VtTpdLmQ5jkAYH3ypUJIpotkB7epOIPmXvpAvCIrFRQXF6fk4D+bmGkV5q2OpqYmdHZ2plSOtbW1CIfDmJiYwLx58xJG4ZaKjFdWVoaBgQF533eIDbgS7zNNo1i3CwsLY9pKeXk5bDabbD1eu3YtXnrpJf6/wWBQTfLk5+ejtrY2zgwGkG5/SiaQQphMJsybN0/RfEItUnnO3DncgE0qcEGmMX/+/KQUEkIIfXqlAqFCMlmT7YKCghilYXFxsezESqPRqJqAAmxfPjk5GeOjDGD9+gnrcqb7w7y8PFV+rITIZB5KS0t5QpISKMFpnQ7eigq4JdxQRAT9zLmnnorxCcrB0tfHE5Jd27bh6vvfLxkN3lhQAE+0vsuaJhMEGL0eYasV+dEACAwAZ1FRTF5CDgcg6geam5v5aJqMgDTruesu9G3eDNf992Pju98NALjyN3+Dtr/+a2iCQRTr9fD09GBtUxPO7d8PnccDndcb8633eKDltvl80ITDMIp8jcmBDIVAJiAEIiYTQjYbwnY7QlYriubNA+XxYKq1FYaJCRgmJkBGFaRalwtml0vVtZMBo9EgYjDwSk9apwOt00FrsaAS4P/bS0qwzOMBrdPFHCf8HUOGGgygjEbWP6jRCMpoBKFWTnaLgSQZVFR4UVHhxcqV8c/I5yMxMWGMKiu1AKwIBgNRn5YUDAYaWm1soCjuW+63cBvr7zL9+6ivr1dNSKYarEqj0cS/m3p7sfj730f17t0ATYPSahF6z3tg+Od/xptRFXbV9u04feAAdH/8IxpffBGWgQHg7/4OePZZlL7jHRhcvRp5eXlYuXJlnH/3RP2pRoOomb0v7vm53Tr091t4gnJg4ObH7dbzgZzklLEA68f0JjHMfnOf8vJu+HxlcDh0CIfZ9wRFEfD5bpLYnHsCv1/LK2adzkK4XCtBknoEAqtBkkz0E1+PuO3CbcKI9wYD6xPVZuOCRIVgs4VhMFCS9cqVZD+k0WjixqbCd7wSycM9S7XvxDNnzvDjzWSJUw7puvbKJJTmqUJz40QKSakxjmGBJwAAdHNJREFUdaaR6riFExtkcxE9U2mrEVuoOSbZMeHtjKws0/X09ODzn/88fvazn2Uj+RxuYaxbty5mZSdTyDaZRhAEfw3OIX0ibN68Gb29vSl3gHq9np+4LVu2DKdPn87aSmeyWL9+vWI5vBXJTSFRJnzmalQYTU1N6O/vx40bN1BSUoKGhoaY/XfeeSf279+PLVu24MCBA5JpcITkpk2bZH361dTUoLe3V5LQBKSf29atW/H666/HkQhFRUUoKyvjSQAxxKukLS0tWWn7yUCv16c8OJWDGjN3MVLxV5eqj7v6+vqUScV0zgViVZFMgoUcsSpn3bp1MXVdqU9ZvXo1NBqNKqfwcuWY6T6roaEhxkdReXl5nOI308HYlCBU40YEhJAUychBjcm9cDulkJbwXjQajaxqgXs+wndu0lYUwvuL3ve6u+++eWz0GrTBgFB+PjwEAWrNGriSUHQXnj2LtZ/7HABgrKkJb37lKyAjEWjCYTAaDRiNBlaCQGhyEppQiA0uxNr8wm61gjGZMBoKIWyz8c+AW7TZvn07IsEgDu3axd0cH9ndMDkJfTTCOxkMQhsIQOvzseSp18sSp9zH4wEZDEITDkPDMGBoGgQAcN8MA4Kz3KBp6Px+QGKCJH5bVKouJXlQWi1ovR60VssTmZxvUcpgYJWf3MdsZlWgZjMinO/PKLkp/I5ECdCMRJXJAsxmCmbzTfM8uz2M8vJyBAIBSd9oM4Vk+p1U+yiLxYL8/HwQFIWi06eBF14Adu5EDdcv/PVfY98992DZO98JU0EBVpaW4sSJEwAAxmhEz913o+/OO/FATw/wpS8BV69i5Ve+gqnqahi/+EXgscck88qNZ+Swdu1ayeBANlsY8+ZNYN68ibh9brcOIyMmjIwYMTpqwuioESMjRoyMmDA2ZsToqBE+nw6RCInhYTOGh6XHX4C8b3JllKZ4njpotTRPTlosYdhsIeTlBVFY6EdhYSDmW8lHajAYjBOtCN8DanzpqVWmVVZWwmg04syZM6qOl0Kmx4rpoKOjQ3ZfT5SsJwhCcbFdKY3phtSiJPc/m/PcTBGSwnqcTprTYUJ/qyArhOTY2Bh+8Ytf5AjJHOKQCXWhFDIxgEokdU8WVqsVVVVVccFbOAJDKWI4wzDQaDSorq5GV1cXCgoKYLFYEAqFUsq/HFatWoXjx48nfZ7T6ZSd2Fut1mknJMXKs5mE+N43bdoUo8QSgiRJ3s2FeMIuhJp2w50vlZ7wGJ1ONyPlpHRNYV5Tqcdqz0nnvuXq9F133ZWxtDJ9jhoITXkzjRhCS6AKlSLo03G7kcj0XWimnYlyXL58OU6fPq14jMWSfpCMZPKajJo15rkoEZLC9iJnii7om5TSUktICklIpftX6hMZASFJReuGVqgOl5gEJGuKHKMyjZpEUyQZsz1sNsMv4ZeYdDqh1WoRFLU7Yf+kEZU9F9ndJ7BISrTYVVVVxU9WpQhxACAoCqTfzyowAwFoQiFowmGQ4TA0oRBKnE6M9fezpGYohHk1Nei4coU/ThMOgxT91nk8bIT0QIA1TY9+C32EkpEIyCxN+Cm9HhGjEbTZjLBeH0tcmkw84akzGkFPTcFXUoJAXh6oqOn66i9+EQBw9qmn4C0rY4lTnQ6UkDjltmm1gEYDgqaTVoGTJAmr1ZrVCbiwDojBLWKmg1T6U/3EBAovXoTxT3/Clv/5H5gEauqR5mZcfe97seHTn4ZfMG4Stk/OMiMIAB/9KPD448DXv47wt77F+rp9/HHg05/GwlWrMLxsGcaamrB00yYArCsZJcj5jFaCzcaqCuvq5BX6waCGj2TOBRjigg1NTBhA0ya43TQiER1CIfZdR5IMzOYwzOZITFR3sznCKx2XLVuES5fOgSRpEAR45eSCBYtx7txFUJQGFEXwHy7YEfc/HNbw0e4DAZIPDMUFPOL8q05MGDExkVjZbLOFkJ8fQEFBAEVF/ihZ6Ud+fgA9PZO4445C0DQfjyjpoHtqzG/dbjfC4TAcDnm1aqYQCmn4oFpCNavfzwbWomkCBkMERiMFh4NVxnIKVJ1OTRAjRJ8BgUhEA4rSxPwXbqcoEqEQQFGaqK9ZNtgYq76moNezKmzut9FIQaulFVXVDMMkreJTMx73+/1x/R5n3ZWsBVMyfVA2zLfTISTfiuIdOaTEDv3lL39R3D+bWPgcYrF582bs27dvprMBILP+0xYuXJhU0BU5ZKpz4Dooi8USNzGVUlTJXZcro2xFm1UTxIWDw+HgTSKFk6UtW7bEHLd58+ak8pBJqI3cnSmoCWyihMrKSpSWsqvb0+WTs6WlBUB8tEc1flqFx6TrKiFbSHSdVPsdubaipg1l4t7TIVOVVJxVVVUYGRlR7ZspGcSYbEcJpMWLF6v2uyQst9raWkQikYREIEEQin641Jr3Kz2ziooK2Xxw55Ekifnz5+PKlSsA1EdhlYKUCbQYiephjL9bYYROJb/fapSJgvMZhcU2tW3AZDLFmN4zDCOZnsFgiAnSFaP6Fpmk5+fnx2zj7quxsRGjo6OoqqpKun0JiUdhPVfjS1uObE3Gb/TmzZvR0dGhSEhWV1fzVhqyC5kkyQZVAiBVQ83V1RgQ+C6bs2kTOqIRfuUg6z6BYeAwGgGvF6HxcRTZbHCPjYH2+3lCUxM1cdf6/ezH52M/fn+c8pMMBPgI9NpAgK/XvJn81FRafkGXfu97SZ/jLS29qeaM+vaMiIIlRcxmREwmmEtKoPV6YfT5YB0YQJRRYknbqH9PWqMBQ5Ks6pYk2W1RchQEAb1er0hoLlmwAL1y/rXD4ZvBYgBoKIpV846OQs/52WUj+7C/CYL1ARsMss8pGITNbgfldrNlHgyyz8zjgd7thn5qCoaJCfZ7chL6yUkYJifjXBgE7XYYnngC+Nu/xREVwbDmz58Pq9V6MwCewwF8+cvY3dyMmldfxYJdu4CBAdTv2IF6jtRsaACWLwcWLcISgkAvwyBQWIhAQQEoAUmZrXGKwUCjuNiP4uJYcod771qtVng8nqT8mtbW1mLRImDHju64fdu3L8GOHTfSyjMX6Z4jJzmi0u3WY2zspgp0ZMTEq0Ddbj3cbj26upQsyap5ks5u14Ak82A0UjCZIiDJ2L6eIG66IWDd3t40N9dqWVJW6hiCIFBaasXQUDMA8O4MhO4NONN1rfamibsUYRsKkXwAK458ZD96hEKpq7F1Ooq/By5PLOFI8MQjTWd33EySNIzGCEwmCkZjJBpILMI/D72e4klNo5GKIce5j9FIgSTpqL9eCoODLEmr11PQ6aQJTyk1bLYES9lGorlTLmiNOqT09N/+9rfL+wCKIsf65pAIydSRRJMFu90OkiRjVj8yWQeF5mPpwG63w2w2g6IoVek1NTUpBj1IF8ms7CxdulTSBF3O/Hc2YuvWrVm/xvz581UH9+IUi+JtqUDtyn6qL32lfCUKEJPo/ET3vH79ep7ESsVEWnwNkiQl6/6DDz6Ia9euSba5VP09arXaGLJo+/btKaUjVUbV1dUxjs7lUFtbK0uSZLKftFgsMYMvsQ/Jmpoa2XqaaKGmpKQEABuJlDOlmjdvHq5Fg64IUVNTg9bWVj6qZDpEuhKE5FOiYATprKLb7XY4HA7FwF3cfXEEheIYTSUhSajIMyXsT1S2caVnQJIkSktLeRJNfA8bNmzAoUOHYtLQ6/Ux9UdIktJ6PVavXh2TN075yRGSqYAULDQKVaIrV66UVcQngnCcw92fnLJR6NdaDgRBwGAwIBAIzI4xOUGAMRgQYBiEtFoEiovhtlr59lxfXx8naFi0aBEuX76cWNnCMGykdgFBaQEQmZgA6fdDGw0iZCUIkIEAwhMTsHi9wNQUS26GQrBotQhOTbER58ESZWGbjSdKeeVoOCzbNiwp+FEvAqA+PFXyeDCFc6RD/2UGDEHAV1MD3YYNOF9RgcFVq/DgO9/J7lRBSMohr7YW7Q89hAXPPQe8/jq6v/1t5F+6xJK9bW3s53e/QzUAYZjKkMXCk5PECy9g5cAAhlasQMRk4v26hm02hGw21pdtFtoSF9gimYURte6jUgVB3Ix0X1SkbE5dVVWFK1cGMDJiwvg4S1YOD98kK9mPCV4v2zcHg1oEg1qwvHc2lYypmsGrB0EwsFjCkmSdRsMgGCTh92sxOWnA2JgBPp8ODEMgHCYRDic3niUIlohlPzdJ2Zvb2O0aDds/RSIagQqWJVdDIRKRCFvPKEoDr1ePzHNm9/K/tFqWmJT+3NxnNmvBMAHo9bHbtdqbx3P7tFqaD1hWWGhCJIK4spcjQzONRK4GlFwJJVpofishpZlpWVkZfvjDH+Jtb3ub5P6zZ8/yKpwccsgEpiMarRKSmUwuWbJE1lxPSN7NBvNiQCHAAKRVQzMZtTddSJnrcApFKdjtdkXlkbh87rvvvqwQfomONxgMCU2Rli5dmlYe0lVIGgwG5OXlYWJiQnUd4nzOCsmGNWvWyPrIVIIaQoQgiLjnl47aC2AH6hUVFaqOnTNnDtqjk2ExCgvjI3suWbIEExMTqiNDZrvtistFGGWbThA0SaPRqCK2hairq5MkJLn0tm7dildeeSVG+Sn37FLpj4X9eaJgaekSkjU1NYqEJJd/p9OJ+fPn49y5c7JBeoQmy5RSf5WkQjKVRYcVK1bg5MmTuOOOO3Dw4EEsWLAAPp8PDMPwpqbCshP2BVyacQoxQZ6oqC9muTwpqQe5PEmBFPS3cqa6SiSa1DXnzJmDc+fOAYj1pSmEUH0oZWYu9JGnps+76667sHfv3pht4sXdTEKcjzvuuIO32ikqKuIJyWXLluHMmTP88QmVYwTB+gQ1GFjFHNhgQWJzQ2c0WJJUIJa5c+eit7cX4aEhaL1e+OXGBgwDIqomJCMRGIeHMef//g+Dq1cjmJ+PKqcTw+3trD9Pnw+lJhMmu7pu+vmMKj4NoRB0DAOSohCKLmYwrMSLvQZNs9ehKICmoeHUkzMAJqqOZAiCjRwfDYCk0WpBRyLsNr0ehM2GsNUKn9HIRoR3OBCy2xF0OhGy2/ko8ZTRiI0bN2JAwie21FjGYrFgyZIl/P+SkhKsW7cu5pg1a9awiwF6PfDAAzgXLSvd1BTuLS4GTp8GrlwB+vrgvnoVptFRaP1+6L1e6L1e2Lu6gNOnUQqgVMaVEa3RICwgKMNWK/8dtlhQ0tiIrvFx1vep0M+pIKhTxGBgFzE0mjjLBM61iBpIten77rtvRoKxaLVaWK0RWK1u1NbKt9NgUINAQItAgIxGnSej/1kzZ4riXHZwr5/4/xRF8CpCiiL47VwxMgy7raqqGt3dPfxrjDNZZxiCN23nPpwaUahYJEkmSoKxakGLJQKrNRQN+BPmf5vNESQzfKBpwOfTwufTiUzpCZ5c1OlY1WYs8UhnzD0uRRFRolRY/iT/bDiT80CAjCpFWZN+sVk6TVswNRVBJKKJITyFys5IhEQkQkq5J84qhOpPg4HiiU0h2HrF5pWiCL5ehsOsQtVgoGCxsM/b6QyioCAAhyPIB4ji1LXsc4vfxv3nriVU6Go0nOIXmDsXmDdvestntiGlmXNLSwtOnTolS0je6qRFDrMXifxKzQZUV1cnPgjSE9SlS5feNEORQabvf+XKlbJ+JAmCSFnRdauAU15J4c4771Q812q18pHhgOyZHGSiP01EWAqvIY5AnIl8GI1GbNiwAcePH+fNLBNBithXqz5NFam2L7lFOIIgVKs6GxoaJAnJxsZGlJeX8/9ra2v5IAiVlZUxURY5zJ8/H2UCf3OJkA3n2lIm20pQYzYt3rZ69WrZ9LRaLR588MEYNyXC841GI7+6nYryVpyXmpoaXnHHmRrrdLqk/WSJ01fT7rhjFyxYEKfmLSgogNFo5E2/CSHZJLpvocpVjUKSVlluwrJqbGzk/V1ydZRr6yaTiSfa+vv744hiVQFuEhGSgv8ajUa2zXPklSSEKkyZui0XFEHODL24uFiQRek8CetpY2MjDAYDT2ICsf28cCyeDBG/evVqxQBkybp3WL16NY4dOyaZD+GCn3BfeXk5zpw5w+dPbsHg7rvvxu7duyX3icu4rKwMkUhEtj0SBIEVK1bgwIED0BQWAnJuFggCjFYLSqsFBSBkt+PMxz/O7177wAM499JLANgFKaKmBhcPHYpLpri4GDU1NSgtLcVralW1USUoGb0HoVsIKdx7772yC3gFBQU3FcIMwwYY0uvx4F/9FXbs3BnTThYvXozzZ89yNrH8duEiUkVFBfx+P2iaVhV5W6oNLFmyRHIMrdVqY7br9XrVLnrCdjuwdSv7ieLASy+BpmlofT4YR0ZgHB2FaXQUS7/73ZhzJ2trofd4oHO7oQ0GoaFpGKamYFBYBHSqyhULWqsFo9GAJkkwEr8NVit80UBZIAhovV5eoauLtoltoRC/eKTV6fCAVguYTNgcDoPW6di6Gv1m9HpQUbP/0upq9I2M8P/5AFPib52OJVU5kjXqP5XW61mXBBaLqsUrAFEfhiE4HJnxYaqEDRuKceiQ9ILlTEKjQZS8nbmgOax/0gjMZjlnHeqwYMGCuPHn6tWr8eabx6PkJKvQ5Ai+cDh2m3A7ax4v3h57zs1tLPkZDmui5CnJk6TBIPs+zoT6MxQi4XZnXxB15gzw299m/TKzGinNnj/5yU8q2sQ3NDTMGj+FOdz+UEsgcER6Nq+hBDGZOmfOnLiO/Fb1oZEOFi9ePNNZSBl1dXWwWq04evRowmPXrFnDH2c0GuOIlEyb32SauE5XIZkobQ4URcWRQ4lIiGQIm3TypgQhYZgq9Hq95CC9qKgo5r/ZbE5IzJpMppRV2JkKdBMTZTsBcZVKYCOCIGJIHCH5IvxdUlLCK6+EZdLS0sK7AtDpdDGRvsUmwWIVnriOaqJqFzGJyF1PeE+pkurJqNmFECuJlFRWd911183FCDXPQfiM+U3x9S4/P5+v11LR26Xyv3DhQjAME6MakrOWEJZLjMm2RBAvJnotgiCwcuXK1PoGCd+ZYjQ1NaG7u5tX9gmDK0kpEMX53L59e0KfqVIuUxobG9Ha2iqpkORM3pUgdqsg9GGabFndd999kqboidIS+mIV/hf76DSZTKr8dgIseXfhwgXFY7h6VFJSgvnz50Ov18cszm3btg2vvfaaYhpcQMLu7m5Fdz8p1buoEpSOErkVzc04LxG0hg9mk5eHsIx5f8RmQ1iKdI2SX5Lb47ITS+4zDIOysjKYzWbe1UBNTU1coIqamhrJPKld0FeL0tJSRQuCiNkMT3U1PNHrLjWZgK99DQBw+l/+BX2bNvHHakIh6NxunqDUezxoyMvDwKVL0Lnd0Hm9KDGbMdnbezOoE+fnlAvuJCLDNdFFC6W3Y6KRobhH5J5SQqcOR46gMtExKsFotZhrMrFm7hYLqxCN+lKlTCYwNhuCWm2MYrRx6VJQN26wKn3OT6rwQxC871QI/0c/EB8fPYZLi4gqi5OSL2YKnKQzxWsvWrQoYV81m8GqOiOYCY9eFIUY1a3fT/LkZTjMWR5A8M1E11mYqLk3ay6u0dAIhUjed+jYGOt6wO3Wxyhrb35zH0QVtxqEwwSv+iWImypdTkHKBR8qLU3sguV2R0rsxx133KG432KxJFQW5XD7YbarYsvLy1MmJIHMEzxShORsh06nSys4gxTkBqZqMNvVskJwypXS0lKYzeY4AjITUXlvBSRSokUikThiPtkIuFJQqivcBF58XHFxccrqtnvvvTclQrCxsRFlZWWw2+14QyJ4xP3338+rI4GbZuZyaqyZREw0Z4nnbhKZVKppz6m8ZxYuXIjJyUmMjo7GKSQ51NXVKT5rzoSUg7hOilVjmTDZFtefBx98EDt27JA0bRcTOErIltknQxCora3FnDlzsGfPHn47SZKSJGQiSN2LsNxLSkowODgYr5QS+ZCMg4CQTJUcFtZnRqad19fXY2xsjCcky8rKMDk5CYZhYLPZoNfrVRFpsVlP3EY4/5JS5F9eXh4AdcQkh7KyspR9XWm1WkU1ZaL7KSsrw9mzZ1FWVoaJiQk+LaEyR+4ZittcomtxPje5c6XIb7VjjiVLlvCEpNL1pJBMYBO59q70zuQWvex2e9oLT+I6xjAMGhoaAIAnJKXeg2rfjemO8UpKSiStF8T9NU9qC8qNEj1/Wq9HsKAAQUF/U9HSgnbBvMK8ejVORNXAQKwKtbS0FIN9fWxQIIoCEYmwZviRCG+aT0Q/SxYswMWzZzG/oQHXL19mtzMMS/Dp9YBGgwWLFqGopIQVABEECI0GmzZtAkIh9hMM4vAbb0ATDsNhNMI7Po4VixbhwqlTKLTZUFZQgKvnzgFR/6jVpaXo7+yEJhKBJhxGaX4+Rvr6WN+pUWJV6/ff9KcaDELn84FgGBCRCBvISGW95SBv35AZcPZdtAyJiSjJSXOkZ/SjNZkQikTYQFIEwbpP4D4UlfCbjI7HGILgFa+qvkkStFYLi9OJlX4//58bS/H1hKZjAk7FWTMIxQPcb8G2sNXKuhHg3C/odDDm5cEdiYCKqmMZkmQXQEgS+SUlGJ6YAKPTxeTXSFGwd3WxRLBGA2bePDA0DZ3Hw6uuAXbMwZc/Qdw8nlNcZ3AuR5KAxcKa2E83hP1KIksC4bj9drdEVIOkCcnz58+jublZ9cvk0qVLmDdv3ltS+ZVDZpFoYDLbCdHphjjARCKoGfiZzeYYRdJM41Z85g6HAw5Hdpx433///VlJF8icQnLJkiUIhUIYGRmRDNhQWVkZ977Q6XQx6iIlyPn8FJvmy91LeXk5T5yo9f0ohVSJjkT1gyTJOAWg8F7kgmDIQeo5ptqu4vwoioLaiLFhwwbe311GricTCAUAmpubsX//fkmSxmKxwOl0xpB84jQqKytjCEkxxINPcTCdVGA0GpGXlxdXp1esWBHnJ4y7F04xp+i/UDRIbm5uxsWLF+OOiyiQGg6HA1NTU7H3yDBYtGgR/3fVqlU4fvy4qr5C6Ri5cqyursbly5fj3knCoymJdihnYs1h5cqVOHHihOIxUGjfW7ZsiSFkOXD3uGbNGpAkia6urqQJSavVGkMOCsvm3nvZQAIcGSWnTASUg3RJuSKQI5OTdUkgVgxy+RerwLljuPbMEW80TaOkpAT19fUJF3TlCEmlumYymZCfny9b5zLp+1suHxaLJYaQFJdxIsWq2WxWNGfm7i1ZNxVSfasUISnMR2NjIyYnJ2EwGPjFbK1WG3Petm3SIXSamprSWqitqamB1WqVfGZ2u12aZBdIumgF/+EAm29xUCzxwmB9fT1/DEmSAEmCMpuRyEMr1dICwmKBZsECjEj0NdXV1ShcvBggCHiibl7uuusuQFReo9F7NFVXY9zlArZuxaL3vpff3/nKK3yeizZswKVDh2Cz2dDY2AifxYJTBw8qu2FjGJCBAOYUFqL/6lVofT7ofD5WIRr9Tfr9rF/Vzs6bitFAAIUmE6aGhlgTdJqGSa9H0OfjiT8ISUDuE/Xfyu3TqFxc00TTSwbKT18dCIZhyckUFoxnW7jQOpntwlHy1ObNMAC4N0krWUaKqBQpZWmtVprIjX643xzJyqlr+d/R/xzZarBYWHcIWi1vNcGDIG6qzAHenQUl+NAGA0veRoldEARbzygqoZqXoGnU1taifWBAMbDgWwlJs4TLli3D4OBg3OBBDmvXrsXZs2dRX1+fdOZyyEGIW5F8kkM696J2EFlbW5u0IkWMW0mBmG2sXbsWR44ciduutNgijOqd6jPX6/WSA2opYiWZCUaiIByJjk8VWq2WL7OlS5dKEpJiaDQarF69Grt27UqYPheYQExALl++XPL4urq6GAIwka/N2QClCUJLS0tShGQ2wBFciQhJtaaMwtXjysrKGIWo2jQ5srC4uBjXr1+P2ceVZUFBATupSwFyCkkpP5DiZycmkYWBRjZs2KDq+uL7llLM8oSMaGIm14ddfvxxFJ47h5F3vCNmO2eaKYZYUZRMn5HMsS0tLTFmxXHtQRhFXEAqeJ54Anj5ZfTcdRceeOABybQbGhp4FaEShPXZKiL3hGbUhYWFcS4YuD5GXIY6nU7RJyrAklHC4B5S4MgoJR+S3H+dToeSkhKsWrVKNjq4+L0iJpN27twZs7+srCzGTFbuXUMQBDQaDXQ6HdasWQOGYfhAZlKw2WygaRomkyllFw8A+05tbm4GgBgiXuiHVe5dmux7MJHJttQ+sapGfExJSQnGxsZkyVFxexYrLsXltXDhwrTHilw+hWlv2bIFACtkMRqNPCHpcDhi1KdybhgaGxuTzoOQ3FRyB8Tls7q6Gi6X6+YOQdsV92dCEAQBvYR/WqXxoN1uR19fn+x+MdavX8//FqriCYKA0WiMu7ZUOXLvEq1WK7lIKtWONkXN1LkFYOFzjVu8IghQJhOo0lJ4RAKI+vp63lVKwZo1uCBybXTvvffioMC/qbjtz5s3TzZonRBLFi/G1UuXEA4E2HdbVE26fs0aHDl0SJ7gZBh2G6dsFPyuLC9Hf3c3nDYbpiYmwGg0KCkvx4DLhaKyMgyNjIAhSeQXFWF4YoInnPJLSjAyNgZKq8WcuXMxPjyMieFhaCgKhQ4Hxl0uVhnLKWSj33WVlehub+f/V5WWQk8Q6G5vZ1WRkQiMZjN8odBNM3aCYBffYu2P2Wcp109pNABNI48g4B8dBRkKsT5pQyHUFBejv6MDZDAYVyZFdjub92heuG8DQSASCEDn9YIMhWBP0V0fQdOYjbNNZ5bTbwIQstmAo0eBBQuyfLXZjaQJSYZh8PTTT0v6rZFCXPTDHG5bqHUwnQgPPPAAXoo6BE8HxcXFqhwmz0aiU0ldJadQFPuorKury8ggU4zZRFIqKR6EgyE1aSSCXP3Oy8uTVSZmitxKJR015mnJgCTJmAmQ3GRIqN5IhEwRFlz5cBM8gkgcSMbhcKCwsBBz584FkF11aTahqF6IItlgYKm2cTH5JoyyLSRwuEmSnPm00v0sWrQIfX19CIfDiqS6OA1ukp+XlxdnHiM0seEUOXJpceT1nDlzYLFY+CBEVVVV0Gq1cLvdsFqtKCsrQ3d3t+x9CCEm5oX1WQrcdmHACvGxCxcuxMmTJ6UvmKC+cASGv7QUr/33f2PlmjWwXL7MK+7NZrPkMxpevhzzFdLdvHlzSv7FpQhcuX0AYoL23C8gU6e+8AWc2r4dWq1Wsv8qKSlRT4KojC5eW1ur2hcYQRBx7/dULUOWLVsWF+BGClqtFqtWrYrbLhdpW47YFIIjRqwi34VSajeSJHllJ0EQioq4TZs24eDBg5KBjqSUmnJqPo1Gg7q6Ol79IoYSIS28ttPpVBW8RQ6JFk+krgmwpPmVK1dwzz338Ns2bNgAq9XKK7M9Hg+/b9OmTWhtbeX94xYUFMQElktmrLh161acOXOGN/Xm6khJSYlq8/Q1a9aAIIikIkqrhRy5Kcby5cuxZ88eLFy4MNYNkUpCUgr19fWKFkR1dXWKAYiUoEaZK1X+XHuqra1NKsidHCorKyXV9FLlLmzLYlc4LpdLlrzlSE+l+mS32/lFj7Lycgy5XHFqc6KgAKEkrJGEft4LGhow6nRCW1KC4WhbKWxqwtjVq7BUVeGOpUuxY8cO1CxejM7z52/ec3Ex/NGxTsTpRJimEYjuoyoq4JawOmhqakJpYyNOCBaE8hYuRH19PQ4Ktt15553Yv3+/6vtRChpkamxEW9RNEYfye+7BGZlF/+3bt+OQxIIVt5ihCYfxwEMP8dspnQ6v/O53rDsCRN2aCElghoklhaP/hceUlZRgqL//JjEqQeRqoh+CoqAJh6GJRHiSlaBpaCgKZCAAMAyqy8vRd+MGb/ZuIElEfD52vCBh4l5UXIxhl4sNJCZIV+qbjHJdvIk/p+Tl7pO7Lwno3W7gz3/OEZLJnrBx40ZVKxYc1q5dmxH/XznMfhQUFCRFRiQLNeY2QixZsiTlCG5SL8pMEHEEQcDhcCia0wFsJy8HJaKFG4BXVFSAIIiEaotkkZ+ff8u0Z4PBkFHyVCmtVCL0ymG6lIpSCkslNDc383m79957VZkkb926NS2TXCES5TFZtyAmkylGuZ/JZ5gpyPmGzMvLw5w5cwDIE5Ji5cOMLCQIFZKC63MTFWGepEgihmGSNpuXKw+j0YjS0lLJc8RBX7hrA+zER+jncuPGjQBuBl/gItJXVVUBAK5fv46ioiK+n5RSSGYKwvIS13+5ibHFYoFJ7BtNRIAYDIabiiqShNPpRFFREcLhMO688060t7fD5XLxZb37pz+FaWQEk1HfcUIsWLCAV6SKCSohUq2fDQ0NyM/Pj138VogiDiCGyBGCI+bUmCBrBe9BnUriIht1QI48EyvN1RCJQtx///2yikkxxP0UwzDQaDTYvHlzzHFOp5OPai+HRPmiaVqynyBJkn9uOp0O+fn5sFgsMYuSBEGgoaGBP1+tlYDc4mayJBFntswFyRKez/Uj3D1K4b777otz1cBBrIATu+sRkkPid7eatseVjZDkXrZsGXw+H4aHhzF//nz09vZKlgn3/qmoqEBfX59koK/phtlsRkVFBTQaDd9W5HxISs1rpOYjSuN2QL6+cP4rNRoN6uvr0dbWpphOS0tLnMuFe++9V3EMZLFYZMn+BQsWoKamRpYgVuOqp6amhidbFy9ejPPnz8ccK7x3vV6P4uJi2bSqq6t5gpxToXKksZiUs9vt0Ol0WLp0aVw0ean6ZbfbUV1dLUmqCl2jJDvflIJaH7biRTCNRiNJHgvHqJxFhpLLjKqqKjAMI+kWRGkhKRlw6dA6HSi9nifmwjYbS86lMa62LFoEb5Llr+SqrOTOO3FJUHfy8vIwPj4um9amTZtwSsKPe8oQkK6IvouMn/oUal99FRC5fngrImlCUsrJfg45cJiNk/pUkAzpJlxVU3p5cS+nVMxQ1IK7Pmeemml/jwtuoRWcGSNhZDDblLhykzHOzEoMYdtWIiPlVG85JA+5+ut0OuF0OlWnwxEE0w2hQhIJ2qKc+WIy7xQlhaTZbMbKlSvjrglIK7fSaa/cudy3cKKj1WpjTPGE+ZD7L4Z4srRx40ZVJANBEHA6ndALnsv69esTmohyMBqNvKmgsHzqN2+OU1iRJMlPkIXppeK8nTufMyUUgnufChVfSLDgl6hOcWbEiscI0jBLjBfE95nKZE8NdCqUmtXV1ZJEx7Jly+KOTWXB8Z577sHLL78su1+ufosDu0kdK4YcISk8r6CgAOXl5XEB+AiCQGFhIf+/rKwMTqeTV+3Ktfna2toYQlLOfYscuLxVV1fHRD+Xutf581mNsZAAU0OOJKOkVdO3qVHeWywWVFZW8iKVuXPn8gFtpK69fPnyGHcDer1+Rhe4uXEyp7g+deqUpA/JZcuWSfqEBdSXu0ajiTl2+fLlOH36NADWZ+2OHTtgMplky5w7V67/TNVnNZeu2gVduXGE8PpS/b7YuiaRWOLBBx9ET08PtFptDNkp7ruVxjVSxP6dd96pymzearWivLw84WKvGFLtrKKiAgMDAzH7OJWoFIQLmhzmzp0bpzhdsWIFioqK8Morr8RYS3AoLCyEw+HA4OAgrFZrjGo6kRuoVBAxGm8SktMcXttoNCIQCMBqtSYVOwFgyfSurq647RmfPxIES9BydVinQ4BzPSN4Nm9VTP8MJYccZhArVqzIeJqZIF0STUiTVbNlCrONRLtVsXbt2rTT0Ov1/GAsE89Frh5x7jjkHM0rQW6iLzZ3T2X1OdGxZrM55UH5bIVaBU6i+kDT9LT2GxzREONDMsE54gmbGsiRbtlSRqcSnI8gCNxzzz18u9LpdJJETLp5SwoCNVt+fj6cTifvuiCZ6xIEgcbGRknl47333hvj51EJ27b9//buPEqK8t7/+LeX6e7ZehZmmH2YjWGZGRhmBkfWYQQcRiQJ5iga9IjbCYlJ3OLCMUqMUTnK9d7oMWqSe9GfWxJzDUlUMF4Fo4aICxC5KkrA5SpKjLIZZJvn94d2pbunt+qururl/TpnjtJdXf1U91PVVZ96lgGx2WxhL7ZHjBghJ554YsSJWAL2gQRnEffvRhyOUXUsWlDpOwZEal0aTX5+fshjY6jxeufMmaP9f/BNj7q6upA9DyKNMRmKL6AfM2bMsOf0BJL+ZfV/3eTJk6WmpibiDKe+cvt/ruGW9607OMBN9HgV6lhVWFg4bHgUIwLJUMtF+t2I5b1C1YNwv8G+Zf3rSn5+fsB3mBL8giDPl62Pw/3O+P+3r68v5OrCjeEa6lypq6srKefckW4C9fX1SUNDg4iErw/xTmboX4eLioq08+BwPcRCTSTX19cXMuQOLo/T6RzWqtC3P/t6k+hRWloq3d3dEbd30qRJEefT8N/+sWPHBvwe+npUBAvXiyO4bCJf3FDx1aOcnJxhN1x9+2NdXd2w1urJcMzvxutRAwJJPXXN9znE87vsG09YDyNupNhsNjnmyw8IJAkks1W2thwzYgyVZJs0aVJM43GOHTs2rvUHvy6V6oKR9A50n0xlZWVx1fOCggKtRcfAwEDILiXxihZy623RU11dHfZkKviEMrilrdPpDHmC7nA4tG2Otr0zZswIe5KXruLdx+12e8iQwFcHTz755KRMNOf7jsrKymTkyJFfjBsUw/LB/x/r+wQzslW0f/jo+9wGBwdjKluofb22tlZ36/hw2+IL7/QG+1rZQkxq49+a3uPxRA3DfdsYamIHEdHVLTPascZmsw2baTyYr753dnaKx4QbEwH7plJRA0y32x3yGBcqqPHn+xx9F/F6f0cqKiqkoKAg4DsaP358XPtJR0dHXKF8sM7OzrDPhSpXc3Oz1jW9o6NDC1J9F4VKqZDlCh7uQk8rwlCCA9xoy8+dO1fGjBkzLEgP1YIslBNOOEG6u7u1VpP+y/uHEQMDA1Fno461hWQsE5b6QsdYw81U660STk1NjYhfPTrmcsn48eMjbpvvuw13kyk45M7JyZHRo0dLRUVFwFi4Iv8a29RMHo9Hq0f5+fkB5wWRgthY+I5dJ598stY6ubKyUtfvlf9+7X9+6buR4P8b6BvepaysTNrb27VlxowZE/dkdZHKWltbK3l5eWEDU/+yNzc3B9SRUPNrVFdXS05OTsDrgvfHBQsWBFzH+pfPvy52dHSIyBe/K6GOt8HbFTwJZDyMDiRDCXdtHOl8xTe8TjDfZ2C320O+PtI6Y22IFGk5m80mn5eUyP66OpE0yCaSjUASWSGWk3izxu6Lpra2NuTdF6OC22R2GU8lVVVVIQfrTydVVVXS3d2dlHUH1+dQ9SuR7pWRBE+KVlJSEjLsycnJCTveW7BwJw9z5swZ1rooHS6ORL44kWpra4vYMizUtpx44okBAVNwC0mbLfqkP/HIyckJaCGj/E6sD3u9ARcUI0aMiGmSpFB8J8+xdp2KR6wT9wVzOBzaRWiiN0US2YaIdTxECxX/VlkTJ06U9vb2iIGo3q5syea7cKurqxPnqaeKiMgRA3/rfK1SfNsYsE9GaBkmItLf3y/Tp0+PK2zwfSeRWmT4tj3U59/Z2TnsRlFzc3Nc31XwMUPPTQ1fgGuz2SLu66HKNXbsWK215siRI4cdz5VSkpubO2xWZd9yvn052jaHuyiPtB9E4vF4JCcnR2w2m3i93oDQPNzr/R/Lz8+X6urqgG7mPj09PdrnGMvNw3At9YL5PsNoLcNiWVfwe6c6XxdunyG3W5qbmyMe66IFE756G9zS3mazhQxK4vndMWpCvtzc3KjjYIYS3BI++EaZ/7ZPmjRJC8v0mjx5ckCLyOB1+76nkSNHSmNjo7hcLqmqqtImq4t3jMQRI0ZEvCHm/52VlJRoN08KCwsDyue7qeR/juCvu7tbOjo6AoY1OP7442Nujee7KTFu3Dit1Ws4/uVasGCBIddK/oFksrps+382/iZMmKB9TqNGjRKR4WOD621hHm75WFqx+oTqheC//g/6+mT9HXeI3HJLzOvMVASSQJoy4uIvXU4Uown1WXg8npju9qcas76TZIQHesvuu1CLpTzxljc3N1d3d5Vo3VeT8dnNnz8/5ONNTU0RT6RDlcV3Eeyjt4VKvHUwPz8/YMZc5XDI5l/8Qp67+WY5WlAQ0AV06tSpIbslxiJaC6t4ui8msow/32DzoV4fLsjT+57x1j8tdAwRSHq9Xu3CNpb39w84fMvPnTs3rnIZRbuB0twsT9x7r+x+4gnD1u27kRfys4kS7hcUFGghRKjX+08YFszpdEpBQUHIiZd8jj/++IjvL5KcY5aemxr+N0Ijvc6/nJH281CvCw46fReD4Sax8Td//vywQwwY8dn19fVJWVmZtLS0BHQv1HsMOvnkk2N6v0g3HEPVNV+rq0itrv1bFOmVLjcB/WfbHfrydzeRmy/BLVfj/W0KFUr7mDV2f7jwNXhMZN+NgFD1xOl0GtLK2idUIOn/ffX09GjL6BmGKFRdj/bbbbfbtd4Gbrd72A2OUBMUBnM4HAl9n3PmzAl73RPrsSMWvvoYELj6B5JRWmzHKng/8P+3f2vJ0tJSrSeAr4t+pKFx3G531JsJ4Y5zeuqvr87oGfM9W2VUIHnHHXdIQ0ODeDwe6e3tlY0bN1pdpJSXLjMmxysdumjrFal7XLaINrnOSSedFNN4gsFjNSWT2eFvtBPfWE96kl3ucGMvWSnU2GbJFm89jOUCx+12W3as/7ytTT6N0PXc6XRKa2urYRMgWR202+123d1rbTabYa1c/NcZTGudEqb1RKwtwWpqaqSjo2PY9kXrVm2mwyUlIgZNJDNt2jQZMWKEtLa2hj5u6th39V4UtrS0yLRp0wyp13pbvDc2NsZ9DhWq7vsey8vLC3sDxn87Yx2Cw3fDJdL+1tHRkbRQLNxM58GKi4u17tci+ieW0HOzRS/f+Oq+9fsC5GhdDmORLl22h4nzN9nXQmvWrFnadocKhPV8JmZ35Q4l1vOiWG8yB4vlc4kUUOlpueYTrQfS+PHjh809EK58DodDlFJh63tZWdmw8DZWsZ5L5ObmxvQ7Huv4zkVFRSFb7YYKfwMCyQTGPI4kVAAdbplI9aivry8guNXTQtL/8VjP2/WsP1sldCXum5kulLvvvjuRVev2q1/9Si699FJZvny5vPLKKzJx4kQZGBgIO4sVvpDIrMnJGIMsGj0XhjabzdDurvF224l32WCRtj3bAslog1THGrbNnTs3I0Nrkeh1zeVyaReosbbciud9q6ur4+7+Gmm9Il+cfMV7tz2e7W1paZHCwkLJzc0Vj8cTd9cjs40fPz5sa6NknxTZ7faI4xMNDg7KmDFjQu6z6diCOz8/P+xYr5E+60S2P9x6g8c11Fqn/L//Jx/29sqhJ5+Maf3BCgoKpLKyUrvwirRdscxYnSxG1e3i4uKAWcOH+XI8sGScEzkcDq2FdLSJu4zel2tra7WhH8JNIONTWlqqK5AOd84SzzZEC7wKCwuloaFBd5e9WMsU7wzqRrbkjsY/7AkVJgRraWmR0aNHa4FkqInRYgkHoj2XcqZPlwMNDfLB1Kna9hUUFEhRUVHAYpG+E9+YgpGGWom2jlQU/D1G64Gk97pE7/KlpaUBx2T/Y2Wsoh2zcnJyAsZJDq4HIrEFYL51lZaWBixnxA35eG6gx1r3gnvb+ITap/0DycMhPicj+JfFN2Zo8PPB5Q3VvT/4fCvU+Vciv1GxzAPhW8+sWbOiLpsNEkox5s2bJ5dffrkcOXJEe+zjjz+WBQsWyFVXXZVw4fS49dZb5YILLpBzzjlHxo8fL3fddZfk5eXJf/3Xf5lajnSTyIlCdXV10rsKxDM7WrqJ9yLG6JOZdDs5MkK4H9tkMPuk3IqQOlR3k+7u7oRmiPWx2WzaiZev683s2bNDhl3t7e0Rx26J17hx42TWrFlSVFQkDocj6jg9Zoi1y58Z9Txc6+1os91Ger2ecnd3d0tZWZmhAXt5ebmuWRjb2tq0oDpSK7FwfBOOzJo1K+aLq3Dfb9jf54YGefHqq0VmzIhp/eHE0vKpoaFBZs6cmdD7pIqw392Xrd70jr9WVVWlq2719/dbdgMtWgvradOmxdRS0OwWzPX19cNaOIUSb6sskS8ueCN1qQ0W60RtsZQtVpWVlTLVL2SL5b3GjBmjjasYal/3/buzszPipDoRw/xU43LJX372M/m/f//3gAYbwcficGPZRRPrDapUE2soFe01wXznhvPmzdMV4oh8Ua8S+QwXLFig+zyhuro6pnJGk8j5SUVFRcAN5mhDDAXTM8GP/+frP4t3qN+tw/6T9gR1lza619GCBQuGHXPCtbANN2GNEfU33DKtra3aWLv+ZRORYeN1xntDK9Mk3ELyt7/9rUyePFlee+01eeyxx6S9vV327dsnmzdvNqiI0R0+fFhefvnlgDu4drtd5syZIxs2bAj5mkOHDsm+ffsC/mCtaLMEJotZQVFdXd2wWfWCpdMJSij++6AZysvL4+qmkQ38LwBGjRoVcf8yqt51dHQMGxjeSL4TL98PeLhyjxw5MmrrhExRWFiYEt25QqmsrJTi4mKtVUGyj2/V1dW6un7HUp7CwsKwszSGW6ee7QzuRuvr7heu/oZqlRvP5+p0OiPetMjNzZURI0ZIQUFB1ElIXC5X2EDGqhaSoSYiyMvLS3g2Uf/Pes/69bJjyRKRiy6Ka10FBQVRzwn8pXpPCKsm3isqKgo7Xli8wVE8Yu2R4/F4ZHBwMKmBZHBLLrfbrQUp/t+T/3nBxIkTA/ZV/2PZ0NDQsPrne66uri5i4DhhwoSAi/NUV/bleaX/xHDB9F6vJNplOxUE79/RQvhYjvv9X47vrfc3ItJnp+c45D8jdbT1K6WkpaUlZMu84Pc2ct8OXsY32VW88vPztXLquWarrKzUbrqFukG1x284ioNBoW1BQUHEm1pGna/7H7N8x6uSkpKwQ6XE2zI+Wh1zu91SW1srSikpKCgIOF4Ej2mcSkPdWCmhs5upU6fK5s2bpb29Xbq6umThwoVyySWXyPr167WTajN8/PHHcuzYsWEnmhUVFfLhhx+GfM1NN90kRUVF2l+sY9UgeXyDtoe7g5huP97BampqQrZusNkizzrpL9IJko9ZA1yHYvY4dTU1NRnXijaebprB+8bJJ58c0E16woQJhnSbDqewsFAKCgoSHpBbD7o5fKGwsFDa29sDxiaLV6iT3FgDvnD1q6WlxZCypSujf8P0tMqN9H6Dg4MRLwJHjhwpU6ZMkf7+fq0lebjfqcLCQpkyZUrM5TLD1KlTh7VkKS4ujms20XCfY3FfnzStWiWSxGNrOgr3ecX62zY2wpizoYwfP15Gjx6dtJvL0fZbX+tBPSFBuEmOjDrPDfc7HOn96uvrw+7jiYwDaeZ5gRE6Ozt13YTSI12vaYLLWlZWFvHmzkknnSRer9fwIDp4mIBEP0OXyxXyN1VPfQ0uQzoNURDumi1SD6NwXeP/PneuyI03yv+ee658PGFCwHNVVVVhexDMmTMn5Pm873P0f05PgGu322XBggVSWVkZ8lgb6XvKy8vTjoWRrmtjrX/+DTX8u/in03Ex2RK+3frmm2/KSy+9JLW1teJ0OmXbtm3yz3/+04iyJdWyZctk79692t97771ndZGyXqLd9ZItWWVpbW2NaZZMkfAX/SL/OrhmWkAXq1SfxczMk5R4x+GKV1tbm+kTwWRLC8hYhRrbKBahWrb414VYZ042okueUcfY6upqmT59etTlkr1PxtNlO57PwIzfybFjx0pvb2/AY01NTXHXO6/Xa8nkUUbw77pmBLOGVIhGbxAYzOoL8XS7wDOzy7Y/vWOxi0RuIYn46P389AwLYIREgjbffpiMoXN83G63oa3LfGUuKiqKq1V/qO9z5MiRw26MpUIoHe27jKcFpnK5RJYtkx1f+5pI0HE43paINpst5nN9Pa1TbTabVFZWhr1B6b+OSL+LvgkM9QgO1fGFhALJFStWyJQpU2Tu3LmydetW2bhxo2zatEkmTJgQtqt0MpSVlYnD4ZCPPvoo4PGPPvoobHdOt9stXq834A/JZ+TOlyknQ06nM6Yf1eC7gf53WRKRKZ/jjATHQ8tm8Z4sIP2FGpg+Vb7zkpKSsL/N4WbpFfmi+1eq3KDw/yzdbndShiYJ930Z+T06nc5hrSLa2triDiSnTZumTf6Q6oI/R6OHCamvr9c1rlc4iX7fsXaVTrQFZLLU1tbK7NmzDV9vLC0k4+FwOGIK+Yzcj0tLS7Ub216vN+aQq7KyMuDCvKuri66GOoTqsq1XqrVCt4L/vjBp0qSEJmYNlp+fH7ZlbKR9MFIPt+bm5pA9RvXeFDD62GrUMcW/XPGuM/i8ItJ6nE6ndm4X7jPJyckZNqFfKB6PJ6DXof/xLdZjW/C4yaFu4IdrlZ6M7zWdJRRI/uQnP5HVq1fL7bffLh6PR9rb22Xjxo1yyimnmNqdzuVySXd3tzz11FPaY0NDQ/LUU09xAI8iVS48RfSfiJWWlsqJJ56oe51GLp+ocONaRJOfnx+yybxR5U+Vi/lMkq4/PB6PJ+ZWcsgMNpst4bFAPR7PsJO6aMen4Am+2tvbw3ZRNmI8PbNbSNbX18u0adMiviZVW0gaLdoYltnEbrfrGvs0VcUyOH8y66rdbo8rJIu2T8Yinu1qaGiQ0tLShN9bj+OOO06qq6ulsbFRamtrQ46f58+3XcXFxQGt3WpqarJ6/9X7fftPQqJ3HcHjDFshlvDkpJNOiuvGykknnRR1mVDnI8kY8iDSZCfhHq+qqhp2jpyqv8m+a86SkpKI5/WRbnKG+xxi3ebgG3r+xxGXy6VNWhmKw+EI2/jEv9FOouNWx5odTZkyRSb4dU+P5Xc8eAxJfCGhPlavvvrqsLtrOTk5csstt8QdtMTr0ksvlbPPPlt6enrkuOOOk//4j/+Qzz77TM455xxTy5FuzL7rYvQOGOnkMx129njLeMIJJ8jBgwe1fxcXF0tubm5C36d/WWbMmCF/+MMf4l4X4hdPl7NEBrj2iVR3MuFiGfqO95EGbo9FtAvdULxer+nj0BohUou5ZI0RF7zOdL3hgczR2dkpnZ2dYYdAStU6mmgoGO92WXmOqmd2dwSaOHFiwO9UcKvcUN+rr9up/7E6Ha5Rwgl188HhcMTVAyCWc17f+UiyP7OampqQvUYi8d1Q8pUtniERzOL/fkac1/uvz7/HQ1FRkezduzfkayorK8PO72Gz2WIOE5M5O3W4my2+md1937Hdbo/YgKe4uHhY/aaFZGgJ3d6K1NS/r68vkVXrtmjRIlm5cqVce+210tnZKZs3b5a1a9cmPKMijBPc+iVY8IG5rq7OlHHiysvLZfr06UkZ28ssU6ZMMSSUCsbBMtCEoIGa9SgpKdEmbgrHNxB4LHz10ePxGNptxQhm35CC9XJycgLGkUyVcfHMEG5Mwby8PN2/YUZ/ZkZ0Bc5m6RLc1NXVWb6/2e32jGw153Q6A3rjlJSUJO0ax+rvEKH5H8fr6+sDQoZYJgyM5Vw6lcc/Da6X8dxwNFKk/SSR65bS0tKEhuSI5b0zKYjy345okxn7f2fRel3FEjYWFxdrs7SHeo9I76/nOOu/jTNnzoz5dSJfBNzBY1ByjA8toRaSP/rRjyI+f+211yayet2+853vyHe+8x1T3zObJXvijAkTJojNZjOkO00w/zs0Dodj2DgQqciIGeWQmGg/uJE4HI5hg1uHWiaaZLS4MrpeUU/16enpSXgdBQUFusfkC76QSuSO83HHHZd2YYTT6Yx407K2tlYKCgriXn88E4zF22U73G9rMsaszCaNjY1WFyEmobqEJksix/d0/W3w741jt9uH3ThM1+2KJlO3S6+2tjbZs2ePfPLJJwmtJ9znOX/+/IDfz1T83P1/Y5L1W9/S0pKSY5pbPfxXugWYHo9Hjh07JgcOHAj7fCi+z21gYEDefvvtZBXPUr59x+FwGDIZZKZI6JP47W9/G/DvI0eOyM6dO8XpdEpzc7PpgSTSW7gxJGPtThPpgB38XEdHR9gm48F8TbTDScUTh3ik2w8ejMX3bx0jjiG5ubkybty4uF8/atQoaWtri/skMB1PrJxOZ9hZFkW+GDQf8Bk1apRUVVVZXYy0EG6G+Uw5X/LHb2d2mDZtWlxDGTU3N4ccisR/X0jlm3kVFRVSVlYWcC2WrB4QiZzDiKTG9VhpaWnM50OxLJcK2+QTanK7UKqqqqSurk73/pLIOVeyjsPJGtquuro6YFKdbJfQFcSmTZuGPbZv3z5ZsmSJLFy4MJFVI02k+6zZsbQemTVrljidzpQ76Uy18sAcdrs9pU5Q0hX7TyDfcAQ1NTVy6NAhi0uTnWKZGTIUm80mDocjpq6DiF9OTk7Cg+VngnjDk0wNJEWMO3/N1M8nm/kPqZOO3XVtNlvUIbfM4ts/9PYGMYtSSioqKiL2vPDfx1P1Rm6441BtbW1Sb8r5X5PH2v090r/95eTkSH19vbz77rvxF1C+GLKhoqJCNm7cmNB69IyXmQ0MvyXj9Xrluuuuk2uuucboVQOGCx5/IhSXy0UIhJQxY8aMgG6EVnfZjrdLq5VdIdmXA9XX11tdBE1nZ2fAbK7ZJJ6T09mzZ2tBWfDkCkAyzJgxI67ZrDM1kKyoqMjYli6Z+H0lItHJ3vyly2drxlj+eoWb/G706NG6J6WJlZHzDCilpLy8PKXHDQ3FZrMZFqLqOd+J1JPFJ9r3k5OTIxMnToz5PcOtt7i4mPlJkiApbcT37t0bdnYlIBz/mafMfs9EmPWDEuug2OlykoP4uN1urc4ZGSTFe9c+llA/lHSZLCKTlJSUaGPNlZWVaaFw8EmalS04ysrKGPdQB1pFwmxutzvuVpKZeH4yatSohMaXRvro6upKeB3p1kIyeFIOK0U7fjQ0NCRlToBYjltOp1PXcfH444+Pedl0qzOxCLUvpcLvQ/CEZb4baV6vN+YQNdR2cMM4soRi7ttuuy3g30op2bVrl9x3330yODiYUMGQHEbt7E6nU5xOZ0ocPMIxq2wej0cWLFgQ19gyeoUbZ9Nn+vTpaXfHDfFLZBISZB+32y11dXUi8kXwV1ZWZnGJAGSacOdemdpC0kip9vmkWnmAVDVt2rSkXH9VVlYOm0TLLEbu/8ludGTU70twC9Dc3FwpKyuLGiBXV1dHfJ6bx5ElFEj++7//e8C/7Xa7lJeXy9lnny3Lli1LqGBIrkR3Wl/gbMTO77vzw4lP4vQGVJl41w36se8BAJKJ8w1ku0w518qU7fAJbhUXj0Raz0WS6EQ/Vpo0aVLI+UbSSbQxQX0ybZ8wW0KB5M6dO40qB9JUMnfA4KbvVu/sNptNGhoawj4/adKksOOaGCH4ZD7Rk/uenh4pLS2Vjz/+OKH1wFpG7Bfjxo1LyXGCAACZgRaS0dlsNqmqquL3OIPRCCN+yfrMYmmBaOQNFW7OpC72S2uk5vROSBtGN+eONtGFUQfxeGYktdls0tHREfb5ZE/EUFFRIUVFRcMej2e8lMHBwZgGJuZHM7XV1tbKiBEjDFlPNvF4PCk7uyEAZKpMuthL1vmRx+MRj8eTlHXrlUnfVyrw/zzz8vLkhBNOiLockKqiHQPtdrvWuCiWOp1IvTfqhlcy973Zs2dzXR2G7iuySy+9NOZlb731Vr2rR5qJtOPabDbdO55ZE12k44ykbW1tIR+fOnWq7nURxmSGwsJCWlLEYfr06XFPygAA0I8WkkAgJnDTx6rjR319vWHn2u3t7RnxvdfV1Wk3TsJ1V6+qqkq7scr1Xhvo6RmZl5cnn332md4iZQXdqUSsYwFw0pEd+J7T3yeffGJ1EQBTMfFTeG63W4aGhmJaVs+4S8xCC2Q3WoZEF+6cevLkySaX5Auc4xuP/SD9tLS0GLauqqoqw9Zlpc7OTm3Ir4GBgZDL2Gy2hCbftOL4o/c9XS5X2oWuqUh3ILlu3TrZsWOHNDQ00MIEnKxkAE6OAPjoGUBdz8yPEyZMiKc4AFJQT0+P7m7FXV1d3AyKU2VlpdVFgAEy6Zopk7YFiUn3ujB16lRxuVzyxhtvGLIt/M7pF1eiOHr06ICJMBYtWiQfffSRYYVC8hkVQunZcUtLS7X/T2aYHeokORNDN6O2KdbWUAAyn/+YPwAQSnFxse5AMj8/P2XGRswGg4ODCa8j3YOGVJQJ1yNW1ovW1lbL3jtbJKOOxtK1OZF6Fc8wcT4FBQVaS07/8994WncuWLAg4ra63e6o82Vko7iuOoK/8Mcff5w+8VlKz8HDv5n6/PnzRSQ5weTo0aMNX2cmI5AEAABG8Hq90tDQYHUx0pKRQQ9jhSMTjRkzxuoiIA7BY3BGO9bFEi4mIxj3X2e4rujBxo8fH3P24HQ6TZsvI53QDCJLGbUT9/b26lo+1ZsxZ+PdYN/M3Zlw1xYAAFinuLhYOjo6rC4GkHISacUFY+Tn5zMEQoxS5Zo4XDmS0aAmnm0uKipigtEExXX7zGazDfvCUqXSwlx6ZworLCzUWkf6OByOpNzJpU7GpqKiwuoiAAAAIIVwHq1fpM+svb097IzEsa4DiSkuLrZskigYW7cdDocWLhsR9o8dO9aIYiEOcaVASilZsmSJuN1uERH5/PPPZenSpcPCqUceeSTxEiLj+HfTttlsUllZmTI/Dul055Jx3gAAADIDQVRm8x9LH0h1tbW1KT30Q25urqH5AUO+WSeuWnb22WcH/PvMM880pDDIPr4AUO8BL9ZxHfSWJZ1OBvPy8uSkk05KeD3ptM0AAABIPs4PEQr1IrP5rs0LCwvpigxTxBVIrlq1yuhyALrEM/NVJkr2mJzp1GIUQPK1trbKm2++aXUxACDjpGLQM3fuXKuLAMBEqXIc0lOOVCkz4kOfT1hK7wEkUkBGeAYAyeXxeKwuAgDAJBzzgeySruEeOUD6IpCEiCQ+HuG4cePiep0ZB4/Ozk5tJmkMF+6HZ/LkybonLQIAAACQvtI1lEL6SqTOUV/TG4EkRERk9uzZCb3e6/UaVBLj1dXV0cU7DpWVlUnvEg4AAAAuqpE+qKuZK12/W1pIpi8CSYhIcrpkxHJAS+b4EOl6QDUbnxMAAAAAZLdErwu5roReBJJImljuVHA3418qKiokLy/P6mIAAAAgggkTJlhdBAAwXKyBYioFjx6Ph96QaSyuWbYBGO+4446z5H1T6QcFQGrjJhIAiBQWFhq+Ts7HIMLvLFJDtONRKtXTSZMmcfxMY7SQRNIY3WUbAGCtESNGSHNzs9XFAICUU1ZWZnURACAh6Xhtbrfb07Lc+AKBJJLGd+dk3rx5UZeBdTiAA4hVYWEhgSQAhDBlyhSriwCYguu3zJUK14XUr+xCIImky8nJMeV9nE5GIEgEB38AkdTW1lpdBADIWKkQBACRjB071uoiIMk4DsFsBJJImkS6bJeXl+t+v9mzZ+t+DfjhAZCY+fPnW10EAACQZKNHj7a6CEii+vp6yc/Pt7oYyDIEkjCE0a3rjj/+eN2vcblcYrfHX6WLioqy+iBMMAkgHokcdwEAAGC9hoaGlOlxyHVp9uAqIktl6k7ucDji3rZJkyZJQ0OD9u+amhqDSpUe6LINAABgjUw9NweAaDj+ZS8CSRgiVQ4i/f39UldXZ8i6urq6DFkPAAAAAERDAwGkq5ycHHE4HFYXA2kmNdrkIu2Z9eMZ7X3cbrcp5QAAAACMkio39wEgHnPmzCGQhG4EkgAAAAAAICpacWa+eG6QpMr4k0gv1BoYih8o4/X29pr2Xg6HQ0488UTT3g8AAAAAABHyhGzDGJJIG9nalWXkyJFJf4+BgQHt/7m7BSCSbD0WA0AycWyFCGEMgOxCIAlDcTKVnlwul9VFAJAmXC6XDA4OWl0MAAAAAGmMQBIJ6+7ulpKSEquLAQAwCS2pAQAAACSCKwokrLq62uoiAAAAAGmLXkYAskGoYQk4/mUvWkjCUIx7kt74MQDMNWnSJFqYAwCQATLlPDovL0+6urrCPs/1HgCj0EISAACL1NbWWl2EmHi9XoJTAACygN1ul5qaGquLARiqsbHR6iIgBAJJAAAQUWtrq1RVVVldDAAAAEC39vZ2q4uAEOiyDUNlSlcFAAAAIJyTTjrJ6iIAQEYiU8geBJIAAAAAoIPD4bC6CACQFASCMAuBJAzFIMcAAACAPgQAEOFaCvDfBzguZj4CySxUXFxsdREAAGmEE0IASJ6cnByOsxmAMBGILtR+wvEvexFIQhev12t1EQAAJuNEEQCSZ968eWK3c1mG9EDwCsAozLINAADCGhgYkJycHKuLAQAAACCDEEjCUMlsRWNGC51sbgXE3U4AobhcLquLAAAAACDD0DcAhkp2qJXs9RcXF8vcuXOT+h4AAAAAAGSLeBr+0GAm8xFIZhkzWwCm6wHE4/FYXQQAAAAAWSZdr58AIB4EkgAAAAAAAEgKPWF7Ng+jlm0IJAEAAAAAQFS04sx8yQwEqT/wRyAJXbhbAQAAAAAAYkWOgFAIJLOU2QeE+fPnm/p+iA8/FAAAAACAcGjlCKM4rS4AMpfT6ZS6ujoREbHbE8++7XY7gRkAAAAAABmCa/zsRQtJxOSEE06I63Vut9uwMrS3t0t3d7dh6wMAAACAVEHLM6QDAkQYhRaSiEkqHHScTqorAAAAAFiF0BTJRP3KLrSQzFKZvqOffPLJVhcBAAAAADJKbm6uVFZWWl0MGCwVGiAh+9DkDDFJtwCTA6p+dXV1UlZWZnUxAAAAgKyTm5srLpfL6mJE5fF4ZPLkyVYXAwbTc72fbtkAUheBZBY77rjjpLi4OGnrd7vd4nA4Ii7T1dUlXq83aWVA7FwuV1qcBAEAAACZZs6cOVYXARCR5DbuIfiEPwLJLGWz2aSioiLm5XNycnS/x4wZM6IGkjT3BwAAAAAAyC6MIYmYuFwu3eGh0+mk6zQAAAAAACmM63ZYgUASunCgAgAAAIBAdC8F4hOcMZA5ZA8CSQAAAAAAAESVzYHhggULrC5CRiGQRMzGjh0r48aNs7oYAAAAAADAArQGhlGY1AZSVFQU03KFhYXMwgwAAAAAAHSLFmYSdmYXWkhCZs6caXURAAAAAAAAkCUIJLMQdx0AAAAAAABgFQJJAAAAAAAAAKYhkAQAAAAAAEBS0VsT/ggks5DNZrO6CAAAAAAAIMWkSl5AeJn5CCQBAAAAAAAAmIZAErqkyt0SAAAAAAAApCcCSQAAAAAAAACmSftA8u2335bzzjtPGhsbJTc3V5qbm2X58uVy+PBhq4sGAAAAAAAAIIjT6gIk6o033pChoSG5++67paWlRbZu3SoXXHCBfPbZZ7Jy5Uqri5eSGBwWAAAAAIzDNRYQXbT9RCnFMHFZJO0DyXnz5sm8efO0fzc1Ncm2bdvkzjvvJJAEAAAAAACwECEjQkn7QDKUvXv3SmlpacRlDh06JIcOHdL+vW/fvmQXCwAAAAAAAMh6aT+GZLDt27fL7bffLt/85jcjLnfTTTdJUVGR9ldXV2dSCTPb+PHjrS4CAAAAAACIQzJbMzK0AfylbCB51VVXic1mi/j3xhtvBLzm/fffl3nz5smpp54qF1xwQcT1L1u2TPbu3av9vffee8ncnKzh9XqtLgIAAAAAAABSWMp22b7ssstkyZIlEZdpamrS/v+DDz6Q/v5+mTp1qvzsZz+Lun632y1utzvRYgIAAAAAAADQIWUDyfLycikvL49p2ffff1/6+/ulu7tbVq1aJXZ7yjb8TAkMKAsAAAAAAACrpGwgGav3339fZs2aJaNGjZKVK1fK3//+d+25yspKC0uWmQgzAQAAAAAAkIi0DySffPJJ2b59u2zfvl1qa2sDnmPA1OFsNlvUz2Xq1Kny5z//2aQSAQAAAEB6czqdkpeXZ3UxgJRGRgN/ad+3ecmSJaKUCvkH/fLz82XEiBFWFwMAAAAA0obL5ZLZs2dbXQwgrRUWFsrIkSOtLgZMkvYtJKFPpC7XHo9nWCtTAAAAAACAZKupqZGamhqriwGTpH0LSQAAAAAAACSOeSNgFgLJLMPBBQAAAAAApDKG4ct8BJIAAAAAAAAATEMgmWVoIQkAAAAAAMxGq0f4I5CELhxAAAAAAAAAkAgCySxjRgvJysrKpL8HAAAAAABIL/TahA+BJAw3efJkq4sAAAAAAABSCD0u4Y9AEgAAAAAAAIBpCCSzDM2jAQAAAACAFcgk4EMgCQAAAAAAAMA0BJJZhrsRAAAAAAAAsBKBJAAAAAAAAJLaiIlJbeCPQDLL6Dm4VFdXJ7EkAAAAAAAAwxFeZj4CSYTV3d1tdREAAAAAAACQYQgkswxjSAIAAAAAALP4cgilFJkENASSAAAAAAAASAq6XyMUAsksE+luBAcJAAAAAAAAJBuBJAAAAAAAAADTEEgCAAAAAAAgKRg3EqEQSAIAAAAAACDp4SHhJHwIJAEAAAAAAJBUzFsBfwSSWWTcuHERn4/lToXdbheXy2VUkQAAAAAAAJBlCCSzSEtLS8TnY7lb4XQ6ZWBgwKgiAQAAAACALEGXbfgQSAIAAAAAACCp3G63FBQUxLQs3bszn9PqAgAAAAAAAMAaZrVarK2tldraWlPeC6mPFpIAAAAAAABZitaIsAKBJAAAAAAAAADTEEgCAAAAAACASWdgGgJJAAAAAACALEUICSswqU0WGj16tLjdbquLAQAAAAAAgCxEIJmFqqqqrC4CAAAAAAAAshRdtgEAAAAAAACYhkASAAAAAAAAgGkIJBGAwWwBAAAAAACQTASSAAAAAAAAAExDIAkAAAAAAADANASSCKCUsroIAAAAAAAAyGAEkgAAAAAAAABMQyCJAExqAwAAAABAdiITgFkIJAEAAAAAAACYhkASAAAAAAAAKYP5LTIfgSQAAAAAAACiIiiEUQgkAQAAAAAAAJiGQBIhDQ4OWl0EAAAAAACQRDabTRwOh67lASM4rS4AUpPTSdUAAAAAACCTnXzyyVYXAVmKFpIAAAAAAAAATEMgCQAAAAAAALpkwzQEkgAAAAAAAIiKWbZhFAJJAAAAAAAAAKYhkAQAAAAAAEBS0A0coRBIAgAAAAAAICno5o1QCCQRVXd3t9VFAAAAAAAAWYIQM/MRSEITboeneTUAAAAAAIgHmQJCIZAEAAAAAAAAYBoCSWi4awEAAAAAAIBkI5AEAAAAAAAAYBoCSQAAAAAAAACmIZCEhlmsAAAAAAAAkGwEkgAAAAAAAABMQyAJAAAAAAAAwDQEkgAAAAAAAABMQyAJAAAAAAAAwDQEkgAAAAAAAEgZTLqb+QgkAQAAAAAAAJiGQBIAAAAAACDLeb1eq4uALEIgCQAAAAAAkOX6+vqsLgKyCIEkAAAAAAAAANMQSAIAAAAAAAAwDYEkAAAAAAAAANMQSAIAAAAAAAAwDYEkAAAAAAAAANMQSAIAAAAAAAAwDYEkAAAAAAAAANMQSAIAAAAAAAAwTUYFkocOHZLOzk6x2WyyefNmq4sDAAAAAAAAIEhGBZJXXHGFVFdXW10MAAAAAAAAAGFkTCC5Zs0a+eMf/ygrV660uigAAAAAAAAQEZvNZnURkIKcVhfACB999JFccMEFsnr1asnLy4vpNYcOHZJDhw5p/963b1+yigcAAAAAAADgS2nfQlIpJUuWLJGlS5dKT09PzK+76aabpKioSPurq6tLYinTQ2trq5SXl1tdDAAAAAAAkCGUUlYXASkoZQPJq666Smw2W8S/N954Q26//XbZv3+/LFu2TNf6ly1bJnv37tX+3nvvvSRtSfpobGyU4uJiq4sBAAAAAACyGCFm5kvZLtuXXXaZLFmyJOIyTU1N8vTTT8uGDRvE7XYHPNfT0yOLFy+We++9N+Rr3W73sNcAAAAAAADAOIwhiVBSNpAsLy+PqfvwbbfdJj/+8Y+1f3/wwQcyMDAgv/rVr6S3tzeZRQQAAAAAAACgU8oGkrGqr68P+HdBQYGIiDQ3N0ttba0VRQIAAAAAAEACaFmZ2VJ2DEkAAAAAAAAAmSftW0gGa2hoYPBTAAAAAAAAIEXRQhIRjRs3ToqKiqwuBgAAAAAAADJExrWQhLFaWlqsLgIAAAAAAAAyCC0kAQAAAAAAAJiGQBIAAAAAAACAaQgkAQAAAAAAAJiGQBIAAAAAAAApQylldRGQZASSAAAAAAAAAExDIAkAAAAAAADANASSAAAAAAAAAExDIAkAAAAAAICUYrPZrC4CkohAEgAAAAAAAIBpCCQBAAAAAAAAmIZAEgAAAAAAAIBpCCQBAAAAAAAQlVLK6iIgQxBIAgAAAAAAADANgSQAAAAAAACSgtmyEQqBJAAAAAAAAKKKJ1yMp5s3XcMzH4EkAAAAAAAAANMQSAIAAAAAAAAwDYEkAAAAAAAAooqnKzVjSCIUAkkAAAAAAAAApiGQBAAAAAAAAGAaAkkAAAAAAAAApiGQBAAAAAAAAGAaAkkAAAAAAABExQQ1MAqBJAAAAAAAAKKKZ5btcPr7+w1bF9IPgSQAAAAAAABMVVBQEPF5WmNmNgJJAAAAAAAApAwjW2IiNRFIAgAAAAAAADANgSQAAAAAAAAA0xBIAgAAAAAAIGW43e6oY0wivTmtLgAAAAAAAADgU1NTIzU1NVYXA0lEC0kAAAAAAAAApiGQBAAAAAAAAGAaAkkAAAAAAAAApiGQBAAAAAAAAGAaAkkAAAAAAAAApiGQBAAAAAAAAGAaAkkAAAAAAAAkhd1O9IThnFYXAAAAAAAAAJlnYGBAXC6X1cVACiKmBgAAAAAAgOEIIxEOgSQAAAAAAAAA0xBIAgAAAAAAADANgSQAAAAAAAAA0xBIAgAAAAAAADANgSQAAAAAAAAA0xBIAgAAAAAAADANgSQAAAAAAAAA0xBIAgAAAAAAADANgSQAAAAAAAAA0xBIAgAAAAAAADANgSQAAAAAAAAA0xBIAgAAAAAAADANgSQAAAAAAAAA0xBIAgAAAAAAADANgSQAAAAAAAAA0xBIAgAAAAAAADANgSQAAAAAAAAA0xBIAgAAAAAAADANgSQAAAAAAAAA0xBIAgAAAAAAADANgSQAAAAAAAAA0xBIAgAAAAAAADANgSQAAAAAAAAA0xBIAgAAAAAAADANgSQAAAAAAACiKioqkra2NquLgQxAIAkAAAAAAICoPB6PNDU1WV0MZAACSQAAAAAAAACmIZAEAAAAAAAAYBoCSQAAAAAAAACmIZAEAAAAAAAAYBoCSQAAAAAAAACmIZAEAAAAAAAAYBoCSQAAAAAAAACmIZAEAAAAAAAAYJqMCSQfe+wx6e3tldzcXCkpKZGvfe1rVhcJAAAAAAAAQBCn1QUwwn//93/LBRdcIDfeeKOccMIJcvToUdm6davVxQIAAAAAAAAQJO0DyaNHj8pFF10kt9xyi5x33nna4+PHj7ewVAAAAAAAAABCSfsu26+88oq8//77YrfbZdKkSVJVVSWDg4NRW0geOnRI9u3bF/AHAAAAAAAAILnSPpDcsWOHiIj88Ic/lB/84Afy6KOPSklJicyaNUs++eSTsK+76aabpKioSPurq6szq8gAAAAAAABA1krZQPKqq64Sm80W8e+NN96QoaEhERG5+uqr5etf/7p0d3fLqlWrxGazycMPPxx2/cuWLZO9e/dqf++9955ZmwYAAAAAAABkrZQdQ/Kyyy6TJUuWRFymqalJdu3aJSKBY0a63W5pamqSd999N+xr3W63uN1uQ8oKAAAAAAAAIDYpG0iWl5dLeXl51OW6u7vF7XbLtm3bZPr06SIicuTIEXn77bdl1KhRyS4mAAAAAAAAAB1SNpCMldfrlaVLl8ry5culrq5ORo0aJbfccouIiJx66qkWlw4AAAAAAACAv7QPJEVEbrnlFnE6nXLWWWfJwYMHpbe3V55++mkpKSmxumgAAAAAAAAA/NiUUsrqQqSCffv2SVFRkezdu1e8Xq/VxQEAAAAAAADSSqz5WsrOsg0AAAAAAAAg8xBIAgAAAAAAADANgSQAAAAAAAAA0xBIAgAAAAAAADANgSQAAAAAAAAA0xBIAgAAAAAAADANgSQAAAAAAAAA0xBIAgAAAAAAADANgSQAAAAAAAAA0xBIAgAAAAAAADCN0+oCpAqllIiI7Nu3z+KSAAAAAAAAAOnHl6v5crZwCCS/tH//fhERqaurs7gkAAAAAAAAQPrav3+/FBUVhX3epqJFllliaGhIPvjgAyksLBSbzWZ1cWCBffv2SV1dnbz33nvi9XqtLg6QMOo0Mg11GpmGOo1MQ51GpqFOI9OYUaeVUrJ//36prq4Wuz38SJG0kPyS3W6X2tpaq4uBFOD1evmxQUahTiPTUKeRaajTyDTUaWQa6jQyTbLrdKSWkT5MagMAAAAAAADANASSAAAAAAAAAExDIAl8ye12y/Lly8XtdltdFMAQ1GlkGuo0Mg11GpmGOo1MQ51GpkmlOs2kNgAAAAAAAABMQwtJAAAAAAAAAKYhkAQAAAAAAABgGgJJAAAAAAAAAKYhkAQAAAAAAABgGgJJZKwVK1aIzWaTiy++WHvs888/lwsvvFBGjBghBQUF8vWvf10++uijgNe9++67Mn/+fMnLy5ORI0fK5ZdfLkePHg1YZv369dLV1SVut1taWlrknnvuMWGLkG1++MMfis1mC/gbO3as9jz1Geno/ffflzPPPFNGjBghubm50tHRIS+99JL2vFJKrr32WqmqqpLc3FyZM2eOvPXWWwHr+OSTT2Tx4sXi9XqluLhYzjvvPDlw4EDAMn/9619lxowZ4vF4pK6uTm6++WZTtg/Zp6GhYdix2mazyYUXXigiHKuRfo4dOybXXHONNDY2Sm5urjQ3N8v1118v/nOhcqxGutm/f79cfPHFMmrUKMnNzZWpU6fKiy++qD1PnUYq+9Of/iQLFiyQ6upqsdlssnr16oDnzay/Dz/8sIwdO1Y8Ho90dHTI448/Hv+GKSADbdy4UTU0NKgJEyaoiy66SHt86dKlqq6uTj311FPqpZdeUscff7yaOnWq9vzRo0dVe3u7mjNnjtq0aZN6/PHHVVlZmVq2bJm2zI4dO1ReXp669NJL1WuvvaZuv/125XA41Nq1a83cRGSB5cuXq7a2NrVr1y7t7+9//7v2PPUZ6eaTTz5Ro0aNUkuWLFEvvPCC2rFjh3riiSfU9u3btWVWrFihioqK1OrVq9WWLVvUV77yFdXY2KgOHjyoLTNv3jw1ceJE9Ze//EU9++yzqqWlRZ1xxhna83v37lUVFRVq8eLFauvWreqhhx5Subm56u677zZ1e5Eddu/eHXCcfvLJJ5WIqHXr1imlOFYj/dxwww1qxIgR6tFHH1U7d+5UDz/8sCooKFA/+clPtGU4ViPdnHbaaWr8+PHqmWeeUW+99ZZavny58nq96v/+7/+UUtRppLbHH39cXX311eqRRx5RIqJ++9vfBjxvVv19/vnnlcPhUDfffLN67bXX1A9+8AOVk5OjXn311bi2i0ASGWf//v1q9OjR6sknn1R9fX1aILlnzx6Vk5OjHn74YW3Z119/XYmI2rBhg1Lqix3dbrerDz/8UFvmzjvvVF6vVx06dEgppdQVV1yh2traAt5z0aJFamBgIMlbhmyzfPlyNXHixJDPUZ+Rjq688ko1ffr0sM8PDQ2pyspKdcstt2iP7dmzR7ndbvXQQw8ppZR67bXXlIioF198UVtmzZo1ymazqffff18ppdRPf/pTVVJSotVz33uPGTPG6E0ChrnoootUc3OzGhoa4liNtDR//nx17rnnBjx2yimnqMWLFyulOFYj/fzzn/9UDodDPfroowGPd3V1qauvvpo6jbQSHEiaWX9PO+00NX/+/IDy9Pb2qm9+85txbQtdtpFxLrzwQpk/f77MmTMn4PGXX35Zjhw5EvD42LFjpb6+XjZs2CAiIhs2bJCOjg6pqKjQlhkYGJB9+/bJ//7v/2rLBK97YGBAWwdgpLfeekuqq6ulqalJFi9eLO+++66IUJ+Rnn7/+99LT0+PnHrqqTJy5EiZNGmS/PznP9ee37lzp3z44YcBdbKoqEh6e3sD6nVxcbH09PRoy8yZM0fsdru88MIL2jIzZ84Ul8ulLTMwMCDbtm2TTz/9NNmbiSx2+PBhuf/+++Xcc88Vm83GsRppaerUqfLUU0/Jm2++KSIiW7Zskeeee04GBwdFhGM10s/Ro0fl2LFj4vF4Ah7Pzc2V5557jjqNtGZm/TX6fIRAEhnll7/8pbzyyity0003DXvuww8/FJfLJcXFxQGPV1RUyIcffqgt439B4Hve91ykZfbt2ycHDx40alMA6e3tlXvuuUfWrl0rd955p+zcuVNmzJgh+/fvpz4jLe3YsUPuvPNOGT16tDzxxBPyrW99S773ve/JvffeKyL/qpeh6qR/nR05cmTA806nU0pLS3XVfSAZVq9eLXv27JElS5aICOceSE9XXXWVnH766TJ27FjJycmRSZMmycUXXyyLFy8WEY7VSD+FhYUyZcoUuf766+WDDz6QY8eOyf333y8bNmyQXbt2UaeR1sysv+GWibd+O+N6FZCC3nvvPbnooovkySefHHb3C0hHvpYIIiITJkyQ3t5eGTVqlPz617+W3NxcC0sGxGdoaEh6enrkxhtvFBGRSZMmydatW+Wuu+6Ss88+2+LSAYn7z//8TxkcHJTq6mqriwLE7de//rU88MAD8uCDD0pbW5ts3rxZLr74YqmuruZYjbR13333ybnnnis1NTXicDikq6tLzjjjDHn55ZetLhqQtWghiYzx8ssvy+7du6Wrq0ucTqc4nU555pln5LbbbhOn0ykVFRVy+PBh2bNnT8DrPvroI6msrBQRkcrKymEzX/r+HW0Zr9dLSISkKi4ultbWVtm+fbtUVlZSn5F2qqqqZPz48QGPjRs3ThuKwFcvQ9VJ/zq7e/fugOePHj0qn3zyia66DxjtnXfekf/5n/+R888/X3uMYzXS0eWXX661kuzo6JCzzjpLLrnkEq0HEsdqpKPm5mZ55pln5MCBA/Lee+/Jxo0b5ciRI9LU1ESdRlozs/6GWybe+k0giYwxe/ZsefXVV2Xz5s3aX09PjyxevFj7/5ycHHnqqae012zbtk3effddmTJlioiITJkyRV599dWAnfXJJ58Ur9erXURPmTIlYB2+ZXzrAJLlwIED8re//U2qqqqku7ub+oy0M23aNNm2bVvAY2+++aaMGjVKREQaGxulsrIyoE7u27dPXnjhhYB6vWfPnoAWDU8//bQMDQ1Jb2+vtsyf/vQnOXLkiLbMk08+KWPGjJGSkpKkbR+y26pVq2TkyJEyf/587TGO1UhH//znP8VuD7xMdDgcMjQ0JCIcq5He8vPzpaqqSj799FN54okn5Ktf/Sp1GmnNzPpr+PlIXFPhAGnCf5ZtpZRaunSpqq+vV08//bR66aWX1JQpU9SUKVO0548ePara29vViSeeqDZv3qzWrl2rysvL1bJly7RlduzYofLy8tTll1+uXn/9dXXHHXcoh8Oh1q5da+amIQtcdtllav369Wrnzp3q+eefV3PmzFFlZWVq9+7dSinqM9LPxo0bldPpVDfccIN666231AMPPKDy8vLU/fffry2zYsUKVVxcrH73u9+pv/71r+qrX/2qamxsVAcPHtSWmTdvnpo0aZJ64YUX1HPPPadGjx6tzjjjDO35PXv2qIqKCnXWWWeprVu3ql/+8pcqLy9P3X333aZuL7LHsWPHVH19vbryyiuHPcexGunm7LPPVjU1NerRRx9VO3fuVI888ogqKytTV1xxhbYMx2qkm7Vr16o1a9aoHTt2qD/+8Y9q4sSJqre3Vx0+fFgpRZ1Gatu/f7/atGmT2rRpkxIRdeutt6pNmzapd955RyllXv19/vnnldPpVCtXrlSvv/66Wr58ucrJyVGvvvpqXNtFIImMFhxIHjx4UH37299WJSUlKi8vTy1cuFDt2rUr4DVvv/22GhwcVLm5uaqsrExddtll6siRIwHLrFu3TnV2diqXy6WamprUqlWrTNgaZJtFixapqqoq5XK5VE1NjVq0aJHavn279jz1GenoD3/4g2pvb1dut1uNHTtW/exnPwt4fmhoSF1zzTWqoqJCud1uNXv2bLVt27aAZf7xj3+oM844QxUUFCiv16vOOecctX///oBltmzZoqZPn67cbreqqalRK1asSPq2IXs98cQTSkSG1VWlOFYj/ezbt09ddNFFqr6+Xnk8HtXU1KSuvvpqdejQIW0ZjtVIN7/61a9UU1OTcrlcqrKyUl144YVqz5492vPUaaSydevWKREZ9nf22Wcrpcytv7/+9a9Va2urcrlcqq2tTT322GNxb5dNKaXia1sJAAAAAAAAAPowhiQAAAAAAAAA0xBIAgAAAAAAADANgSQAAAAAAAAA0xBIAgAAAAAAADANgSQAAAAAAAAA0xBIAgAAAAAAADANgSQAAAAAAAAA0xBIAgAAAAAAADANgSQAAABgoG3btsnkyZOlsbFRfve731ldHAAAgJRjU0opqwsBAAAAZIpFixbJcccdJxMmTJDzzjtP3n33XauLBAAAkFJoIQkAAABT/fCHP5TOzk6ri6Gx2WyyevVqXa9paGgQm80mNptN9uzZE/BcUVGRjBo1SlpaWmTkyJHDXjtr1izttZs3b46/4AAAAGmKQBIAACAD3XXXXVJYWChHjx7VHjtw4IDk5OTIrFmzApZdv3692Gw2+dvf/mZyKc1ldBD6ox/9SHbt2iVFRUXDHl+0aJG0tLTIsmXLhr3ukUcekY0bNxpWDgAAgHRDIAkAAJCB+vv75cCBA/LSSy9pjz377LNSWVkpL7zwgnz++efa4+vWrZP6+nppbm62oqhpq7CwUCorK8VmswU8/sILL0htba2cfvrp8uc//3nY60pLS6W8vNysYgIAAKQcAkkAAIAMNGbMGKmqqpL169drj61fv16++tWvSmNjo/zlL38JeLy/v19ERO677z7p6enRwrZvfOMbsnv3bhERGRoaktraWrnzzjsD3mvTpk1it9vlnXfeERGRPXv2yPnnny/l5eXi9XrlhBNOkC1btkQs7y9+8QsZN26ceDweGTt2rPz0pz/Vnnv77bfFZrPJI488Iv39/ZKXlycTJ06UDRs2BKzj5z//udTV1UleXp4sXLhQbr31VikuLhYRkXvuuUeuu+462bJli9Zd+p577tFe+/HHH8vChQslLy9PRo8eLb///e9j+6BDWLVqlXzjG9+Qs846S+6///6AVqoAAAAgkAQAAMhY/f39sm7dOu3f69atk1mzZklfX5/2+MGDB+WFF17QAskjR47I9ddfL1u2bJHVq1fL22+/LUuWLBEREbvdLmeccYY8+OCDAe/zwAMPyLRp02TUqFEiInLqqafK7t27Zc2aNfLyyy9LV1eXzJ49Wz755JOQ5XzggQfk2muvlRtuuEFef/11ufHGG+Waa66Re++9N2C5q6++Wr7//e/L5s2bpbW1Vc444wwt7Hv++edl6dKlctFFF8nmzZtl7ty5csMNN2ivXbRokVx22WXS1tYmu3btkl27dsmiRYu056+77jo57bTT5K9//aucdNJJsnjx4rDljWT37t3y+OOPy5lnnilz584Vm80mjz32mO71AAAAZDICSQAAgAzV398vzz//vBw9elT2798vmzZtkr6+Ppk5c6bWcnLDhg1y6NAhLZA899xzZXBwUJqamuT444+X2267TdasWSMHDhwQEZHFixfL888/r80cPTQ0JL/85S9l8eLFIiLy3HPPycaNG+Xhhx+Wnp4eGT16tKxcuVKKi4vlN7/5TchyLl++XP7t3/5NTjnlFGlsbJRTTjlFLrnkErn77rsDlvv+978v8+fPl9bWVrnuuuvknXfeke3bt4uIyO233y6Dg4Py/e9/X1pbW+Xb3/62DA4Oaq/Nzc2VgoICcTqdUllZKZWVlZKbm6s9v2TJEjnjjDOkpaVFbrzxRjlw4EBc4zzef//90tbWJm1tbeJwOOT0008PaIkJAAAAAkkAAICMNWvWLPnss8/kxRdflGeffVZaW1ulvLxc+vr6tHEk169fL01NTVJfXy8iIi+//LIsWLBA6uvrpbCwUPr6+kREtACys7NTxo0bp7WSfOaZZ2T37t1y6qmniojIli1b5MCBAzJixAgpKCjQ/nbu3Bly0pzPPvtM/va3v8l5550XsPyPf/zjYctPmDBB+/+qqioREa07+bZt2+S4444LWD7435H4rzs/P1+8Xq+2bj1WrVolZ555pvbvM888Ux577DH5+9//rntdAAAAmcppdQEAAACQHC0tLVJbWyvr1q2TTz/9VAsXq6urpa6uTv785z/LunXr5IQTThCRL8LBgYEBGRgYkAceeEDKy8vl3XfflYGBATl8+LC23sWLF8uDDz4oV111lTz44IMyb948GTFihIh8MZN38NiVPr7xHP35Wl7+/Oc/l97e3oDnHA5HwL9zcnK0//dNJDM0NKTzUwnNf92+9etd90svvSRbt26VK664Qq688krt8WPHjsn9998vl1xyiSFlBQAASHcEkgAAABmsv79f1q9fL59++qlcfvnl2uMzZ86UNWvWyMaNG+Vb3/qWiIi88cYb8o9//ENWrFghdXV1IiIBs3T7fOMb35Af/OAH8vLLL8tvfvMbueuuu7Tnurq65MMPPxSn0ykNDQ1Ry1dRUSHV1dWyY8cOrdt3PMaMGSMvvvhiwGPB/3a5XHLs2LG43yOaVatWycyZM+WOO+4IePy+++6Te+65h0ASAADgSwSSAAAAGay/v18uvPBCOXLkiNZCUkSkr69PvvOd78jhw4e18SPr6+vF5XLJ7bffLkuXLpWtW7fK9ddfP2ydDQ0NMnXqVDnvvPPk2LFj8pWvfEV7bs6cOTJlyhT52te+JjfffLO0trbKBx98II899pgsXLhQenp6hq3vuuuuk+9973tSVFQk8+bNk0OHDslLL70kn376qVx66aUxbed3v/tdmTlzptx6662yYMECefrpp2XNmjVaS0pfuXfu3CmbN2+W2tpaKSwsFLfbHfNnGcmhQ4fkoYcekhtvvFHa29sDnjv//PPl5ptvlldeeUW6uroMeT8AAIB0xhiSAAAAGay/v18OHjwoLS0tUlFRoT3e19cn+/fvlzFjxmjjMZaXl8s999wjDz/8sIwfP15WrFghK1euDLnexYsXy5YtW2ThwoUBk8PYbDZ5/PHHZebMmXLOOedIa2urnH766fLOO+8EvL+/888/X37xi1/IqlWrpKOjQ/r6+uSee+6RxsbGmLdz2rRpctddd8mtt94qEydOlLVr18oll1wiHo9HW+brX/+6zJs3T/r7+6W8vFweeuihmNcfzerVq2Xv3r2ycOHCYc+NHj1aOjo6ZNWqVYa9HwAAQDqzKaWU1YUAAAAAjHbBBRfIG2+8Ic8++6zh625oaJCLL75YLr744rhe//bbb0tjY6Ns2rRJOjs7DS0bAABAqqOFJAAAADLCypUrZcuWLbJ9+3a5/fbb5d5775Wzzz47ae935ZVXSkFBgezdu1fX6wYHB6WtrS1JpQIAAEh9tJAEAABARjjttNNk/fr1sn//fmlqapLvfve7snTp0qS81zvvvCNHjhwREZGmpiax22O/z//+++/LwYMHReRf43YCAABkEwJJAAAAAAAAAKahyzYAAAAAAAAA0xBIAgAAAAAAADANgSQAAAAAAAAA0xBIAgAAAAAAADANgSQAAAAAAAAA0xBIAgAAAAAAADANgSQAAAAAAAAA0xBIAgAAAAAAADDN/wdxy5+zGVgf2gAAAABJRU5ErkJggg=="/>
 </div>
 </div>
 </div>
@@ -9137,12 +8679,12 @@ INFO: rrtemplate-STAR-WD-v0.1.fits STAR WD PCA IGM=None z=-0.002-0.002
 </div>
 </div>
 </div>
-</div><div class="jp-Cell jp-CodeCell jp-Notebook-cell">
+</div><div class="jp-Cell jp-CodeCell jp-Notebook-cell jp-mod-noOutputs">
 <div class="jp-Cell-inputWrapper" tabindex="0">
 <div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
 </div>
 <div class="jp-InputArea jp-Cell-inputArea">
-<div class="jp-InputPrompt jp-InputArea-prompt">In [36]:</div>
+<div class="jp-InputPrompt jp-InputArea-prompt">In [ ]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
 <div class="cm-editor cm-s-jupyter">
 <div class="highlight hl-ipython3"><pre><span></span><span class="n">q</span> <span class="o">=</span> <span class="s2">"""</span>
@@ -9165,43 +8707,6 @@ INFO: rrtemplate-STAR-WD-v0.1.fits STAR WD PCA IGM=None z=-0.002-0.002
 </div>
 </div>
 </div>
-<div class="jp-Cell-outputWrapper">
-<div class="jp-Collapser jp-OutputCollapser jp-Cell-outputCollapser">
-</div>
-<div class="jp-OutputArea jp-Cell-outputArea">
-<div class="jp-OutputArea-child jp-OutputArea-executeResult">
-<div class="jp-OutputPrompt jp-OutputArea-prompt">Out[36]:</div>
-<div class="jp-RenderedHTMLCommon jp-RenderedHTML jp-OutputArea-output jp-OutputArea-executeResult" data-mime-type="text/html" tabindex="0">
-<div><i>Table length=50</i>
-<table class="table-striped table-bordered table-condensed" id="table140046316543984">
-<thead><tr><th>specobjid</th><th>bestobjid</th><th>z</th><th>zerr</th><th>zwarning</th><th>class</th><th>subclass</th><th>rchi2diff</th><th>primtarget</th><th>sectarget</th></tr></thead>
-<thead><tr><th>int64</th><th>int64</th><th>float64</th><th>float64</th><th>int64</th><th>str6</th><th>str11</th><th>float64</th><th>int64</th><th>int64</th></tr></thead>
-<tr><td>3327035125891360768</td><td>1237655468065620461</td><td>0.26219922</td><td>6.426468e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>0.16153336</td><td>96</td><td>0</td></tr>
-<tr><td>3327036500280895488</td><td>1237655468065489538</td><td>0.21097003</td><td>5.7919853e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>0.13921309</td><td>64</td><td>0</td></tr>
-<tr><td>3327038424426244096</td><td>1237655468065620456</td><td>0.2605426</td><td>6.229882e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>0.22558784</td><td>32</td><td>0</td></tr>
-<tr><td>3327038974182057984</td><td>1237655468065620382</td><td>0.11276812</td><td>1.5994665e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>0.510905</td><td>64</td><td>0</td></tr>
-<tr><td>3327040073693685760</td><td>1237651736318574966</td><td>0.06364931</td><td>2.8312488e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>0.42436635</td><td>64</td><td>0</td></tr>
-<tr><td>3327040348571592704</td><td>1237651736318640378</td><td>0.20836118</td><td>4.189276e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>1.1794078</td><td>96</td><td>0</td></tr>
-<tr><td>3327040898327406592</td><td>1237655468602491146</td><td>0.20784536</td><td>4.1236628e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>0.61972916</td><td>64</td><td>0</td></tr>
-<tr><td>3327041722961127424</td><td>1237651736318575080</td><td>0.1408417</td><td>1.9260546e-05</td><td>0</td><td>GALAXY</td><td>STARFORMING</td><td>0.49670327</td><td>64</td><td>0</td></tr>
-<tr><td>3327042822472755200</td><td>1237651736318574838</td><td>0.21259658</td><td>7.138862e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>0.14038157</td><td>96</td><td>0</td></tr>
-<tr><td>3327044196862289920</td><td>1237655468602556710</td><td>0.12747255</td><td>1.0024814e-05</td><td>0</td><td>GALAXY</td><td>STARFORMING</td><td>0.9118272</td><td>64</td><td>0</td></tr>
-<tr><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td></tr>
-<tr><td>3327063988071589888</td><td>1237655468602294437</td><td>0.117277816</td><td>1.2225097e-05</td><td>0</td><td>GALAXY</td><td>STARBURST</td><td>2.301178</td><td>64</td><td>0</td></tr>
-<tr><td>3327065087583217664</td><td>1237651736318378283</td><td>0.02987722</td><td>6.544521e-06</td><td>0</td><td>GALAXY</td><td>STARBURST</td><td>6.2372937</td><td>64</td><td>0</td></tr>
-<tr><td>3327065362461124608</td><td>1237655468602360140</td><td>0.08503898</td><td>2.8198616e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>0.38777363</td><td>64</td><td>0</td></tr>
-<tr><td>3327065912216938496</td><td>1237651736318443551</td><td>0.16617252</td><td>3.350158e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>0.5785748</td><td>64</td><td>0</td></tr>
-<tr><td>3327066187094845440</td><td>1237655468602294603</td><td>0.084284484</td><td>1.1737382e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>0.53542316</td><td>64</td><td>0</td></tr>
-<tr><td>3327066736850659328</td><td>1237651736318378031</td><td>0.050459415</td><td>3.3662614e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>0.066199064</td><td>64</td><td>0</td></tr>
-<tr><td>3327067011728566272</td><td>1237651735781377183</td><td>0.44971278</td><td>0.00015747716</td><td>0</td><td>GALAXY</td><td>--</td><td>0.060908318</td><td>32</td><td>0</td></tr>
-<tr><td>3327067286606473216</td><td>1237651736318444114</td><td>0.15844806</td><td>2.7416756e-05</td><td>0</td><td>GALAXY</td><td>STARFORMING</td><td>0.13396144</td><td>64</td><td>0</td></tr>
-<tr><td>3327067561484380160</td><td>1237655468064965078</td><td>0.0846016</td><td>2.5953486e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>0.16839969</td><td>64</td><td>0</td></tr>
-<tr><td>3327068111240194048</td><td>1237655468064964823</td><td>0.08544502</td><td>3.2923934e-05</td><td>0</td><td>GALAXY</td><td>STARFORMING</td><td>0.3577659</td><td>64</td><td>0</td></tr>
-</table></div>
-</div>
-</div>
-</div>
-</div>
 </div>
 <div class="jp-Cell jp-MarkdownCell jp-Notebook-cell">
 <div class="jp-Cell-inputWrapper" tabindex="0">
@@ -9218,7 +8723,7 @@ INFO: rrtemplate-STAR-WD-v0.1.fits STAR WD PCA IGM=None z=-0.002-0.002
 <div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
 </div>
 <div class="jp-InputArea jp-Cell-inputArea">
-<div class="jp-InputPrompt jp-InputArea-prompt">In [37]:</div>
+<div class="jp-InputPrompt jp-InputArea-prompt">In [ ]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
 <div class="cm-editor cm-s-jupyter">
 <div class="highlight hl-ipython3"><pre><span></span><span class="k">assert</span> <span class="p">(</span><span class="n">np</span><span class="o">.</span><span class="n">unique</span><span class="p">(</span><span class="n">sdss_ids</span><span class="p">[</span><span class="s1">'specobjid'</span><span class="p">])</span> <span class="o">==</span> <span class="n">sdss_ids</span><span class="p">[</span><span class="s1">'specobjid'</span><span class="p">])</span><span class="o">.</span><span class="n">all</span><span class="p">()</span>
@@ -9238,12 +8743,12 @@ INFO: rrtemplate-STAR-WD-v0.1.fits STAR WD PCA IGM=None z=-0.002-0.002
 </div>
 </div>
 </div>
-</div><div class="jp-Cell jp-CodeCell jp-Notebook-cell">
+</div><div class="jp-Cell jp-CodeCell jp-Notebook-cell jp-mod-noOutputs">
 <div class="jp-Cell-inputWrapper" tabindex="0">
 <div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
 </div>
 <div class="jp-InputArea jp-Cell-inputArea">
-<div class="jp-InputPrompt jp-InputArea-prompt">In [38]:</div>
+<div class="jp-InputPrompt jp-InputArea-prompt">In [ ]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
 <div class="cm-editor cm-s-jupyter">
 <div class="highlight hl-ipython3"><pre><span></span><span class="n">include</span> <span class="o">=</span> <span class="n">client</span><span class="o">.</span><span class="n">get_all_fields</span><span class="p">(</span><span class="n">dataset_list</span><span class="o">=</span><span class="p">[</span><span class="s1">'SDSS-DR17'</span><span class="p">])</span>
@@ -9252,20 +8757,6 @@ INFO: rrtemplate-STAR-WD-v0.1.fits STAR WD PCA IGM=None z=-0.002-0.002
                                          <span class="n">dataset_list</span><span class="o">=</span><span class="p">[</span><span class="s1">'SDSS-DR17'</span><span class="p">])</span>
 <span class="n">sdss_spectra</span><span class="o">.</span><span class="n">info</span>
 </pre></div>
-</div>
-</div>
-</div>
-</div>
-<div class="jp-Cell-outputWrapper">
-<div class="jp-Collapser jp-OutputCollapser jp-Cell-outputCollapser">
-</div>
-<div class="jp-OutputArea jp-Cell-outputArea">
-<div class="jp-OutputArea-child jp-OutputArea-executeResult">
-<div class="jp-OutputPrompt jp-OutputArea-prompt">Out[38]:</div>
-<div class="jp-RenderedText jp-OutputArea-output jp-OutputArea-executeResult" data-mime-type="text/plain" tabindex="0">
-<pre>{'status': {'success': True,
-  'info': ["Successfully found 50 records in dr_list=['SDSS-DR17']"],
-  'warnings': []}}</pre>
 </div>
 </div>
 </div>
@@ -9287,13 +8778,13 @@ INFO: rrtemplate-STAR-WD-v0.1.fits STAR WD PCA IGM=None z=-0.002-0.002
 <div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
 </div>
 <div class="jp-InputArea jp-Cell-inputArea">
-<div class="jp-InputPrompt jp-InputArea-prompt">In [39]:</div>
+<div class="jp-InputPrompt jp-InputArea-prompt">In [ ]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
 <div class="cm-editor cm-s-jupyter">
-<div class="highlight hl-ipython3"><pre><span></span><span class="n">sdss_records</span> <span class="o">=</span> <span class="nb">sorted</span><span class="p">(</span><span class="n">sdss_spectra</span><span class="o">.</span><span class="n">records</span><span class="p">,</span> <span class="n">key</span><span class="o">=</span><span class="k">lambda</span> <span class="n">x</span><span class="p">:</span> <span class="n">x</span><span class="o">.</span><span class="n">specid</span><span class="p">)</span>
-<span class="k">assert</span> <span class="p">(</span><span class="n">np</span><span class="o">.</span><span class="n">array</span><span class="p">([</span><span class="n">r</span><span class="o">.</span><span class="n">specid</span> <span class="k">for</span> <span class="n">r</span> <span class="ow">in</span> <span class="n">sdss_records</span><span class="p">])</span> <span class="o">==</span> <span class="n">sdss_ids</span><span class="p">[</span><span class="s1">'specobjid'</span><span class="p">])</span><span class="o">.</span><span class="n">all</span><span class="p">()</span>
-<span class="k">assert</span> <span class="nb">all</span><span class="p">([</span><span class="n">r</span><span class="o">.</span><span class="n">plate</span> <span class="o">==</span> <span class="mi">2955</span> <span class="k">for</span> <span class="n">r</span> <span class="ow">in</span> <span class="n">sdss_records</span><span class="p">])</span>
-<span class="k">assert</span> <span class="nb">all</span><span class="p">([</span><span class="n">r</span><span class="o">.</span><span class="n">mjd</span> <span class="o">==</span> <span class="mi">54562</span> <span class="k">for</span> <span class="n">r</span> <span class="ow">in</span> <span class="n">sdss_records</span><span class="p">])</span>
+<div class="highlight hl-ipython3"><pre><span></span><span class="n">sdss_spectra</span> <span class="o">=</span> <span class="n">sdss_spectra</span><span class="o">.</span><span class="n">reorder</span><span class="p">(</span><span class="n">sdss_ids</span><span class="p">[</span><span class="s1">'specobjid'</span><span class="p">]</span><span class="o">.</span><span class="n">value</span><span class="o">.</span><span class="n">tolist</span><span class="p">())</span>
+<span class="k">assert</span> <span class="p">(</span><span class="n">np</span><span class="o">.</span><span class="n">array</span><span class="p">([</span><span class="n">r</span><span class="o">.</span><span class="n">specid</span> <span class="k">for</span> <span class="n">r</span> <span class="ow">in</span> <span class="n">sdss_spectra</span><span class="o">.</span><span class="n">records</span><span class="p">])</span> <span class="o">==</span> <span class="n">sdss_ids</span><span class="p">[</span><span class="s1">'specobjid'</span><span class="p">])</span><span class="o">.</span><span class="n">all</span><span class="p">()</span>
+<span class="k">assert</span> <span class="nb">all</span><span class="p">([</span><span class="n">r</span><span class="o">.</span><span class="n">plate</span> <span class="o">==</span> <span class="mi">2955</span> <span class="k">for</span> <span class="n">r</span> <span class="ow">in</span> <span class="n">sdss_spectra</span><span class="o">.</span><span class="n">records</span><span class="p">])</span>
+<span class="k">assert</span> <span class="nb">all</span><span class="p">([</span><span class="n">r</span><span class="o">.</span><span class="n">mjd</span> <span class="o">==</span> <span class="mi">54562</span> <span class="k">for</span> <span class="n">r</span> <span class="ow">in</span> <span class="n">sdss_spectra</span><span class="o">.</span><span class="n">records</span><span class="p">])</span>
 </pre></div>
 </div>
 </div>
@@ -9315,10 +8806,10 @@ INFO: rrtemplate-STAR-WD-v0.1.fits STAR WD PCA IGM=None z=-0.002-0.002
 <div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
 </div>
 <div class="jp-InputArea jp-Cell-inputArea">
-<div class="jp-InputPrompt jp-InputArea-prompt">In [40]:</div>
+<div class="jp-InputPrompt jp-InputArea-prompt">In [ ]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
 <div class="cm-editor cm-s-jupyter">
-<div class="highlight hl-ipython3"><pre><span></span><span class="k">assert</span> <span class="nb">all</span><span class="p">([(</span><span class="n">r</span><span class="o">.</span><span class="n">wavelength</span> <span class="o">==</span> <span class="n">sdss_records</span><span class="p">[</span><span class="mi">0</span><span class="p">]</span><span class="o">.</span><span class="n">wavelength</span><span class="p">)</span><span class="o">.</span><span class="n">all</span><span class="p">()</span> <span class="k">for</span> <span class="n">r</span> <span class="ow">in</span> <span class="n">sdss_records</span><span class="p">])</span>
+<div class="highlight hl-ipython3"><pre><span></span><span class="k">assert</span> <span class="nb">all</span><span class="p">([(</span><span class="n">r</span><span class="o">.</span><span class="n">wavelength</span> <span class="o">==</span> <span class="n">sdss_spectra</span><span class="o">.</span><span class="n">records</span><span class="p">[</span><span class="mi">0</span><span class="p">]</span><span class="o">.</span><span class="n">wavelength</span><span class="p">)</span><span class="o">.</span><span class="n">all</span><span class="p">()</span> <span class="k">for</span> <span class="n">r</span> <span class="ow">in</span> <span class="n">sdss_spectra</span><span class="o">.</span><span class="n">records</span><span class="p">])</span>
 </pre></div>
 </div>
 </div>
@@ -9335,36 +8826,23 @@ INFO: rrtemplate-STAR-WD-v0.1.fits STAR WD PCA IGM=None z=-0.002-0.002
 </div>
 </div>
 </div>
-</div><div class="jp-Cell jp-CodeCell jp-Notebook-cell">
+</div><div class="jp-Cell jp-CodeCell jp-Notebook-cell jp-mod-noOutputs">
 <div class="jp-Cell-inputWrapper" tabindex="0">
 <div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
 </div>
 <div class="jp-InputArea jp-Cell-inputArea">
-<div class="jp-InputPrompt jp-InputArea-prompt">In [41]:</div>
+<div class="jp-InputPrompt jp-InputArea-prompt">In [ ]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
 <div class="cm-editor cm-s-jupyter">
-<div class="highlight hl-ipython3"><pre><span></span><span class="n">sdss_fully_masked</span> <span class="o">=</span> <span class="n">np</span><span class="o">.</span><span class="n">zeros</span><span class="p">((</span><span class="nb">len</span><span class="p">(</span><span class="n">sdss_records</span><span class="p">),</span> <span class="p">),</span> <span class="n">dtype</span><span class="o">=</span><span class="nb">bool</span><span class="p">)</span>
+<div class="highlight hl-ipython3"><pre><span></span><span class="n">sdss_fully_masked</span> <span class="o">=</span> <span class="n">np</span><span class="o">.</span><span class="n">zeros</span><span class="p">((</span><span class="nb">len</span><span class="p">(</span><span class="n">sdss_spectra</span><span class="o">.</span><span class="n">records</span><span class="p">),</span> <span class="p">),</span> <span class="n">dtype</span><span class="o">=</span><span class="nb">bool</span><span class="p">)</span>
 
-<span class="k">for</span> <span class="n">k</span> <span class="ow">in</span> <span class="nb">range</span><span class="p">(</span><span class="nb">len</span><span class="p">(</span><span class="n">sdss_records</span><span class="p">)):</span>
-    <span class="k">assert</span> <span class="n">np</span><span class="o">.</span><span class="n">isfinite</span><span class="p">(</span><span class="n">sdss_records</span><span class="p">[</span><span class="n">k</span><span class="p">]</span><span class="o">.</span><span class="n">flux</span><span class="p">)</span><span class="o">.</span><span class="n">all</span><span class="p">()</span>
-    <span class="k">assert</span> <span class="n">np</span><span class="o">.</span><span class="n">isfinite</span><span class="p">(</span><span class="n">sdss_records</span><span class="p">[</span><span class="n">k</span><span class="p">]</span><span class="o">.</span><span class="n">ivar</span><span class="p">)</span><span class="o">.</span><span class="n">all</span><span class="p">()</span>
-    <span class="k">if</span> <span class="p">(</span><span class="n">sdss_records</span><span class="p">[</span><span class="n">k</span><span class="p">]</span><span class="o">.</span><span class="n">mask</span> <span class="o">&gt;</span> <span class="mi">0</span><span class="p">)</span><span class="o">.</span><span class="n">all</span><span class="p">():</span>
+<span class="k">for</span> <span class="n">k</span> <span class="ow">in</span> <span class="nb">range</span><span class="p">(</span><span class="nb">len</span><span class="p">(</span><span class="n">sdss_spectra</span><span class="o">.</span><span class="n">records</span><span class="p">)):</span>
+    <span class="k">assert</span> <span class="n">np</span><span class="o">.</span><span class="n">isfinite</span><span class="p">(</span><span class="n">sdss_spectra</span><span class="o">.</span><span class="n">records</span><span class="p">[</span><span class="n">k</span><span class="p">]</span><span class="o">.</span><span class="n">flux</span><span class="p">)</span><span class="o">.</span><span class="n">all</span><span class="p">()</span>
+    <span class="k">assert</span> <span class="n">np</span><span class="o">.</span><span class="n">isfinite</span><span class="p">(</span><span class="n">sdss_spectra</span><span class="o">.</span><span class="n">records</span><span class="p">[</span><span class="n">k</span><span class="p">]</span><span class="o">.</span><span class="n">ivar</span><span class="p">)</span><span class="o">.</span><span class="n">all</span><span class="p">()</span>
+    <span class="k">if</span> <span class="p">(</span><span class="n">sdss_spectra</span><span class="o">.</span><span class="n">records</span><span class="p">[</span><span class="n">k</span><span class="p">]</span><span class="o">.</span><span class="n">mask</span> <span class="o">&gt;</span> <span class="mi">0</span><span class="p">)</span><span class="o">.</span><span class="n">all</span><span class="p">():</span>
         <span class="nb">print</span><span class="p">(</span><span class="sa">f</span><span class="s2">"WARNING: Spectrum record </span><span class="si">{</span><span class="n">k</span><span class="si">:</span><span class="s2">d</span><span class="si">}</span><span class="s2"> is fully masked!"</span><span class="p">)</span>
         <span class="n">sdss_fully_masked</span><span class="p">[</span><span class="n">k</span><span class="p">]</span> <span class="o">=</span> <span class="kc">True</span>
 </pre></div>
-</div>
-</div>
-</div>
-</div>
-<div class="jp-Cell-outputWrapper">
-<div class="jp-Collapser jp-OutputCollapser jp-Cell-outputCollapser">
-</div>
-<div class="jp-OutputArea jp-Cell-outputArea">
-<div class="jp-OutputArea-child">
-<div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
-<div class="jp-RenderedText jp-OutputArea-output" data-mime-type="text/plain" tabindex="0">
-<pre>WARNING: Spectrum record 0 is fully masked!
-</pre>
 </div>
 </div>
 </div>
@@ -9391,247 +8869,16 @@ INFO: rrtemplate-STAR-WD-v0.1.fits STAR WD PCA IGM=None z=-0.002-0.002
 </div>
 </div>
 </div>
-</div><div class="jp-Cell jp-CodeCell jp-Notebook-cell">
+</div><div class="jp-Cell jp-CodeCell jp-Notebook-cell jp-mod-noOutputs">
 <div class="jp-Cell-inputWrapper" tabindex="0">
 <div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
 </div>
 <div class="jp-InputArea jp-Cell-inputArea">
-<div class="jp-InputPrompt jp-InputArea-prompt">In [42]:</div>
+<div class="jp-InputPrompt jp-InputArea-prompt">In [ ]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
 <div class="cm-editor cm-s-jupyter">
-<div class="highlight hl-ipython3"><pre><span></span><span class="n">sdss_records</span><span class="p">[</span><span class="mi">0</span><span class="p">]</span>
+<div class="highlight hl-ipython3"><pre><span></span><span class="n">sdss_spectra</span><span class="o">.</span><span class="n">records</span><span class="p">[</span><span class="mi">0</span><span class="p">]</span>
 </pre></div>
-</div>
-</div>
-</div>
-</div>
-<div class="jp-Cell-outputWrapper">
-<div class="jp-Collapser jp-OutputCollapser jp-Cell-outputCollapser">
-</div>
-<div class="jp-OutputArea jp-Cell-outputArea">
-<div class="jp-OutputArea-child jp-OutputArea-executeResult">
-<div class="jp-OutputPrompt jp-OutputArea-prompt">Out[42]:</div>
-<div class="jp-RenderedText jp-OutputArea-output jp-OutputArea-executeResult" data-mime-type="text/plain" tabindex="0">
-<pre>{'redshift_err': 6.426467734854668e-05,
- 'specprimary': True,
- 'specid': 3327035125891360768,
- 'wavemin': 3821.2021484375,
- 'targetid': 1237655468065620461,
- 'sparcl_id': 'f54e0331-5e22-11f0-95ba-525400f334e1',
- 'instrument': 'SDSS',
- 'spectype': 'GALAXY',
- 'ra': 236.58816,
- 'data_release': 'SDSS-DR17',
- 'datasetgroup': 'SDSS_BOSS',
- 'wavemax': 9191.7880859375,
- 'telescope': 'sloan25m',
- 'dec': 0.91476191,
- 'redshift_warning': 0,
- 'exptime': 3002.0,
- 'site': 'apo',
- 'redshift': 0.2621992230415344,
- 'tcolumn': [0, 1, 2, 3, -1, -1, -1, -1, -1, -1],
- 'spec2_g': 24.95490074157715,
- 'run2d': 26,
- 'elodie_feh': 0.0,
- 'comments_person': '',
- 'fracnsigma': [0.3508818745613098,
-  0.0670764297246933,
-  0.006413682363927364,
-  0.0008017102954909205,
-  0.0005344735691323876,
-  0.0,
-  0.0,
-  0.0,
-  0.0,
-  0.0],
- 'deredsn2': 0.0,
- 'elodie_z': 0.0,
- 'designid': -1,
- 'platequality': 'good',
- 'spectrosynflux_ivar': [2.1609764099121094,
-  4.695135116577148,
-  2.821389675140381,
-  1.6888610124588013,
-  0.8614444136619568],
- 'survey': 'sdss',
- 'tile': 1929,
- 'ancillary_target1': 0,
- 'chunk': 'chunk186',
- 'cx': -0.5505830676883018,
- 'spec2_r': 26.778099060058594,
- 'elodie_logg': 0.0,
- 'firstrelease': 'dr7',
- 'lambda_eff': 5000.0,
- 'sn_median': [0.30225488543510437,
-  1.2845332622528076,
-  8.549945831298828,
-  12.833003044128418,
-  7.959794521331787],
- 'ancillary_target2': 0,
- 'eboss_target0': 0,
- 'thing_id': 0,
- 'mjd': 54562,
- 'spectrographid': 1,
- 'platesn2': 20.60099983215332,
- 'subclass_noqso': '',
- 'fiberid': 3,
- 'subclass': '',
- 'vdispchi2': 2368.89501953125,
- 'elodie_rchi2': 0.0,
- 'anyandmask': 231800836,
- 'targetobjid': '     11268994537292320',
- 'spec1_g': 20.60099983215332,
- 'spectroskyflux': [5.863976955413818,
-  10.033677101135254,
-  26.674739837646484,
-  46.53768539428711,
-  89.36570739746094],
- 'rchi2diff_noqso': 0.0,
- 'vdispz_err': 0.0,
- 'elodie_z_err': 0.0,
- 'spectrosynflux': [0.8224945664405823,
-  4.342596530914307,
-  25.939159393310547,
-  47.046897888183594,
-  63.13018798828125],
- 'cy': -0.8346277053986425,
- 'calibflux_ivar': [6.960999965667725,
-  32.389869689941406,
-  15.000844955444336,
-  5.515562057495117,
-  0.4543570280075073],
- 'specsegue1': 0,
- 'eboss_target1': 0,
- 'tfile': 'spEigenGal-53724.fits',
- 'segue1_target1': 0,
- 'rchi2': 1.1840944290161133,
- 'spec1_r': 21.144100189208984,
- 'specsegue': 0,
- 'specsegue2': 0,
- 'marvels_target1': 0,
- 'chi68p': 1.0683659315109253,
- 'xfocal': 254.52798461914062,
- 'eboss_target2': 0,
- 'sectarget': 0,
- 'elodie_teff': 0.0,
- 'sourcetype': 'GALAXY',
- 'bluefiber': -1,
- 'elodie_object': '',
- 'segue2_target2': 0,
- 'anyormask': 266272772,
- 'run1d': 0,
- 'elodie_filename': '',
- 'specsdss': 1,
- 'sn_median_all': 5.26422119140625,
- 'special_target1': 0,
- 'npoly': 3,
- 'plate': 2955,
- 'fracnsighi': [0.17691074311733246,
-  0.029396044090390205,
-  0.0024051310028880835,
-  0.0005344735691323876,
-  0.0005344735691323876,
-  0.0,
-  0.0,
-  0.0,
-  0.0,
-  0.0],
- 'segue2_target1': 0,
- 'vdisp_err': 19.371538162231445,
- 'eboss_target_id': 0,
- 'class_noqso': '',
- 'primtarget': 96,
- 'zwarning_noqso': 0,
- 'calibflux': [0.9236018657684326,
-  6.705709457397461,
-  29.254060745239258,
-  49.9967041015625,
-  72.04325866699219],
- 'spectroflux_ivar': [1.5567643642425537,
-  4.762773513793945,
-  2.497319459915161,
-  1.469778060913086,
-  0.6877836585044861],
- 'rchi2diff': 0.16153335571289062,
- 'programname': 'legacy',
- 'zoffset': 0.0,
- 'speclegacy': 1,
- 'z_person': 0.0,
- 'boss_specobj_id': 0,
- 'targettype': 'SCIENCE',
- 'theta': [0.0009990220423787832,
-  -0.0020634604152292013,
-  0.0063892873004078865,
-  0.010271521285176277,
-  -9.59719467163086,
-  31.447433471679688,
-  -23.034820556640625,
-  0.0,
-  0.0,
-  0.0],
- 'class_person': 0,
- 'elodie_dof': 0,
- 'nturnoff': -1,
- 'platerun': 'dr2008.02.1',
- 'z_conf_person': 0,
- 'objid': [2327, 40, 2, 95, 544],
- 'boss_target2': 0,
- 'elodie_sptype': '',
- 'z_err_noqso': 0.0,
- 'vdispz': 0.0,
- 'segue1_target2': 0,
- 'thing_id_targeting': 0,
- 'fracnsiglo': [0.17397113144397736,
-  0.037680383771657944,
-  0.0040085515938699245,
-  0.0002672367845661938,
-  0.0,
-  0.0,
-  0.0,
-  0.0,
-  0.0,
-  0.0],
- 'elodie_z_modelerr': 0.0,
- 'marvels_target2': 0,
- 'special_target2': 0,
- 'nspecobs': 1,
- 'spec1_i': 20.87619972229004,
- 'elodie_bv': 0.0,
- 'wcoverage': 0.3741999864578247,
- 'specboss': 0,
- 'legacy_target2': 0,
- 'fluxobjid': '1237655468065620461',
- 'legacy_target1': 96,
- 'z_noqso': 0.0,
- 'vdisp': 174.73614501953125,
- 'vdispdof': 2117,
- 'snturnoff': -9999.0,
- 'spectroflux': [1.6958324909210205,
-  4.575725555419922,
-  25.73033332824707,
-  46.75497055053711,
-  63.58713912963867],
- 'spec2_i': 23.063199996948242,
- 'vdispnpix': 2168.0,
- 'cz': 0.015964928936132036,
- 'boss_target1': 0,
- 'dof': 3735,
- 'plateid': '3327034301257639936',
- 'yfocal': -158.91990661621094,
- 'mask': array([16777216, 16777216, 16777216, ..., 16777216, 16777216, 16777216]),
- 'wave_sigma': array([0., 0., 0., ..., 0., 0., 0.]),
- 'model': array([0.50012714, 0.59808964, 0.66844636, ..., 9.11743164, 9.0471859 ,
-        9.00358009]),
- 'wavelength': array([3802.76948244, 3803.64520329, 3804.5211258 , ..., 9217.22098659,
-        9219.34357452, 9221.46665124]),
- 'ivar': array([0., 0., 0., ..., 0., 0., 0.]),
- 'flux': array([0.85558206, 0.85530269, 0.85502368, ..., 8.03089142, 8.03085518,
-        8.03081989]),
- 'sky': array([0., 0., 0., ..., 0., 0., 0.]),
- 'dateobs': '["2008-04-06 00:00:00+00","2008-04-06 00:00:00+00"]',
- 'dateobs_center': '2008-04-06 00:00:00+00',
- '_dr': 'SDSS-DR17'}</pre>
 </div>
 </div>
 </div>
@@ -9645,7 +8892,7 @@ INFO: rrtemplate-STAR-WD-v0.1.fits STAR WD PCA IGM=None z=-0.002-0.002
 </div><div class="jp-RenderedHTMLCommon jp-RenderedMarkdown jp-MarkdownOutput" data-mime-type="text/markdown">
 <h3 id="Organize-metadata">Organize metadata<a class="anchor-link" href="#Organize-metadata">¶</a></h3><p>Prospect needs several inputs:</p>
 <ol>
-<li>An object containing spectra.  In this case we'll use a <a href="https://specutils.readthedocs.io/en/stable/api/specutils.Spectrum1D.html#specutils.Spectrum1D"><code>Spectrum1D</code></a> object.<ul>
+<li>An object containing spectra.  In this case we'll use a <a href="https://specutils.readthedocs.io/en/stable/api/specutils.Spectrum.html#specutils.Spectrum"><code>Spectrum</code></a> object.<ul>
 <li>The object contains the usual flux, wavelength, uncertainty.</li>
 <li>In addtion a "plugmap" table is needed. This should be an Astropy <code>Table</code> with the expected columns.</li>
 </ul>
@@ -9653,7 +8900,7 @@ INFO: rrtemplate-STAR-WD-v0.1.fits STAR WD PCA IGM=None z=-0.002-0.002
 <li>A redshift catalog. This should be an Astropy <code>Table</code> with the expected columns.</li>
 <li>A model spectrum.  The model is actually provided by SPARCL, but we need to input it separately.</li>
 </ol>
-<h4 id="Spectrum-object">Spectrum object<a class="anchor-link" href="#Spectrum-object">¶</a></h4><p>First we assemble the components of the spectrum object</p>
+<h4 id="Spectrum-object">Spectrum object<a class="anchor-link" href="#Spectrum-object">¶</a></h4><p>First we assemble the components of the spectrum object. Most of the work is done simply by converting the retrieved results to a <code>specutils</code> object.</p>
 </div>
 </div>
 </div>
@@ -9662,26 +8909,10 @@ INFO: rrtemplate-STAR-WD-v0.1.fits STAR WD PCA IGM=None z=-0.002-0.002
 <div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
 </div>
 <div class="jp-InputArea jp-Cell-inputArea">
-<div class="jp-InputPrompt jp-InputArea-prompt">In [43]:</div>
+<div class="jp-InputPrompt jp-InputArea-prompt">In [ ]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
 <div class="cm-editor cm-s-jupyter">
-<div class="highlight hl-ipython3"><pre><span></span><span class="n">flux</span> <span class="o">=</span> <span class="n">np</span><span class="o">.</span><span class="n">zeros</span><span class="p">((</span><span class="nb">len</span><span class="p">(</span><span class="n">sdss_records</span><span class="p">),</span> <span class="n">sdss_records</span><span class="p">[</span><span class="mi">0</span><span class="p">]</span><span class="o">.</span><span class="n">flux</span><span class="o">.</span><span class="n">shape</span><span class="p">[</span><span class="mi">0</span><span class="p">]),</span>
-                <span class="n">dtype</span><span class="o">=</span><span class="n">sdss_records</span><span class="p">[</span><span class="mi">0</span><span class="p">]</span><span class="o">.</span><span class="n">flux</span><span class="o">.</span><span class="n">dtype</span><span class="p">)</span>
-<span class="n">uncertainty</span> <span class="o">=</span> <span class="n">np</span><span class="o">.</span><span class="n">zeros</span><span class="p">((</span><span class="nb">len</span><span class="p">(</span><span class="n">sdss_records</span><span class="p">),</span> <span class="n">sdss_records</span><span class="p">[</span><span class="mi">0</span><span class="p">]</span><span class="o">.</span><span class="n">ivar</span><span class="o">.</span><span class="n">shape</span><span class="p">[</span><span class="mi">0</span><span class="p">]),</span>
-                       <span class="n">dtype</span><span class="o">=</span><span class="n">sdss_records</span><span class="p">[</span><span class="mi">0</span><span class="p">]</span><span class="o">.</span><span class="n">ivar</span><span class="o">.</span><span class="n">dtype</span><span class="p">)</span>
-<span class="n">mask</span> <span class="o">=</span> <span class="n">np</span><span class="o">.</span><span class="n">zeros</span><span class="p">((</span><span class="nb">len</span><span class="p">(</span><span class="n">sdss_records</span><span class="p">),</span> <span class="n">sdss_records</span><span class="p">[</span><span class="mi">0</span><span class="p">]</span><span class="o">.</span><span class="n">mask</span><span class="o">.</span><span class="n">shape</span><span class="p">[</span><span class="mi">0</span><span class="p">]),</span>
-                <span class="n">dtype</span><span class="o">=</span><span class="n">sdss_records</span><span class="p">[</span><span class="mi">0</span><span class="p">]</span><span class="o">.</span><span class="n">mask</span><span class="o">.</span><span class="n">dtype</span><span class="p">)</span>
-
-<span class="n">meta</span> <span class="o">=</span> <span class="p">{</span><span class="s1">'sparcl_id'</span><span class="p">:</span> <span class="nb">list</span><span class="p">(),</span> <span class="s1">'data_release'</span><span class="p">:</span> <span class="nb">list</span><span class="p">()}</span>
-<span class="n">sparcl_id</span> <span class="o">=</span> <span class="nb">list</span><span class="p">()</span>
-<span class="n">data_release</span> <span class="o">=</span> <span class="nb">list</span><span class="p">()</span>
-
-<span class="k">for</span> <span class="n">k</span> <span class="ow">in</span> <span class="nb">range</span><span class="p">(</span><span class="nb">len</span><span class="p">(</span><span class="n">sdss_records</span><span class="p">)):</span>
-    <span class="n">flux</span><span class="p">[</span><span class="n">k</span><span class="p">,</span> <span class="p">:]</span> <span class="o">=</span> <span class="n">sdss_records</span><span class="p">[</span><span class="n">k</span><span class="p">]</span><span class="o">.</span><span class="n">flux</span>
-    <span class="n">uncertainty</span><span class="p">[</span><span class="n">k</span><span class="p">,</span> <span class="p">:]</span> <span class="o">=</span> <span class="n">sdss_records</span><span class="p">[</span><span class="n">k</span><span class="p">]</span><span class="o">.</span><span class="n">ivar</span>
-    <span class="n">mask</span><span class="p">[</span><span class="n">k</span><span class="p">,</span> <span class="p">:]</span> <span class="o">=</span> <span class="n">sdss_records</span><span class="p">[</span><span class="n">k</span><span class="p">]</span><span class="o">.</span><span class="n">mask</span>
-    <span class="n">meta</span><span class="p">[</span><span class="s1">'sparcl_id'</span><span class="p">]</span><span class="o">.</span><span class="n">append</span><span class="p">(</span><span class="n">sdss_records</span><span class="p">[</span><span class="n">k</span><span class="p">]</span><span class="o">.</span><span class="n">sparcl_id</span><span class="p">)</span>
-    <span class="n">meta</span><span class="p">[</span><span class="s1">'data_release'</span><span class="p">]</span><span class="o">.</span><span class="n">append</span><span class="p">(</span><span class="n">sdss_records</span><span class="p">[</span><span class="n">k</span><span class="p">]</span><span class="o">.</span><span class="n">data_release</span><span class="p">)</span>
+<div class="highlight hl-ipython3"><pre><span></span><span class="n">sdss_specutils</span> <span class="o">=</span> <span class="n">sdss_spectra</span><span class="o">.</span><span class="n">to_specutils</span><span class="p">()</span>
 </pre></div>
 </div>
 </div>
@@ -9694,7 +8925,7 @@ INFO: rrtemplate-STAR-WD-v0.1.fits STAR WD PCA IGM=None z=-0.002-0.002
 </div>
 <div class="jp-InputArea jp-Cell-inputArea"><div class="jp-InputPrompt jp-InputArea-prompt">
 </div><div class="jp-RenderedHTMLCommon jp-RenderedMarkdown jp-MarkdownOutput" data-mime-type="text/markdown">
-<p>And the "plugmap" table. We'll start with photometric quantities.</p>
+<p>We need a "plugmap" table. We'll start with photometric quantities.</p>
 </div>
 </div>
 </div>
@@ -9703,7 +8934,7 @@ INFO: rrtemplate-STAR-WD-v0.1.fits STAR WD PCA IGM=None z=-0.002-0.002
 <div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
 </div>
 <div class="jp-InputArea jp-Cell-inputArea">
-<div class="jp-InputPrompt jp-InputArea-prompt">In [44]:</div>
+<div class="jp-InputPrompt jp-InputArea-prompt">In [ ]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
 <div class="cm-editor cm-s-jupyter">
 <div class="highlight hl-ipython3"><pre><span></span><span class="n">columns</span> <span class="o">=</span> <span class="p">(</span><span class="s1">'z.specobjid'</span><span class="p">,</span> <span class="s1">'p.objid'</span><span class="p">,</span> <span class="s1">'p.ra'</span><span class="p">,</span> <span class="s1">'p.dec'</span><span class="p">,</span> <span class="s1">'p.u'</span><span class="p">,</span> <span class="s1">'p.g'</span><span class="p">,</span> <span class="s1">'p.r'</span><span class="p">,</span> <span class="s1">'p.i'</span><span class="p">,</span> <span class="s1">'p.z'</span><span class="p">)</span>
@@ -9727,7 +8958,7 @@ INFO: rrtemplate-STAR-WD-v0.1.fits STAR WD PCA IGM=None z=-0.002-0.002
 <div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
 </div>
 <div class="jp-InputArea jp-Cell-inputArea">
-<div class="jp-InputPrompt jp-InputArea-prompt">In [45]:</div>
+<div class="jp-InputPrompt jp-InputArea-prompt">In [ ]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
 <div class="cm-editor cm-s-jupyter">
 <div class="highlight hl-ipython3"><pre><span></span><span class="k">for</span> <span class="n">col</span> <span class="ow">in</span> <span class="n">plugmap</span><span class="o">.</span><span class="n">colnames</span><span class="p">:</span>
@@ -9738,7 +8969,7 @@ INFO: rrtemplate-STAR-WD-v0.1.fits STAR WD PCA IGM=None z=-0.002-0.002
 <span class="n">plugmap</span><span class="o">.</span><span class="n">add_column</span><span class="p">(</span><span class="n">mag</span><span class="p">,</span> <span class="n">name</span><span class="o">=</span><span class="s1">'MAG'</span><span class="p">)</span>
 <span class="n">plugmap</span><span class="o">.</span><span class="n">add_column</span><span class="p">(</span><span class="n">sdss_ids</span><span class="p">[</span><span class="s1">'primtarget'</span><span class="p">],</span> <span class="n">name</span><span class="o">=</span><span class="s1">'PRIMTARGET'</span><span class="p">)</span>
 <span class="n">plugmap</span><span class="o">.</span><span class="n">add_column</span><span class="p">(</span><span class="n">sdss_ids</span><span class="p">[</span><span class="s1">'sectarget'</span><span class="p">],</span> <span class="n">name</span><span class="o">=</span><span class="s1">'SECTARGET'</span><span class="p">)</span>
-<span class="n">meta</span><span class="p">[</span><span class="s1">'plugmap'</span><span class="p">]</span> <span class="o">=</span> <span class="n">plugmap</span><span class="p">[</span><span class="o">~</span><span class="n">sdss_fully_masked</span><span class="p">]</span>
+<span class="n">sdss_specutils</span><span class="o">.</span><span class="n">meta</span><span class="p">[</span><span class="s1">'plugmap'</span><span class="p">]</span> <span class="o">=</span> <span class="n">plugmap</span><span class="p">[</span><span class="o">~</span><span class="n">sdss_fully_masked</span><span class="p">]</span>
 </pre></div>
 </div>
 </div>
@@ -9760,7 +8991,7 @@ INFO: rrtemplate-STAR-WD-v0.1.fits STAR WD PCA IGM=None z=-0.002-0.002
 <div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
 </div>
 <div class="jp-InputArea jp-Cell-inputArea">
-<div class="jp-InputPrompt jp-InputArea-prompt">In [46]:</div>
+<div class="jp-InputPrompt jp-InputArea-prompt">In [ ]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
 <div class="cm-editor cm-s-jupyter">
 <div class="highlight hl-ipython3"><pre><span></span><span class="k">assert</span> <span class="p">(</span><span class="n">plugmap</span><span class="p">[</span><span class="s1">'OBJID'</span><span class="p">]</span> <span class="o">==</span> <span class="n">sdss_ids</span><span class="p">[</span><span class="s1">'bestobjid'</span><span class="p">])</span><span class="o">.</span><span class="n">all</span><span class="p">()</span>
@@ -9785,14 +9016,14 @@ INFO: rrtemplate-STAR-WD-v0.1.fits STAR WD PCA IGM=None z=-0.002-0.002
 <div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
 </div>
 <div class="jp-InputArea jp-Cell-inputArea">
-<div class="jp-InputPrompt jp-InputArea-prompt">In [47]:</div>
+<div class="jp-InputPrompt jp-InputArea-prompt">In [ ]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
 <div class="cm-editor cm-s-jupyter">
-<div class="highlight hl-ipython3"><pre><span></span><span class="n">sdss_prospect</span> <span class="o">=</span> <span class="n">Spectrum1D</span><span class="p">(</span><span class="n">flux</span><span class="o">=</span><span class="n">flux</span><span class="p">[</span><span class="o">~</span><span class="n">sdss_fully_masked</span><span class="p">,</span> <span class="p">:]</span> <span class="o">*</span> <span class="n">u</span><span class="o">.</span><span class="n">Unit</span><span class="p">(</span><span class="s1">'1e-17 erg / (Angstrom cm2 s)'</span><span class="p">),</span>
-                           <span class="n">spectral_axis</span><span class="o">=</span><span class="n">sdss_records</span><span class="p">[</span><span class="mi">0</span><span class="p">]</span><span class="o">.</span><span class="n">wavelength</span> <span class="o">*</span> <span class="n">u</span><span class="o">.</span><span class="n">Unit</span><span class="p">(</span><span class="s1">'Angstrom'</span><span class="p">),</span>
-                           <span class="n">uncertainty</span><span class="o">=</span><span class="n">InverseVariance</span><span class="p">(</span><span class="n">uncertainty</span><span class="p">[</span><span class="o">~</span><span class="n">sdss_fully_masked</span><span class="p">,</span> <span class="p">:]),</span>
-                           <span class="n">mask</span><span class="o">=</span><span class="n">mask</span><span class="p">[</span><span class="o">~</span><span class="n">sdss_fully_masked</span><span class="p">,</span> <span class="p">:]</span> <span class="o">!=</span> <span class="mi">0</span><span class="p">,</span>
-                           <span class="n">meta</span><span class="o">=</span><span class="n">meta</span><span class="p">)</span>
+<div class="highlight hl-ipython3"><pre><span></span><span class="n">sdss_prospect</span> <span class="o">=</span> <span class="n">Spectrum1D</span><span class="p">(</span><span class="n">flux</span><span class="o">=</span><span class="n">sdss_specutils</span><span class="o">.</span><span class="n">flux</span><span class="p">[</span><span class="o">~</span><span class="n">sdss_fully_masked</span><span class="p">,</span> <span class="p">:],</span>
+                           <span class="n">spectral_axis</span><span class="o">=</span><span class="n">sdss_specutils</span><span class="o">.</span><span class="n">spectral_axis</span><span class="p">,</span>
+                           <span class="n">uncertainty</span><span class="o">=</span><span class="n">InverseVariance</span><span class="p">(</span><span class="n">sdss_specutils</span><span class="o">.</span><span class="n">uncertainty</span><span class="p">[</span><span class="o">~</span><span class="n">sdss_fully_masked</span><span class="p">,</span> <span class="p">:]),</span>
+                           <span class="n">mask</span><span class="o">=</span><span class="n">sdss_specutils</span><span class="o">.</span><span class="n">mask</span><span class="p">[</span><span class="o">~</span><span class="n">sdss_fully_masked</span><span class="p">,</span> <span class="p">:]</span> <span class="o">!=</span> <span class="mi">0</span><span class="p">,</span>
+                           <span class="n">meta</span><span class="o">=</span><span class="n">sdss_specutils</span><span class="o">.</span><span class="n">meta</span><span class="p">)</span>
 </pre></div>
 </div>
 </div>
@@ -9809,12 +9040,12 @@ INFO: rrtemplate-STAR-WD-v0.1.fits STAR WD PCA IGM=None z=-0.002-0.002
 </div>
 </div>
 </div>
-</div><div class="jp-Cell jp-CodeCell jp-Notebook-cell">
+</div><div class="jp-Cell jp-CodeCell jp-Notebook-cell jp-mod-noOutputs">
 <div class="jp-Cell-inputWrapper" tabindex="0">
 <div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
 </div>
 <div class="jp-InputArea jp-Cell-inputArea">
-<div class="jp-InputPrompt jp-InputArea-prompt">In [48]:</div>
+<div class="jp-InputPrompt jp-InputArea-prompt">In [ ]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
 <div class="cm-editor cm-s-jupyter">
 <div class="highlight hl-ipython3"><pre><span></span><span class="n">sdss_zcatalog</span> <span class="o">=</span> <span class="n">sdss_ids</span><span class="o">.</span><span class="n">copy</span><span class="p">()</span>
@@ -9825,43 +9056,6 @@ INFO: rrtemplate-STAR-WD-v0.1.fits STAR WD PCA IGM=None z=-0.002-0.002
         <span class="n">sdss_zcatalog</span><span class="o">.</span><span class="n">rename_column</span><span class="p">(</span><span class="n">col</span><span class="p">,</span> <span class="n">col</span><span class="o">.</span><span class="n">upper</span><span class="p">())</span>
 <span class="n">sdss_zcatalog</span>
 </pre></div>
-</div>
-</div>
-</div>
-</div>
-<div class="jp-Cell-outputWrapper">
-<div class="jp-Collapser jp-OutputCollapser jp-Cell-outputCollapser">
-</div>
-<div class="jp-OutputArea jp-Cell-outputArea">
-<div class="jp-OutputArea-child jp-OutputArea-executeResult">
-<div class="jp-OutputPrompt jp-OutputArea-prompt">Out[48]:</div>
-<div class="jp-RenderedHTMLCommon jp-RenderedHTML jp-OutputArea-output jp-OutputArea-executeResult" data-mime-type="text/html" tabindex="0">
-<div><i>Table length=50</i>
-<table class="table-striped table-bordered table-condensed" id="table140046225045584">
-<thead><tr><th>SPECOBJID</th><th>BESTOBJID</th><th>Z</th><th>Z_ERR</th><th>ZWARNING</th><th>CLASS</th><th>SUBCLASS</th><th>RCHI2DIFF</th><th>PRIMTARGET</th><th>SECTARGET</th></tr></thead>
-<thead><tr><th>int64</th><th>int64</th><th>float64</th><th>float64</th><th>int64</th><th>str6</th><th>str11</th><th>float64</th><th>int64</th><th>int64</th></tr></thead>
-<tr><td>3327035125891360768</td><td>1237655468065620461</td><td>0.26219922</td><td>6.426468e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>0.16153336</td><td>96</td><td>0</td></tr>
-<tr><td>3327036500280895488</td><td>1237655468065489538</td><td>0.21097003</td><td>5.7919853e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>0.13921309</td><td>64</td><td>0</td></tr>
-<tr><td>3327038424426244096</td><td>1237655468065620456</td><td>0.2605426</td><td>6.229882e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>0.22558784</td><td>32</td><td>0</td></tr>
-<tr><td>3327038974182057984</td><td>1237655468065620382</td><td>0.11276812</td><td>1.5994665e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>0.510905</td><td>64</td><td>0</td></tr>
-<tr><td>3327040073693685760</td><td>1237651736318574966</td><td>0.06364931</td><td>2.8312488e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>0.42436635</td><td>64</td><td>0</td></tr>
-<tr><td>3327040348571592704</td><td>1237651736318640378</td><td>0.20836118</td><td>4.189276e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>1.1794078</td><td>96</td><td>0</td></tr>
-<tr><td>3327040898327406592</td><td>1237655468602491146</td><td>0.20784536</td><td>4.1236628e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>0.61972916</td><td>64</td><td>0</td></tr>
-<tr><td>3327041722961127424</td><td>1237651736318575080</td><td>0.1408417</td><td>1.9260546e-05</td><td>0</td><td>GALAXY</td><td>STARFORMING</td><td>0.49670327</td><td>64</td><td>0</td></tr>
-<tr><td>3327042822472755200</td><td>1237651736318574838</td><td>0.21259658</td><td>7.138862e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>0.14038157</td><td>96</td><td>0</td></tr>
-<tr><td>3327044196862289920</td><td>1237655468602556710</td><td>0.12747255</td><td>1.0024814e-05</td><td>0</td><td>GALAXY</td><td>STARFORMING</td><td>0.9118272</td><td>64</td><td>0</td></tr>
-<tr><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td></tr>
-<tr><td>3327063988071589888</td><td>1237655468602294437</td><td>0.117277816</td><td>1.2225097e-05</td><td>0</td><td>GALAXY</td><td>STARBURST</td><td>2.301178</td><td>64</td><td>0</td></tr>
-<tr><td>3327065087583217664</td><td>1237651736318378283</td><td>0.02987722</td><td>6.544521e-06</td><td>0</td><td>GALAXY</td><td>STARBURST</td><td>6.2372937</td><td>64</td><td>0</td></tr>
-<tr><td>3327065362461124608</td><td>1237655468602360140</td><td>0.08503898</td><td>2.8198616e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>0.38777363</td><td>64</td><td>0</td></tr>
-<tr><td>3327065912216938496</td><td>1237651736318443551</td><td>0.16617252</td><td>3.350158e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>0.5785748</td><td>64</td><td>0</td></tr>
-<tr><td>3327066187094845440</td><td>1237655468602294603</td><td>0.084284484</td><td>1.1737382e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>0.53542316</td><td>64</td><td>0</td></tr>
-<tr><td>3327066736850659328</td><td>1237651736318378031</td><td>0.050459415</td><td>3.3662614e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>0.066199064</td><td>64</td><td>0</td></tr>
-<tr><td>3327067011728566272</td><td>1237651735781377183</td><td>0.44971278</td><td>0.00015747716</td><td>0</td><td>GALAXY</td><td>--</td><td>0.060908318</td><td>32</td><td>0</td></tr>
-<tr><td>3327067286606473216</td><td>1237651736318444114</td><td>0.15844806</td><td>2.7416756e-05</td><td>0</td><td>GALAXY</td><td>STARFORMING</td><td>0.13396144</td><td>64</td><td>0</td></tr>
-<tr><td>3327067561484380160</td><td>1237655468064965078</td><td>0.0846016</td><td>2.5953486e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>0.16839969</td><td>64</td><td>0</td></tr>
-<tr><td>3327068111240194048</td><td>1237655468064964823</td><td>0.08544502</td><td>3.2923934e-05</td><td>0</td><td>GALAXY</td><td>STARFORMING</td><td>0.3577659</td><td>64</td><td>0</td></tr>
-</table></div>
 </div>
 </div>
 </div>
@@ -9882,16 +9076,10 @@ INFO: rrtemplate-STAR-WD-v0.1.fits STAR WD PCA IGM=None z=-0.002-0.002
 <div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
 </div>
 <div class="jp-InputArea jp-Cell-inputArea">
-<div class="jp-InputPrompt jp-InputArea-prompt">In [49]:</div>
+<div class="jp-InputPrompt jp-InputArea-prompt">In [ ]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
 <div class="cm-editor cm-s-jupyter">
-<div class="highlight hl-ipython3"><pre><span></span><span class="n">model_flux</span> <span class="o">=</span> <span class="n">np</span><span class="o">.</span><span class="n">zeros</span><span class="p">((</span><span class="nb">len</span><span class="p">(</span><span class="n">sdss_records</span><span class="p">),</span> <span class="n">sdss_records</span><span class="p">[</span><span class="mi">0</span><span class="p">]</span><span class="o">.</span><span class="n">model</span><span class="o">.</span><span class="n">shape</span><span class="p">[</span><span class="mi">0</span><span class="p">]),</span>
-                      <span class="n">dtype</span><span class="o">=</span><span class="n">sdss_records</span><span class="p">[</span><span class="mi">0</span><span class="p">]</span><span class="o">.</span><span class="n">model</span><span class="o">.</span><span class="n">dtype</span><span class="p">)</span>
-
-<span class="k">for</span> <span class="n">k</span> <span class="ow">in</span> <span class="nb">range</span><span class="p">(</span><span class="nb">len</span><span class="p">(</span><span class="n">sdss_records</span><span class="p">)):</span>
-        <span class="n">model_flux</span><span class="p">[</span><span class="n">k</span><span class="p">,</span> <span class="p">:]</span> <span class="o">=</span> <span class="n">sdss_records</span><span class="p">[</span><span class="n">k</span><span class="p">]</span><span class="o">.</span><span class="n">model</span>
-
-<span class="n">sdss_model</span> <span class="o">=</span> <span class="p">(</span><span class="n">sdss_records</span><span class="p">[</span><span class="mi">0</span><span class="p">]</span><span class="o">.</span><span class="n">wavelength</span><span class="p">,</span> <span class="n">model_flux</span><span class="p">[</span><span class="o">~</span><span class="n">sdss_fully_masked</span><span class="p">,</span> <span class="p">:])</span>
+<div class="highlight hl-ipython3"><pre><span></span><span class="n">sdss_model</span> <span class="o">=</span> <span class="p">(</span><span class="n">sdss_specutils</span><span class="o">.</span><span class="n">spectral_axis</span><span class="p">,</span> <span class="n">sdss_specutils</span><span class="o">.</span><span class="n">meta</span><span class="p">[</span><span class="s1">'model'</span><span class="p">][</span><span class="o">~</span><span class="n">sdss_fully_masked</span><span class="p">,</span> <span class="p">:])</span>
 </pre></div>
 </div>
 </div>
@@ -9954,12 +9142,12 @@ INFO: rrtemplate-STAR-WD-v0.1.fits STAR WD PCA IGM=None z=-0.002-0.002
 </div>
 </div>
 </div>
-</div><div class="jp-Cell jp-CodeCell jp-Notebook-cell">
+</div><div class="jp-Cell jp-CodeCell jp-Notebook-cell jp-mod-noOutputs">
 <div class="jp-Cell-inputWrapper" tabindex="0">
 <div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
 </div>
 <div class="jp-InputArea jp-Cell-inputArea">
-<div class="jp-InputPrompt jp-InputArea-prompt">In [51]:</div>
+<div class="jp-InputPrompt jp-InputArea-prompt">In [ ]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
 <div class="cm-editor cm-s-jupyter">
 <div class="highlight hl-ipython3"><pre><span></span><span class="n">q</span> <span class="o">=</span> <span class="s2">"""</span>
@@ -9983,43 +9171,6 @@ INFO: rrtemplate-STAR-WD-v0.1.fits STAR WD PCA IGM=None z=-0.002-0.002
 </div>
 </div>
 </div>
-<div class="jp-Cell-outputWrapper">
-<div class="jp-Collapser jp-OutputCollapser jp-Cell-outputCollapser">
-</div>
-<div class="jp-OutputArea jp-Cell-outputArea">
-<div class="jp-OutputArea-child jp-OutputArea-executeResult">
-<div class="jp-OutputPrompt jp-OutputArea-prompt">Out[51]:</div>
-<div class="jp-RenderedHTMLCommon jp-RenderedHTML jp-OutputArea-output jp-OutputArea-executeResult" data-mime-type="text/html" tabindex="0">
-<div><i>Table length=50</i>
-<table class="table-striped table-bordered table-condensed" id="table140046224292544">
-<thead><tr><th>specobjid</th><th>bestobjid</th><th>z</th><th>zerr</th><th>zwarning</th><th>class</th><th>subclass</th><th>rchi2diff</th><th>boss_target1</th><th>eboss_target0</th><th>eboss_target1</th><th>eboss_target2</th></tr></thead>
-<thead><tr><th>int64</th><th>int64</th><th>float64</th><th>float64</th><th>int64</th><th>str6</th><th>int64</th><th>float64</th><th>int64</th><th>int64</th><th>int64</th><th>int64</th></tr></thead>
-<tr><td>-7639230456632420352</td><td>1237665127987282622</td><td>0.8864001</td><td>7.46243e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>0.06786668</td><td>0</td><td>0</td><td>17592186044416</td><td>562949953421312</td></tr>
-<tr><td>-7639227982731257856</td><td>1237665098459972441</td><td>0.9110273</td><td>0.00010862139</td><td>0</td><td>GALAXY</td><td>--</td><td>0.017336488</td><td>0</td><td>0</td><td>17592186044416</td><td>562949953421312</td></tr>
-<tr><td>-7639227707853350912</td><td>1237665128524284395</td><td>0.38422197</td><td>3.6719743e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>0.04284048</td><td>0</td><td>0</td><td>17592186044416</td><td>562949953421312</td></tr>
-<tr><td>-7639227432975443968</td><td>1237665098459972179</td><td>0.800372</td><td>7.3419695e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>0.026912212</td><td>0</td><td>0</td><td>17592186044416</td><td>562949953421312</td></tr>
-<tr><td>-7639226333463816192</td><td>1237665128524350020</td><td>0.7552478</td><td>0.00021523784</td><td>0</td><td>GALAXY</td><td>--</td><td>0.013269424</td><td>0</td><td>0</td><td>17592186044416</td><td>562949953421312</td></tr>
-<tr><td>-7639225783708002304</td><td>1237665128524415517</td><td>0.8210997</td><td>8.6923865e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>0.023777902</td><td>0</td><td>0</td><td>17592186044416</td><td>562949953421312</td></tr>
-<tr><td>-7639225233952188416</td><td>1237665098460037767</td><td>1.4448175</td><td>0.7513441</td><td>0</td><td>GALAXY</td><td>--</td><td>0.011829615</td><td>0</td><td>0</td><td>17592186044416</td><td>562949953421312</td></tr>
-<tr><td>-7639224959074281472</td><td>1237665128524153288</td><td>0.92107</td><td>0.000118537646</td><td>0</td><td>GALAXY</td><td>--</td><td>0.017925024</td><td>0</td><td>0</td><td>17592186044416</td><td>562949953421312</td></tr>
-<tr><td>-7639224409318467584</td><td>1237665097923035567</td><td>0.98253536</td><td>0.00013488902</td><td>0</td><td>GALAXY</td><td>--</td><td>0.0124723315</td><td>0</td><td>0</td><td>17592186044416</td><td>562949953421312</td></tr>
-<tr><td>-7639224134440560640</td><td>1237665128524153695</td><td>0.7265247</td><td>0.00017648208</td><td>0</td><td>GALAXY</td><td>--</td><td>0.012127399</td><td>0</td><td>0</td><td>17592186044416</td><td>562949953421312</td></tr>
-<tr><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td></tr>
-<tr><td>-7639198570795214848</td><td>1237665129060959070</td><td>0.880374</td><td>0.00012446102</td><td>0</td><td>GALAXY</td><td>--</td><td>0.011144221</td><td>0</td><td>0</td><td>17592186044416</td><td>562949953421312</td></tr>
-<tr><td>-7639198021039400960</td><td>1237664834855306140</td><td>0.8465685</td><td>0.0001428312</td><td>0</td><td>GALAXY</td><td>--</td><td>0.010542035</td><td>0</td><td>0</td><td>17592186044416</td><td>562949953421312</td></tr>
-<tr><td>-7639197196405680128</td><td>1237665097385771894</td><td>0.95612645</td><td>0.00012754179</td><td>0</td><td>GALAXY</td><td>--</td><td>0.016105115</td><td>0</td><td>0</td><td>17592186044416</td><td>562949953421312</td></tr>
-<tr><td>-7639196371771959296</td><td>1237665097385772080</td><td>0.9289423</td><td>0.00012436773</td><td>0</td><td>GALAXY</td><td>--</td><td>0.020461261</td><td>0</td><td>0</td><td>17592186044416</td><td>562949953421312</td></tr>
-<tr><td>-7639191698847541248</td><td>1237665098459644688</td><td>0.8261564</td><td>6.6143366e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>0.044942915</td><td>0</td><td>0</td><td>17592186044416</td><td>562949953421312</td></tr>
-<tr><td>-7639191423969634304</td><td>1237665128523891276</td><td>0.8741866</td><td>0.0001341164</td><td>0</td><td>GALAXY</td><td>--</td><td>0.0131188035</td><td>0</td><td>0</td><td>17592186044416</td><td>562949953421312</td></tr>
-<tr><td>-7639190874213820416</td><td>1237665098459644459</td><td>0.8458714</td><td>0.00012319988</td><td>0</td><td>GALAXY</td><td>--</td><td>0.019765258</td><td>0</td><td>0</td><td>17592186044416</td><td>562949953421312</td></tr>
-<tr><td>-7639190599335913472</td><td>1237665098459644444</td><td>0.8814687</td><td>0.0001139445</td><td>0</td><td>GALAXY</td><td>--</td><td>0.013265789</td><td>0</td><td>0</td><td>17592186044416</td><td>562949953421312</td></tr>
-<tr><td>-7639190049580099584</td><td>1237665098459710264</td><td>0.29381013</td><td>5.2243926e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>0.017308354</td><td>0</td><td>0</td><td>17592186044416</td><td>562949953421312</td></tr>
-<tr><td>-7639188950068471808</td><td>1237665098459644427</td><td>0.9214909</td><td>0.00020075552</td><td>0</td><td>GALAXY</td><td>--</td><td>0.011227965</td><td>0</td><td>0</td><td>17592186044416</td><td>562949953421312</td></tr>
-</table></div>
-</div>
-</div>
-</div>
-</div>
 </div>
 <div class="jp-Cell jp-MarkdownCell jp-Notebook-cell">
 <div class="jp-Cell-inputWrapper" tabindex="0">
@@ -10036,7 +9187,7 @@ INFO: rrtemplate-STAR-WD-v0.1.fits STAR WD PCA IGM=None z=-0.002-0.002
 <div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
 </div>
 <div class="jp-InputArea jp-Cell-inputArea">
-<div class="jp-InputPrompt jp-InputArea-prompt">In [52]:</div>
+<div class="jp-InputPrompt jp-InputArea-prompt">In [ ]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
 <div class="cm-editor cm-s-jupyter">
 <div class="highlight hl-ipython3"><pre><span></span><span class="k">assert</span> <span class="p">(</span><span class="n">np</span><span class="o">.</span><span class="n">unique</span><span class="p">(</span><span class="n">boss_ids</span><span class="p">[</span><span class="s1">'specobjid'</span><span class="p">])</span> <span class="o">==</span> <span class="n">boss_ids</span><span class="p">[</span><span class="s1">'specobjid'</span><span class="p">])</span><span class="o">.</span><span class="n">all</span><span class="p">()</span>
@@ -10056,12 +9207,12 @@ INFO: rrtemplate-STAR-WD-v0.1.fits STAR WD PCA IGM=None z=-0.002-0.002
 </div>
 </div>
 </div>
-</div><div class="jp-Cell jp-CodeCell jp-Notebook-cell">
+</div><div class="jp-Cell jp-CodeCell jp-Notebook-cell jp-mod-noOutputs">
 <div class="jp-Cell-inputWrapper" tabindex="0">
 <div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
 </div>
 <div class="jp-InputArea jp-Cell-inputArea">
-<div class="jp-InputPrompt jp-InputArea-prompt">In [53]:</div>
+<div class="jp-InputPrompt jp-InputArea-prompt">In [ ]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
 <div class="cm-editor cm-s-jupyter">
 <div class="highlight hl-ipython3"><pre><span></span><span class="n">include</span> <span class="o">=</span> <span class="n">client</span><span class="o">.</span><span class="n">get_all_fields</span><span class="p">(</span><span class="n">dataset_list</span><span class="o">=</span><span class="p">[</span><span class="s1">'BOSS-DR17'</span><span class="p">])</span>
@@ -10070,20 +9221,6 @@ INFO: rrtemplate-STAR-WD-v0.1.fits STAR WD PCA IGM=None z=-0.002-0.002
                                          <span class="n">dataset_list</span><span class="o">=</span><span class="p">[</span><span class="s1">'BOSS-DR17'</span><span class="p">])</span>
 <span class="n">boss_spectra</span><span class="o">.</span><span class="n">info</span>
 </pre></div>
-</div>
-</div>
-</div>
-</div>
-<div class="jp-Cell-outputWrapper">
-<div class="jp-Collapser jp-OutputCollapser jp-Cell-outputCollapser">
-</div>
-<div class="jp-OutputArea jp-Cell-outputArea">
-<div class="jp-OutputArea-child jp-OutputArea-executeResult">
-<div class="jp-OutputPrompt jp-OutputArea-prompt">Out[53]:</div>
-<div class="jp-RenderedText jp-OutputArea-output jp-OutputArea-executeResult" data-mime-type="text/plain" tabindex="0">
-<pre>{'status': {'success': True,
-  'info': ["Successfully found 50 records in dr_list=['BOSS-DR17']"],
-  'warnings': []}}</pre>
 </div>
 </div>
 </div>
@@ -10105,13 +9242,13 @@ INFO: rrtemplate-STAR-WD-v0.1.fits STAR WD PCA IGM=None z=-0.002-0.002
 <div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
 </div>
 <div class="jp-InputArea jp-Cell-inputArea">
-<div class="jp-InputPrompt jp-InputArea-prompt">In [54]:</div>
+<div class="jp-InputPrompt jp-InputArea-prompt">In [ ]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
 <div class="cm-editor cm-s-jupyter">
-<div class="highlight hl-ipython3"><pre><span></span><span class="n">boss_records</span> <span class="o">=</span> <span class="nb">sorted</span><span class="p">(</span><span class="n">boss_spectra</span><span class="o">.</span><span class="n">records</span><span class="p">,</span> <span class="n">key</span><span class="o">=</span><span class="k">lambda</span> <span class="n">x</span><span class="p">:</span> <span class="n">x</span><span class="o">.</span><span class="n">specid</span><span class="p">)</span>
-<span class="k">assert</span> <span class="p">(</span><span class="n">np</span><span class="o">.</span><span class="n">array</span><span class="p">([</span><span class="n">r</span><span class="o">.</span><span class="n">specid</span> <span class="k">for</span> <span class="n">r</span> <span class="ow">in</span> <span class="n">boss_records</span><span class="p">])</span> <span class="o">==</span> <span class="n">boss_ids</span><span class="p">[</span><span class="s1">'specobjid'</span><span class="p">])</span><span class="o">.</span><span class="n">all</span><span class="p">()</span>
-<span class="k">assert</span> <span class="nb">all</span><span class="p">([</span><span class="n">r</span><span class="o">.</span><span class="n">plate</span> <span class="o">==</span> <span class="mi">9599</span> <span class="k">for</span> <span class="n">r</span> <span class="ow">in</span> <span class="n">boss_records</span><span class="p">])</span>
-<span class="k">assert</span> <span class="nb">all</span><span class="p">([</span><span class="n">r</span><span class="o">.</span><span class="n">mjd</span> <span class="o">==</span> <span class="mi">58131</span> <span class="k">for</span> <span class="n">r</span> <span class="ow">in</span> <span class="n">boss_records</span><span class="p">])</span>
+<div class="highlight hl-ipython3"><pre><span></span><span class="n">boss_spectra</span> <span class="o">=</span> <span class="n">boss_spectra</span><span class="o">.</span><span class="n">reorder</span><span class="p">(</span><span class="n">boss_ids</span><span class="p">[</span><span class="s1">'specobjid'</span><span class="p">]</span><span class="o">.</span><span class="n">value</span><span class="o">.</span><span class="n">tolist</span><span class="p">())</span>
+<span class="k">assert</span> <span class="p">(</span><span class="n">np</span><span class="o">.</span><span class="n">array</span><span class="p">([</span><span class="n">r</span><span class="o">.</span><span class="n">specid</span> <span class="k">for</span> <span class="n">r</span> <span class="ow">in</span> <span class="n">boss_spectra</span><span class="o">.</span><span class="n">records</span><span class="p">])</span> <span class="o">==</span> <span class="n">boss_ids</span><span class="p">[</span><span class="s1">'specobjid'</span><span class="p">])</span><span class="o">.</span><span class="n">all</span><span class="p">()</span>
+<span class="k">assert</span> <span class="nb">all</span><span class="p">([</span><span class="n">r</span><span class="o">.</span><span class="n">plate</span> <span class="o">==</span> <span class="mi">9599</span> <span class="k">for</span> <span class="n">r</span> <span class="ow">in</span> <span class="n">boss_spectra</span><span class="o">.</span><span class="n">records</span><span class="p">])</span>
+<span class="k">assert</span> <span class="nb">all</span><span class="p">([</span><span class="n">r</span><span class="o">.</span><span class="n">mjd</span> <span class="o">==</span> <span class="mi">58131</span> <span class="k">for</span> <span class="n">r</span> <span class="ow">in</span> <span class="n">boss_spectra</span><span class="o">.</span><span class="n">records</span><span class="p">])</span>
 </pre></div>
 </div>
 </div>
@@ -10133,10 +9270,10 @@ INFO: rrtemplate-STAR-WD-v0.1.fits STAR WD PCA IGM=None z=-0.002-0.002
 <div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
 </div>
 <div class="jp-InputArea jp-Cell-inputArea">
-<div class="jp-InputPrompt jp-InputArea-prompt">In [55]:</div>
+<div class="jp-InputPrompt jp-InputArea-prompt">In [ ]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
 <div class="cm-editor cm-s-jupyter">
-<div class="highlight hl-ipython3"><pre><span></span><span class="k">assert</span> <span class="nb">all</span><span class="p">([(</span><span class="n">r</span><span class="o">.</span><span class="n">wavelength</span> <span class="o">==</span> <span class="n">boss_records</span><span class="p">[</span><span class="mi">0</span><span class="p">]</span><span class="o">.</span><span class="n">wavelength</span><span class="p">)</span><span class="o">.</span><span class="n">all</span><span class="p">()</span> <span class="k">for</span> <span class="n">r</span> <span class="ow">in</span> <span class="n">boss_records</span><span class="p">])</span>
+<div class="highlight hl-ipython3"><pre><span></span><span class="k">assert</span> <span class="nb">all</span><span class="p">([(</span><span class="n">r</span><span class="o">.</span><span class="n">wavelength</span> <span class="o">==</span> <span class="n">boss_spectra</span><span class="o">.</span><span class="n">records</span><span class="p">[</span><span class="mi">0</span><span class="p">]</span><span class="o">.</span><span class="n">wavelength</span><span class="p">)</span><span class="o">.</span><span class="n">all</span><span class="p">()</span> <span class="k">for</span> <span class="n">r</span> <span class="ow">in</span> <span class="n">boss_spectra</span><span class="o">.</span><span class="n">records</span><span class="p">])</span>
 </pre></div>
 </div>
 </div>
@@ -10158,15 +9295,15 @@ INFO: rrtemplate-STAR-WD-v0.1.fits STAR WD PCA IGM=None z=-0.002-0.002
 <div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
 </div>
 <div class="jp-InputArea jp-Cell-inputArea">
-<div class="jp-InputPrompt jp-InputArea-prompt">In [56]:</div>
+<div class="jp-InputPrompt jp-InputArea-prompt">In [ ]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
 <div class="cm-editor cm-s-jupyter">
-<div class="highlight hl-ipython3"><pre><span></span><span class="n">boss_fully_masked</span> <span class="o">=</span> <span class="n">np</span><span class="o">.</span><span class="n">zeros</span><span class="p">((</span><span class="nb">len</span><span class="p">(</span><span class="n">boss_records</span><span class="p">),</span> <span class="p">),</span> <span class="n">dtype</span><span class="o">=</span><span class="nb">bool</span><span class="p">)</span>
+<div class="highlight hl-ipython3"><pre><span></span><span class="n">boss_fully_masked</span> <span class="o">=</span> <span class="n">np</span><span class="o">.</span><span class="n">zeros</span><span class="p">((</span><span class="nb">len</span><span class="p">(</span><span class="n">boss_spectra</span><span class="o">.</span><span class="n">records</span><span class="p">),</span> <span class="p">),</span> <span class="n">dtype</span><span class="o">=</span><span class="nb">bool</span><span class="p">)</span>
 
-<span class="k">for</span> <span class="n">k</span> <span class="ow">in</span> <span class="nb">range</span><span class="p">(</span><span class="nb">len</span><span class="p">(</span><span class="n">boss_records</span><span class="p">)):</span>
-    <span class="k">assert</span> <span class="n">np</span><span class="o">.</span><span class="n">isfinite</span><span class="p">(</span><span class="n">boss_records</span><span class="p">[</span><span class="n">k</span><span class="p">]</span><span class="o">.</span><span class="n">flux</span><span class="p">)</span><span class="o">.</span><span class="n">all</span><span class="p">()</span>
-    <span class="k">assert</span> <span class="n">np</span><span class="o">.</span><span class="n">isfinite</span><span class="p">(</span><span class="n">boss_records</span><span class="p">[</span><span class="n">k</span><span class="p">]</span><span class="o">.</span><span class="n">ivar</span><span class="p">)</span><span class="o">.</span><span class="n">all</span><span class="p">()</span>
-    <span class="k">if</span> <span class="p">(</span><span class="n">boss_records</span><span class="p">[</span><span class="n">k</span><span class="p">]</span><span class="o">.</span><span class="n">mask</span> <span class="o">&gt;</span> <span class="mi">0</span><span class="p">)</span><span class="o">.</span><span class="n">all</span><span class="p">():</span>
+<span class="k">for</span> <span class="n">k</span> <span class="ow">in</span> <span class="nb">range</span><span class="p">(</span><span class="nb">len</span><span class="p">(</span><span class="n">boss_spectra</span><span class="o">.</span><span class="n">records</span><span class="p">)):</span>
+    <span class="k">assert</span> <span class="n">np</span><span class="o">.</span><span class="n">isfinite</span><span class="p">(</span><span class="n">boss_spectra</span><span class="o">.</span><span class="n">records</span><span class="p">[</span><span class="n">k</span><span class="p">]</span><span class="o">.</span><span class="n">flux</span><span class="p">)</span><span class="o">.</span><span class="n">all</span><span class="p">()</span>
+    <span class="k">assert</span> <span class="n">np</span><span class="o">.</span><span class="n">isfinite</span><span class="p">(</span><span class="n">boss_spectra</span><span class="o">.</span><span class="n">records</span><span class="p">[</span><span class="n">k</span><span class="p">]</span><span class="o">.</span><span class="n">ivar</span><span class="p">)</span><span class="o">.</span><span class="n">all</span><span class="p">()</span>
+    <span class="k">if</span> <span class="p">(</span><span class="n">boss_spectra</span><span class="o">.</span><span class="n">records</span><span class="p">[</span><span class="n">k</span><span class="p">]</span><span class="o">.</span><span class="n">mask</span> <span class="o">&gt;</span> <span class="mi">0</span><span class="p">)</span><span class="o">.</span><span class="n">all</span><span class="p">():</span>
         <span class="nb">print</span><span class="p">(</span><span class="sa">f</span><span class="s2">"WARNING: Spectrum record </span><span class="si">{</span><span class="n">k</span><span class="si">:</span><span class="s2">d</span><span class="si">}</span><span class="s2"> is fully masked!"</span><span class="p">)</span>
         <span class="n">boss_fully_masked</span><span class="p">[</span><span class="n">k</span><span class="p">]</span> <span class="o">=</span> <span class="kc">True</span>
 </pre></div>
@@ -10185,247 +9322,16 @@ INFO: rrtemplate-STAR-WD-v0.1.fits STAR WD PCA IGM=None z=-0.002-0.002
 </div>
 </div>
 </div>
-</div><div class="jp-Cell jp-CodeCell jp-Notebook-cell">
+</div><div class="jp-Cell jp-CodeCell jp-Notebook-cell jp-mod-noOutputs">
 <div class="jp-Cell-inputWrapper" tabindex="0">
 <div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
 </div>
 <div class="jp-InputArea jp-Cell-inputArea">
-<div class="jp-InputPrompt jp-InputArea-prompt">In [57]:</div>
+<div class="jp-InputPrompt jp-InputArea-prompt">In [ ]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
 <div class="cm-editor cm-s-jupyter">
-<div class="highlight hl-ipython3"><pre><span></span><span class="n">boss_records</span><span class="p">[</span><span class="mi">0</span><span class="p">]</span>
+<div class="highlight hl-ipython3"><pre><span></span><span class="n">boss_spectra</span><span class="o">.</span><span class="n">records</span><span class="p">[</span><span class="mi">0</span><span class="p">]</span>
 </pre></div>
-</div>
-</div>
-</div>
-</div>
-<div class="jp-Cell-outputWrapper">
-<div class="jp-Collapser jp-OutputCollapser jp-Cell-outputCollapser">
-</div>
-<div class="jp-OutputArea jp-Cell-outputArea">
-<div class="jp-OutputArea-child jp-OutputArea-executeResult">
-<div class="jp-OutputPrompt jp-OutputArea-prompt">Out[57]:</div>
-<div class="jp-RenderedText jp-OutputArea-output jp-OutputArea-executeResult" data-mime-type="text/plain" tabindex="0">
-<pre>{'redshift_err': 7.462430221494287e-05,
- 'specprimary': True,
- 'specid': -7639230456632420352,
- 'wavemin': 3601.637451171875,
- 'targetid': 1237665127987282622,
- 'sparcl_id': '098d97da-252f-11f0-bc98-525400f334e1',
- 'instrument': 'BOSS',
- 'spectype': 'GALAXY',
- 'ra': 134.30633999999998,
- 'data_release': 'BOSS-DR17',
- 'datasetgroup': 'SDSS_BOSS',
- 'wavemax': 10332.37109375,
- 'telescope': 'sloan25m',
- 'dec': 23.560574,
- 'redshift_warning': 0,
- 'exptime': 3600.35,
- 'site': 'apo',
- 'redshift': 0.8864001035690308,
- 'tcolumn': [0, 1, 2, 3, -1, -1, -1, -1, -1, -1],
- 'spec2_g': 6.294640064239502,
- 'run2d': 'v5_13_2',
- 'elodie_feh': 0.0,
- 'comments_person': '',
- 'fracnsigma': [0.3162296712398529,
-  0.055831827223300934,
-  0.009041591547429562,
-  0.0011301989434286952,
-  0.0,
-  0.0,
-  0.0,
-  0.0,
-  0.0,
-  0.0],
- 'deredsn2': 5.500629901885986,
- 'elodie_z': 0.0,
- 'designid': 10182,
- 'platequality': 'good',
- 'spectrosynflux_ivar': [6.276416778564453,
-  9.02142333984375,
-  6.571553707122803,
-  3.8821513652801514,
-  1.8567394018173218],
- 'survey': 'eboss',
- 'tile': 17241,
- 'ancillary_target1': 0,
- 'chunk': 'eboss23',
- 'cx': -0.6402665775983531,
- 'spec2_r': 15.703800201416016,
- 'elodie_logg': 0.0,
- 'firstrelease': 'dr17',
- 'lambda_eff': 7500.0,
- 'sn_median': [0.2263146936893463,
-  0.7281882166862488,
-  0.8945983052253723,
-  1.4738258123397827,
-  1.3543939590454102],
- 'ancillary_target2': 0,
- 'eboss_target0': 0,
- 'thing_id': 316262311,
- 'mjd': 58131,
- 'spectrographid': 1,
- 'platesn2': 5.500629901885986,
- 'subclass_noqso': '',
- 'fiberid': 1,
- 'subclass': '',
- 'vdispchi2': 1443.5518798828125,
- 'elodie_rchi2': 0.0,
- 'anyandmask': 96731136,
- 'targetobjid': '',
- 'spec1_g': 5.500629901885986,
- 'spectroskyflux': [9.836366653442383,
-  13.262933731079102,
-  29.112598419189453,
-  63.5466194152832,
-  171.4568634033203],
- 'rchi2diff_noqso': 0.08232581615447998,
- 'vdispz_err': 0.0,
- 'elodie_z_err': 0.0,
- 'spectrosynflux': [0.7843775153160095,
-  1.2373796701431274,
-  1.8416348695755005,
-  3.9133851528167725,
-  5.673061847686768],
- 'cy': 0.6559603107653976,
- 'calibflux_ivar': [5.2025065422058105,
-  34.74420928955078,
-  10.3529052734375,
-  3.913039207458496,
-  0.20810265839099884],
- 'specsegue1': 0,
- 'eboss_target1': 17592186044416,
- 'tfile': 'spEigenGal-56436.fits',
- 'segue1_target1': 0,
- 'rchi2': 1.0829224586486816,
- 'spec1_r': 19.635000228881836,
- 'specsegue': 0,
- 'specsegue2': 0,
- 'marvels_target1': 0,
- 'chi68p': 0.9948847889900208,
- 'xfocal': 266.6521301269531,
- 'eboss_target2': 562949953421312,
- 'sectarget': 0,
- 'elodie_teff': 0.0,
- 'sourcetype': 'ELG',
- 'bluefiber': 1,
- 'elodie_object': '',
- 'segue2_target2': 0,
- 'anyormask': 265224192,
- 'run1d': 0,
- 'elodie_filename': '',
- 'specsdss': 0,
- 'sn_median_all': 0.9232138395309448,
- 'special_target1': 0,
- 'npoly': 3,
- 'plate': 9599,
- 'fracnsighi': [0.16229656338691711,
-  0.03096744976937771,
-  0.006103074178099632,
-  0.0009041591547429562,
-  0.0,
-  0.0,
-  0.0,
-  0.0,
-  0.0,
-  0.0],
- 'segue2_target1': 0,
- 'vdisp_err': 178.60658264160156,
- 'eboss_target_id': 2990008,
- 'class_noqso': 'GALAXY',
- 'primtarget': 0,
- 'zwarning_noqso': 0,
- 'calibflux': [0.8216304183006287,
-  0.8483012318611145,
-  1.568734049797058,
-  3.4619531631469727,
-  5.181345462799072],
- 'spectroflux_ivar': [2.5664212703704834,
-  9.050325393676758,
-  5.572259902954102,
-  2.5301566123962402,
-  0.08179719746112823],
- 'rchi2diff': 0.06786668300628662,
- 'programname': 'ELG_NGC',
- 'zoffset': 0.0,
- 'speclegacy': 0,
- 'z_person': 0.0,
- 'boss_specobj_id': 3188821,
- 'targettype': 'SCIENCE',
- 'theta': [-0.001900560106150806,
-  -0.2047363519668579,
-  0.6663264632225037,
-  0.09140719473361969,
-  -2.2184066772460938,
-  4.503273963928223,
-  -2.028078317642212,
-  0.0,
-  0.0,
-  0.0],
- 'class_person': 0,
- 'elodie_dof': 0,
- 'nturnoff': 0,
- 'platerun': '2016.11.b.eboss',
- 'z_conf_person': 0,
- 'objid': [0, 0, 0, 0, 0],
- 'boss_target2': 0,
- 'elodie_sptype': '',
- 'z_err_noqso': 7.462430221494287e-05,
- 'vdispz': 0.0,
- 'segue1_target2': 0,
- 'thing_id_targeting': 0,
- 'fracnsiglo': [0.1539330929517746,
-  0.024864375591278076,
-  0.0029385171364992857,
-  0.00022603978868573904,
-  0.0,
-  0.0,
-  0.0,
-  0.0,
-  0.0,
-  0.0],
- 'elodie_z_modelerr': 0.0,
- 'marvels_target2': 0,
- 'special_target2': 0,
- 'nspecobs': 1,
- 'spec1_i': 15.253999710083008,
- 'elodie_bv': 0.0,
- 'wcoverage': 0.4424000084400177,
- 'specboss': 1,
- 'legacy_target2': 0,
- 'fluxobjid': '1237665127987282622',
- 'legacy_target1': 0,
- 'z_noqso': 0.8864001035690308,
- 'vdisp': 427.2975158691406,
- 'vdispdof': 1018,
- 'snturnoff': 0.0,
- 'spectroflux': [3.7370755672454834,
-  1.2999285459518433,
-  2.04257869720459,
-  3.88021183013916,
-  6.065510272979736],
- 'spec2_i': 16.18160057067871,
- 'vdispnpix': 1242.0,
- 'cz': 0.3997183762488972,
- 'boss_target1': 0,
- 'dof': 4417,
- 'plateid': '10807513342203146240',
- 'yfocal': -139.72686767578125,
- 'mask': array([88080384, 88080384, 88080384, ..., 83886080, 83886080, 83886080]),
- 'wave_sigma': array([0., 0., 0., ..., 0., 0., 0.]),
- 'model': array([0.61179036, 0.59592736, 0.58086985, ..., 0.90960234, 0.90695798,
-        0.91079909]),
- 'wavelength': array([ 3585.91507517,  3586.7408577 ,  3587.56683039, ...,
-        10351.42166679, 10353.80544415, 10356.18977045]),
- 'ivar': array([0., 0., 0., ..., 0., 0., 0.]),
- 'flux': array([-1.16054475, -1.16002548, -1.15950704, ..., -0.8605082 ,
-        -0.860511  , -0.86051393]),
- 'sky': array([0., 0., 0., ..., 0., 0., 0.]),
- 'dateobs': '["2018-01-13 05:57:56+00","2018-01-13 05:57:56+00"]',
- 'dateobs_center': '2018-01-13 05:57:56+00',
- '_dr': 'BOSS-DR17'}</pre>
 </div>
 </div>
 </div>
@@ -10447,7 +9353,7 @@ INFO: rrtemplate-STAR-WD-v0.1.fits STAR WD PCA IGM=None z=-0.002-0.002
 <li>A redshift catalog. This should be an Astropy <code>Table</code> with the expected columns.</li>
 <li>A model spectrum.  The model is actually provided by SPARCL, but we need to input it separately.</li>
 </ol>
-<h4 id="Spectrum-object">Spectrum object<a class="anchor-link" href="#Spectrum-object">¶</a></h4><p>First we assemble the components of the spectrum object</p>
+<h4 id="Spectrum-object">Spectrum object<a class="anchor-link" href="#Spectrum-object">¶</a></h4><p>First we assemble the components of the spectrum object. Most of the work is done simply by converting the retrieved results to a <code>specutils</code> object.</p>
 </div>
 </div>
 </div>
@@ -10456,26 +9362,10 @@ INFO: rrtemplate-STAR-WD-v0.1.fits STAR WD PCA IGM=None z=-0.002-0.002
 <div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
 </div>
 <div class="jp-InputArea jp-Cell-inputArea">
-<div class="jp-InputPrompt jp-InputArea-prompt">In [58]:</div>
+<div class="jp-InputPrompt jp-InputArea-prompt">In [ ]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
 <div class="cm-editor cm-s-jupyter">
-<div class="highlight hl-ipython3"><pre><span></span><span class="n">flux</span> <span class="o">=</span> <span class="n">np</span><span class="o">.</span><span class="n">zeros</span><span class="p">((</span><span class="nb">len</span><span class="p">(</span><span class="n">boss_records</span><span class="p">),</span> <span class="n">boss_records</span><span class="p">[</span><span class="mi">0</span><span class="p">]</span><span class="o">.</span><span class="n">flux</span><span class="o">.</span><span class="n">shape</span><span class="p">[</span><span class="mi">0</span><span class="p">]),</span>
-                <span class="n">dtype</span><span class="o">=</span><span class="n">boss_records</span><span class="p">[</span><span class="mi">0</span><span class="p">]</span><span class="o">.</span><span class="n">flux</span><span class="o">.</span><span class="n">dtype</span><span class="p">)</span>
-<span class="n">uncertainty</span> <span class="o">=</span> <span class="n">np</span><span class="o">.</span><span class="n">zeros</span><span class="p">((</span><span class="nb">len</span><span class="p">(</span><span class="n">boss_records</span><span class="p">),</span> <span class="n">boss_records</span><span class="p">[</span><span class="mi">0</span><span class="p">]</span><span class="o">.</span><span class="n">ivar</span><span class="o">.</span><span class="n">shape</span><span class="p">[</span><span class="mi">0</span><span class="p">]),</span>
-                       <span class="n">dtype</span><span class="o">=</span><span class="n">boss_records</span><span class="p">[</span><span class="mi">0</span><span class="p">]</span><span class="o">.</span><span class="n">ivar</span><span class="o">.</span><span class="n">dtype</span><span class="p">)</span>
-<span class="n">mask</span> <span class="o">=</span> <span class="n">np</span><span class="o">.</span><span class="n">zeros</span><span class="p">((</span><span class="nb">len</span><span class="p">(</span><span class="n">boss_records</span><span class="p">),</span> <span class="n">boss_records</span><span class="p">[</span><span class="mi">0</span><span class="p">]</span><span class="o">.</span><span class="n">mask</span><span class="o">.</span><span class="n">shape</span><span class="p">[</span><span class="mi">0</span><span class="p">]),</span>
-                <span class="n">dtype</span><span class="o">=</span><span class="n">boss_records</span><span class="p">[</span><span class="mi">0</span><span class="p">]</span><span class="o">.</span><span class="n">mask</span><span class="o">.</span><span class="n">dtype</span><span class="p">)</span>
-
-<span class="n">meta</span> <span class="o">=</span> <span class="p">{</span><span class="s1">'sparcl_id'</span><span class="p">:</span> <span class="nb">list</span><span class="p">(),</span> <span class="s1">'data_release'</span><span class="p">:</span> <span class="nb">list</span><span class="p">()}</span>
-<span class="n">sparcl_id</span> <span class="o">=</span> <span class="nb">list</span><span class="p">()</span>
-<span class="n">data_release</span> <span class="o">=</span> <span class="nb">list</span><span class="p">()</span>
-
-<span class="k">for</span> <span class="n">k</span> <span class="ow">in</span> <span class="nb">range</span><span class="p">(</span><span class="nb">len</span><span class="p">(</span><span class="n">boss_records</span><span class="p">)):</span>
-    <span class="n">flux</span><span class="p">[</span><span class="n">k</span><span class="p">,</span> <span class="p">:]</span> <span class="o">=</span> <span class="n">boss_records</span><span class="p">[</span><span class="n">k</span><span class="p">]</span><span class="o">.</span><span class="n">flux</span>
-    <span class="n">uncertainty</span><span class="p">[</span><span class="n">k</span><span class="p">,</span> <span class="p">:]</span> <span class="o">=</span> <span class="n">boss_records</span><span class="p">[</span><span class="n">k</span><span class="p">]</span><span class="o">.</span><span class="n">ivar</span>
-    <span class="n">mask</span><span class="p">[</span><span class="n">k</span><span class="p">,</span> <span class="p">:]</span> <span class="o">=</span> <span class="n">boss_records</span><span class="p">[</span><span class="n">k</span><span class="p">]</span><span class="o">.</span><span class="n">mask</span>
-    <span class="n">meta</span><span class="p">[</span><span class="s1">'sparcl_id'</span><span class="p">]</span><span class="o">.</span><span class="n">append</span><span class="p">(</span><span class="n">boss_records</span><span class="p">[</span><span class="n">k</span><span class="p">]</span><span class="o">.</span><span class="n">sparcl_id</span><span class="p">)</span>
-    <span class="n">meta</span><span class="p">[</span><span class="s1">'data_release'</span><span class="p">]</span><span class="o">.</span><span class="n">append</span><span class="p">(</span><span class="n">boss_records</span><span class="p">[</span><span class="n">k</span><span class="p">]</span><span class="o">.</span><span class="n">data_release</span><span class="p">)</span>
+<div class="highlight hl-ipython3"><pre><span></span><span class="n">boss_specutils</span> <span class="o">=</span> <span class="n">boss_spectra</span><span class="o">.</span><span class="n">to_specutils</span><span class="p">()</span>
 </pre></div>
 </div>
 </div>
@@ -10488,7 +9378,7 @@ INFO: rrtemplate-STAR-WD-v0.1.fits STAR WD PCA IGM=None z=-0.002-0.002
 </div>
 <div class="jp-InputArea jp-Cell-inputArea"><div class="jp-InputPrompt jp-InputArea-prompt">
 </div><div class="jp-RenderedHTMLCommon jp-RenderedMarkdown jp-MarkdownOutput" data-mime-type="text/markdown">
-<p>And the "plugmap" table. We'll start with photometric quantities.</p>
+<p>We need a "plugmap" table. We'll start with photometric quantities.</p>
 </div>
 </div>
 </div>
@@ -10497,7 +9387,7 @@ INFO: rrtemplate-STAR-WD-v0.1.fits STAR WD PCA IGM=None z=-0.002-0.002
 <div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
 </div>
 <div class="jp-InputArea jp-Cell-inputArea">
-<div class="jp-InputPrompt jp-InputArea-prompt">In [59]:</div>
+<div class="jp-InputPrompt jp-InputArea-prompt">In [ ]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
 <div class="cm-editor cm-s-jupyter">
 <div class="highlight hl-ipython3"><pre><span></span><span class="n">columns</span> <span class="o">=</span> <span class="p">(</span><span class="s1">'z.specobjid'</span><span class="p">,</span> <span class="s1">'p.objid'</span><span class="p">,</span> <span class="s1">'p.ra'</span><span class="p">,</span> <span class="s1">'p.dec'</span><span class="p">,</span> <span class="s1">'p.u'</span><span class="p">,</span> <span class="s1">'p.g'</span><span class="p">,</span> <span class="s1">'p.r'</span><span class="p">,</span> <span class="s1">'p.i'</span><span class="p">,</span> <span class="s1">'p.z'</span><span class="p">)</span>
@@ -10521,7 +9411,7 @@ INFO: rrtemplate-STAR-WD-v0.1.fits STAR WD PCA IGM=None z=-0.002-0.002
 <div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
 </div>
 <div class="jp-InputArea jp-Cell-inputArea">
-<div class="jp-InputPrompt jp-InputArea-prompt">In [60]:</div>
+<div class="jp-InputPrompt jp-InputArea-prompt">In [ ]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
 <div class="cm-editor cm-s-jupyter">
 <div class="highlight hl-ipython3"><pre><span></span><span class="k">for</span> <span class="n">col</span> <span class="ow">in</span> <span class="n">plugmap</span><span class="o">.</span><span class="n">colnames</span><span class="p">:</span>
@@ -10534,7 +9424,7 @@ INFO: rrtemplate-STAR-WD-v0.1.fits STAR WD PCA IGM=None z=-0.002-0.002
 <span class="n">plugmap</span><span class="o">.</span><span class="n">add_column</span><span class="p">(</span><span class="n">boss_ids</span><span class="p">[</span><span class="s1">'eboss_target0'</span><span class="p">],</span> <span class="n">name</span><span class="o">=</span><span class="s1">'EBOSS_TARGET0'</span><span class="p">)</span>
 <span class="n">plugmap</span><span class="o">.</span><span class="n">add_column</span><span class="p">(</span><span class="n">boss_ids</span><span class="p">[</span><span class="s1">'eboss_target1'</span><span class="p">],</span> <span class="n">name</span><span class="o">=</span><span class="s1">'EBOSS_TARGET1'</span><span class="p">)</span>
 <span class="n">plugmap</span><span class="o">.</span><span class="n">add_column</span><span class="p">(</span><span class="n">boss_ids</span><span class="p">[</span><span class="s1">'eboss_target2'</span><span class="p">],</span> <span class="n">name</span><span class="o">=</span><span class="s1">'EBOSS_TARGET2'</span><span class="p">)</span>
-<span class="n">meta</span><span class="p">[</span><span class="s1">'plugmap'</span><span class="p">]</span> <span class="o">=</span> <span class="n">plugmap</span><span class="p">[</span><span class="o">~</span><span class="n">boss_fully_masked</span><span class="p">]</span>
+<span class="n">boss_specutils</span><span class="o">.</span><span class="n">meta</span><span class="p">[</span><span class="s1">'plugmap'</span><span class="p">]</span> <span class="o">=</span> <span class="n">plugmap</span><span class="p">[</span><span class="o">~</span><span class="n">boss_fully_masked</span><span class="p">]</span>
 </pre></div>
 </div>
 </div>
@@ -10556,7 +9446,7 @@ INFO: rrtemplate-STAR-WD-v0.1.fits STAR WD PCA IGM=None z=-0.002-0.002
 <div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
 </div>
 <div class="jp-InputArea jp-Cell-inputArea">
-<div class="jp-InputPrompt jp-InputArea-prompt">In [61]:</div>
+<div class="jp-InputPrompt jp-InputArea-prompt">In [ ]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
 <div class="cm-editor cm-s-jupyter">
 <div class="highlight hl-ipython3"><pre><span></span><span class="k">assert</span> <span class="p">(</span><span class="n">plugmap</span><span class="p">[</span><span class="s1">'OBJID'</span><span class="p">]</span> <span class="o">==</span> <span class="n">boss_ids</span><span class="p">[</span><span class="s1">'bestobjid'</span><span class="p">])</span><span class="o">.</span><span class="n">all</span><span class="p">()</span>
@@ -10581,14 +9471,14 @@ INFO: rrtemplate-STAR-WD-v0.1.fits STAR WD PCA IGM=None z=-0.002-0.002
 <div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
 </div>
 <div class="jp-InputArea jp-Cell-inputArea">
-<div class="jp-InputPrompt jp-InputArea-prompt">In [62]:</div>
+<div class="jp-InputPrompt jp-InputArea-prompt">In [ ]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
 <div class="cm-editor cm-s-jupyter">
-<div class="highlight hl-ipython3"><pre><span></span><span class="n">boss_prospect</span> <span class="o">=</span> <span class="n">Spectrum1D</span><span class="p">(</span><span class="n">flux</span><span class="o">=</span><span class="n">flux</span><span class="p">[</span><span class="o">~</span><span class="n">boss_fully_masked</span><span class="p">,</span> <span class="p">:]</span> <span class="o">*</span> <span class="n">u</span><span class="o">.</span><span class="n">Unit</span><span class="p">(</span><span class="s1">'1e-17 erg / (Angstrom cm2 s)'</span><span class="p">),</span>
-                           <span class="n">spectral_axis</span><span class="o">=</span><span class="n">boss_records</span><span class="p">[</span><span class="mi">0</span><span class="p">]</span><span class="o">.</span><span class="n">wavelength</span> <span class="o">*</span> <span class="n">u</span><span class="o">.</span><span class="n">Unit</span><span class="p">(</span><span class="s1">'Angstrom'</span><span class="p">),</span>
-                           <span class="n">uncertainty</span><span class="o">=</span><span class="n">InverseVariance</span><span class="p">(</span><span class="n">uncertainty</span><span class="p">[</span><span class="o">~</span><span class="n">boss_fully_masked</span><span class="p">,</span> <span class="p">:]),</span>
-                           <span class="n">mask</span><span class="o">=</span><span class="n">mask</span><span class="p">[</span><span class="o">~</span><span class="n">boss_fully_masked</span><span class="p">,</span> <span class="p">:]</span> <span class="o">!=</span> <span class="mi">0</span><span class="p">,</span>
-                           <span class="n">meta</span><span class="o">=</span><span class="n">meta</span><span class="p">)</span>
+<div class="highlight hl-ipython3"><pre><span></span><span class="n">boss_prospect</span> <span class="o">=</span> <span class="n">Spectrum1D</span><span class="p">(</span><span class="n">flux</span><span class="o">=</span><span class="n">boss_specutils</span><span class="o">.</span><span class="n">flux</span><span class="p">[</span><span class="o">~</span><span class="n">boss_fully_masked</span><span class="p">,</span> <span class="p">:],</span>
+                           <span class="n">spectral_axis</span><span class="o">=</span><span class="n">boss_specutils</span><span class="o">.</span><span class="n">spectral_axis</span><span class="p">,</span>
+                           <span class="n">uncertainty</span><span class="o">=</span><span class="n">boss_specutils</span><span class="o">.</span><span class="n">uncertainty</span><span class="p">[</span><span class="o">~</span><span class="n">boss_fully_masked</span><span class="p">,</span> <span class="p">:],</span>
+                           <span class="n">mask</span><span class="o">=</span><span class="n">boss_specutils</span><span class="o">.</span><span class="n">mask</span><span class="p">[</span><span class="o">~</span><span class="n">boss_fully_masked</span><span class="p">,</span> <span class="p">:]</span> <span class="o">!=</span> <span class="mi">0</span><span class="p">,</span>
+                           <span class="n">meta</span><span class="o">=</span><span class="n">boss_specutils</span><span class="o">.</span><span class="n">meta</span><span class="p">)</span>
 </pre></div>
 </div>
 </div>
@@ -10605,12 +9495,12 @@ INFO: rrtemplate-STAR-WD-v0.1.fits STAR WD PCA IGM=None z=-0.002-0.002
 </div>
 </div>
 </div>
-</div><div class="jp-Cell jp-CodeCell jp-Notebook-cell">
+</div><div class="jp-Cell jp-CodeCell jp-Notebook-cell jp-mod-noOutputs">
 <div class="jp-Cell-inputWrapper" tabindex="0">
 <div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
 </div>
 <div class="jp-InputArea jp-Cell-inputArea">
-<div class="jp-InputPrompt jp-InputArea-prompt">In [63]:</div>
+<div class="jp-InputPrompt jp-InputArea-prompt">In [ ]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
 <div class="cm-editor cm-s-jupyter">
 <div class="highlight hl-ipython3"><pre><span></span><span class="n">boss_zcatalog</span> <span class="o">=</span> <span class="n">boss_ids</span><span class="o">.</span><span class="n">copy</span><span class="p">()</span>
@@ -10621,43 +9511,6 @@ INFO: rrtemplate-STAR-WD-v0.1.fits STAR WD PCA IGM=None z=-0.002-0.002
         <span class="n">boss_zcatalog</span><span class="o">.</span><span class="n">rename_column</span><span class="p">(</span><span class="n">col</span><span class="p">,</span> <span class="n">col</span><span class="o">.</span><span class="n">upper</span><span class="p">())</span>
 <span class="n">boss_zcatalog</span>
 </pre></div>
-</div>
-</div>
-</div>
-</div>
-<div class="jp-Cell-outputWrapper">
-<div class="jp-Collapser jp-OutputCollapser jp-Cell-outputCollapser">
-</div>
-<div class="jp-OutputArea jp-Cell-outputArea">
-<div class="jp-OutputArea-child jp-OutputArea-executeResult">
-<div class="jp-OutputPrompt jp-OutputArea-prompt">Out[63]:</div>
-<div class="jp-RenderedHTMLCommon jp-RenderedHTML jp-OutputArea-output jp-OutputArea-executeResult" data-mime-type="text/html" tabindex="0">
-<div><i>Table length=50</i>
-<table class="table-striped table-bordered table-condensed" id="table140046222957184">
-<thead><tr><th>SPECOBJID</th><th>BESTOBJID</th><th>Z</th><th>Z_ERR</th><th>ZWARNING</th><th>CLASS</th><th>SUBCLASS</th><th>RCHI2DIFF</th><th>BOSS_TARGET1</th><th>EBOSS_TARGET0</th><th>EBOSS_TARGET1</th><th>EBOSS_TARGET2</th></tr></thead>
-<thead><tr><th>int64</th><th>int64</th><th>float64</th><th>float64</th><th>int64</th><th>str6</th><th>int64</th><th>float64</th><th>int64</th><th>int64</th><th>int64</th><th>int64</th></tr></thead>
-<tr><td>-7639230456632420352</td><td>1237665127987282622</td><td>0.8864001</td><td>7.46243e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>0.06786668</td><td>0</td><td>0</td><td>17592186044416</td><td>562949953421312</td></tr>
-<tr><td>-7639227982731257856</td><td>1237665098459972441</td><td>0.9110273</td><td>0.00010862139</td><td>0</td><td>GALAXY</td><td>--</td><td>0.017336488</td><td>0</td><td>0</td><td>17592186044416</td><td>562949953421312</td></tr>
-<tr><td>-7639227707853350912</td><td>1237665128524284395</td><td>0.38422197</td><td>3.6719743e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>0.04284048</td><td>0</td><td>0</td><td>17592186044416</td><td>562949953421312</td></tr>
-<tr><td>-7639227432975443968</td><td>1237665098459972179</td><td>0.800372</td><td>7.3419695e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>0.026912212</td><td>0</td><td>0</td><td>17592186044416</td><td>562949953421312</td></tr>
-<tr><td>-7639226333463816192</td><td>1237665128524350020</td><td>0.7552478</td><td>0.00021523784</td><td>0</td><td>GALAXY</td><td>--</td><td>0.013269424</td><td>0</td><td>0</td><td>17592186044416</td><td>562949953421312</td></tr>
-<tr><td>-7639225783708002304</td><td>1237665128524415517</td><td>0.8210997</td><td>8.6923865e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>0.023777902</td><td>0</td><td>0</td><td>17592186044416</td><td>562949953421312</td></tr>
-<tr><td>-7639225233952188416</td><td>1237665098460037767</td><td>1.4448175</td><td>0.7513441</td><td>0</td><td>GALAXY</td><td>--</td><td>0.011829615</td><td>0</td><td>0</td><td>17592186044416</td><td>562949953421312</td></tr>
-<tr><td>-7639224959074281472</td><td>1237665128524153288</td><td>0.92107</td><td>0.000118537646</td><td>0</td><td>GALAXY</td><td>--</td><td>0.017925024</td><td>0</td><td>0</td><td>17592186044416</td><td>562949953421312</td></tr>
-<tr><td>-7639224409318467584</td><td>1237665097923035567</td><td>0.98253536</td><td>0.00013488902</td><td>0</td><td>GALAXY</td><td>--</td><td>0.0124723315</td><td>0</td><td>0</td><td>17592186044416</td><td>562949953421312</td></tr>
-<tr><td>-7639224134440560640</td><td>1237665128524153695</td><td>0.7265247</td><td>0.00017648208</td><td>0</td><td>GALAXY</td><td>--</td><td>0.012127399</td><td>0</td><td>0</td><td>17592186044416</td><td>562949953421312</td></tr>
-<tr><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td></tr>
-<tr><td>-7639198570795214848</td><td>1237665129060959070</td><td>0.880374</td><td>0.00012446102</td><td>0</td><td>GALAXY</td><td>--</td><td>0.011144221</td><td>0</td><td>0</td><td>17592186044416</td><td>562949953421312</td></tr>
-<tr><td>-7639198021039400960</td><td>1237664834855306140</td><td>0.8465685</td><td>0.0001428312</td><td>0</td><td>GALAXY</td><td>--</td><td>0.010542035</td><td>0</td><td>0</td><td>17592186044416</td><td>562949953421312</td></tr>
-<tr><td>-7639197196405680128</td><td>1237665097385771894</td><td>0.95612645</td><td>0.00012754179</td><td>0</td><td>GALAXY</td><td>--</td><td>0.016105115</td><td>0</td><td>0</td><td>17592186044416</td><td>562949953421312</td></tr>
-<tr><td>-7639196371771959296</td><td>1237665097385772080</td><td>0.9289423</td><td>0.00012436773</td><td>0</td><td>GALAXY</td><td>--</td><td>0.020461261</td><td>0</td><td>0</td><td>17592186044416</td><td>562949953421312</td></tr>
-<tr><td>-7639191698847541248</td><td>1237665098459644688</td><td>0.8261564</td><td>6.6143366e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>0.044942915</td><td>0</td><td>0</td><td>17592186044416</td><td>562949953421312</td></tr>
-<tr><td>-7639191423969634304</td><td>1237665128523891276</td><td>0.8741866</td><td>0.0001341164</td><td>0</td><td>GALAXY</td><td>--</td><td>0.0131188035</td><td>0</td><td>0</td><td>17592186044416</td><td>562949953421312</td></tr>
-<tr><td>-7639190874213820416</td><td>1237665098459644459</td><td>0.8458714</td><td>0.00012319988</td><td>0</td><td>GALAXY</td><td>--</td><td>0.019765258</td><td>0</td><td>0</td><td>17592186044416</td><td>562949953421312</td></tr>
-<tr><td>-7639190599335913472</td><td>1237665098459644444</td><td>0.8814687</td><td>0.0001139445</td><td>0</td><td>GALAXY</td><td>--</td><td>0.013265789</td><td>0</td><td>0</td><td>17592186044416</td><td>562949953421312</td></tr>
-<tr><td>-7639190049580099584</td><td>1237665098459710264</td><td>0.29381013</td><td>5.2243926e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>0.017308354</td><td>0</td><td>0</td><td>17592186044416</td><td>562949953421312</td></tr>
-<tr><td>-7639188950068471808</td><td>1237665098459644427</td><td>0.9214909</td><td>0.00020075552</td><td>0</td><td>GALAXY</td><td>--</td><td>0.011227965</td><td>0</td><td>0</td><td>17592186044416</td><td>562949953421312</td></tr>
-</table></div>
 </div>
 </div>
 </div>
@@ -10678,16 +9531,10 @@ INFO: rrtemplate-STAR-WD-v0.1.fits STAR WD PCA IGM=None z=-0.002-0.002
 <div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
 </div>
 <div class="jp-InputArea jp-Cell-inputArea">
-<div class="jp-InputPrompt jp-InputArea-prompt">In [64]:</div>
+<div class="jp-InputPrompt jp-InputArea-prompt">In [ ]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
 <div class="cm-editor cm-s-jupyter">
-<div class="highlight hl-ipython3"><pre><span></span><span class="n">model_flux</span> <span class="o">=</span> <span class="n">np</span><span class="o">.</span><span class="n">zeros</span><span class="p">((</span><span class="nb">len</span><span class="p">(</span><span class="n">boss_records</span><span class="p">),</span> <span class="n">boss_records</span><span class="p">[</span><span class="mi">0</span><span class="p">]</span><span class="o">.</span><span class="n">model</span><span class="o">.</span><span class="n">shape</span><span class="p">[</span><span class="mi">0</span><span class="p">]),</span>
-                      <span class="n">dtype</span><span class="o">=</span><span class="n">boss_records</span><span class="p">[</span><span class="mi">0</span><span class="p">]</span><span class="o">.</span><span class="n">model</span><span class="o">.</span><span class="n">dtype</span><span class="p">)</span>
-
-<span class="k">for</span> <span class="n">k</span> <span class="ow">in</span> <span class="nb">range</span><span class="p">(</span><span class="nb">len</span><span class="p">(</span><span class="n">boss_records</span><span class="p">)):</span>
-        <span class="n">model_flux</span><span class="p">[</span><span class="n">k</span><span class="p">,</span> <span class="p">:]</span> <span class="o">=</span> <span class="n">boss_records</span><span class="p">[</span><span class="n">k</span><span class="p">]</span><span class="o">.</span><span class="n">model</span>
-
-<span class="n">boss_model</span> <span class="o">=</span> <span class="p">(</span><span class="n">boss_records</span><span class="p">[</span><span class="mi">0</span><span class="p">]</span><span class="o">.</span><span class="n">wavelength</span><span class="p">,</span> <span class="n">model_flux</span><span class="p">[</span><span class="o">~</span><span class="n">boss_fully_masked</span><span class="p">,</span> <span class="p">:])</span>
+<div class="highlight hl-ipython3"><pre><span></span><span class="n">boss_model</span> <span class="o">=</span> <span class="p">(</span><span class="n">boss_specutils</span><span class="o">.</span><span class="n">spectral_axis</span><span class="p">,</span> <span class="n">boss_specutils</span><span class="o">.</span><span class="n">meta</span><span class="p">[</span><span class="s1">'model'</span><span class="p">][</span><span class="o">~</span><span class="n">boss_fully_masked</span><span class="p">,</span> <span class="p">:])</span>
 </pre></div>
 </div>
 </div>
@@ -10722,6 +9569,20 @@ INFO: rrtemplate-STAR-WD-v0.1.fits STAR WD PCA IGM=None z=-0.002-0.002
             <span class="n">mask_type</span><span class="o">=</span><span class="s1">'EBOSS_TARGET1'</span><span class="p">,</span>
             <span class="n">model_from_zcat</span><span class="o">=</span><span class="kc">False</span><span class="p">,</span>
             <span class="n">model</span><span class="o">=</span><span class="n">boss_model</span><span class="p">)</span>
+</pre></div>
+</div>
+</div>
+</div>
+</div>
+</div><div class="jp-Cell jp-CodeCell jp-Notebook-cell jp-mod-noOutputs">
+<div class="jp-Cell-inputWrapper" tabindex="0">
+<div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
+</div>
+<div class="jp-InputArea jp-Cell-inputArea">
+<div class="jp-InputPrompt jp-InputArea-prompt">In [ ]:</div>
+<div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
+<div class="cm-editor cm-s-jupyter">
+<div class="highlight hl-ipython3"><pre><span></span> 
 </pre></div>
 </div>
 </div>

--- a/04_HowTos/SPARCL/Plot_SPARCL_Spectra_with_Prospect.html
+++ b/04_HowTos/SPARCL/Plot_SPARCL_Spectra_with_Prospect.html
@@ -7332,7 +7332,12 @@ a.anchor-link {
     if (!diagrams.length) {
       return;
     }
-    const mermaid = (await import("https://cdnjs.cloudflare.com/ajax/libs/mermaid/10.7.0/mermaid.esm.min.mjs")).default;
+    const mermaid = (await import("https://cdnjs.cloudflare.com/ajax/libs/mermaid/11.10.0/mermaid.esm.min.mjs")).default;
+    const elkUrl = "https://cdnjs.cloudflare.com/ajax/libs/mermaid-layout-elk/0.1.9/mermaid-layout-elk.esm.min.mjs";
+    if(elkUrl) {
+      const elkLayouts = (await import(elkUrl)).default;
+      mermaid.registerLayoutLoaders(elkLayouts);
+    }
     const parser = new DOMParser();
 
     mermaid.initialize({
@@ -7429,7 +7434,8 @@ a.anchor-link {
      * Post-process to ensure mermaid diagrams contain only valid SVG and XHTML.
      */
     function cleanMermaidSvg(svg) {
-      return svg.replace(RE_VOID_ELEMENT, replaceVoidElement);
+      svg = svg.replace(RE_VOID_ELEMENT, replaceVoidElement);
+      return `${SVG_XML_HEADER}${svg}`;
     }
 
 
@@ -7455,6 +7461,285 @@ a.anchor-link {
       }
       return `<${tag} ${rest}>`;
     }
+
+
+  /**
+   * Named HTML entities with their decimal equivalent codes.
+   *
+   * @see https://www.w3.org/TR/WD-html40-970708/sgml/entities.html
+   * */
+  const HTML_ENTITIES = `<!ENTITY Aacute "&#193;">
+<!ENTITY aacute "&#225;">
+<!ENTITY Acirc "&#194;">
+<!ENTITY acirc "&#226;">
+<!ENTITY acute "&#180;">
+<!ENTITY AElig "&#198;">
+<!ENTITY aelig "&#230;">
+<!ENTITY Agrave "&#192;">
+<!ENTITY agrave "&#224;">
+<!ENTITY alefsym "&#8501;">
+<!ENTITY Alpha "&#913;">
+<!ENTITY alpha "&#945;">
+<!ENTITY amp "&#38;">
+<!ENTITY and "&#8869;">
+<!ENTITY ang "&#8736;">
+<!ENTITY Aring "&#197;">
+<!ENTITY aring "&#229;">
+<!ENTITY asymp "&#8776;">
+<!ENTITY Atilde "&#195;">
+<!ENTITY atilde "&#227;">
+<!ENTITY Auml "&#196;">
+<!ENTITY auml "&#228;">
+<!ENTITY bdquo "&#8222;">
+<!ENTITY Beta "&#914;">
+<!ENTITY beta "&#946;">
+<!ENTITY brvbar "&#166;">
+<!ENTITY bull "&#8226;">
+<!ENTITY cap "&#8745;">
+<!ENTITY Ccedil "&#199;">
+<!ENTITY ccedil "&#231;">
+<!ENTITY cedil "&#184;">
+<!ENTITY cent "&#162;">
+<!ENTITY Chi "&#935;">
+<!ENTITY chi "&#967;">
+<!ENTITY circ "&#710;">
+<!ENTITY clubs "&#9827;">
+<!ENTITY cong "&#8773;">
+<!ENTITY copy "&#169;">
+<!ENTITY crarr "&#8629;">
+<!ENTITY cup "&#8746;">
+<!ENTITY curren "&#164;">
+<!ENTITY dagger "&#8224;">
+<!ENTITY Dagger "&#8225;">
+<!ENTITY darr "&#8595;">
+<!ENTITY dArr "&#8659;">
+<!ENTITY deg "&#176;">
+<!ENTITY Delta "&#916;">
+<!ENTITY delta "&#948;">
+<!ENTITY diams "&#9830;">
+<!ENTITY divide "&#247;">
+<!ENTITY Eacute "&#201;">
+<!ENTITY eacute "&#233;">
+<!ENTITY Ecirc "&#202;">
+<!ENTITY ecirc "&#234;">
+<!ENTITY Egrave "&#200;">
+<!ENTITY egrave "&#232;">
+<!ENTITY empty "&#8709;">
+<!ENTITY emsp "&#8195;">
+<!ENTITY ensp "&#8194;">
+<!ENTITY epsilon "&#949;">
+<!ENTITY Epsilon "&#917;">
+<!ENTITY equiv "&#8801;">
+<!ENTITY Eta "&#919;">
+<!ENTITY eta "&#951;">
+<!ENTITY ETH "&#208;">
+<!ENTITY eth "&#240;">
+<!ENTITY Euml "&#203;">
+<!ENTITY euml "&#235;">
+<!ENTITY exist "&#8707;">
+<!ENTITY fnof "&#402;">
+<!ENTITY forall "&#8704;">
+<!ENTITY frac12 "&#189;">
+<!ENTITY frac14 "&#188;">
+<!ENTITY frac34 "&#190;">
+<!ENTITY frasl "&#8260;">
+<!ENTITY Gamma "&#915;">
+<!ENTITY gamma "&#947;">
+<!ENTITY ge "&#8805;">
+<!ENTITY gt "&#62;">
+<!ENTITY harr "&#8596;">
+<!ENTITY hArr "&#8660;">
+<!ENTITY hearts "&#9829;">
+<!ENTITY hellip "&#8230;">
+<!ENTITY Iacute "&#205;">
+<!ENTITY iacute "&#237;">
+<!ENTITY Icirc "&#206;">
+<!ENTITY icirc "&#238;">
+<!ENTITY iexcl "&#161;">
+<!ENTITY Igrave "&#204;">
+<!ENTITY igrave "&#236;">
+<!ENTITY image "&#8465;">
+<!ENTITY infin "&#8734;">
+<!ENTITY int "&#8747;">
+<!ENTITY Iota "&#921;">
+<!ENTITY iota "&#953;">
+<!ENTITY iquest "&#191;">
+<!ENTITY isin "&#8712;">
+<!ENTITY Iuml "&#207;">
+<!ENTITY iuml "&#239;">
+<!ENTITY Kappa "&#922;">
+<!ENTITY kappa "&#954;">
+<!ENTITY Lambda "&#923;">
+<!ENTITY lambda "&#955;">
+<!ENTITY lang "&#9001;">
+<!ENTITY laquo "&#171;">
+<!ENTITY larr "&#8592;">
+<!ENTITY lArr "&#8656;">
+<!ENTITY lceil "&#8968;">
+<!ENTITY ldquo "&#8220;">
+<!ENTITY le "&#8804;">
+<!ENTITY lfloor "&#8970;">
+<!ENTITY lowast "&#8727;">
+<!ENTITY loz "&#9674;">
+<!ENTITY lrm "&#8206;">
+<!ENTITY lsaquo "&#8249;">
+<!ENTITY lsquo "&#8216;">
+<!ENTITY lt "&#60;">
+<!ENTITY macr "&#175;">
+<!ENTITY mdash "&#8212;">
+<!ENTITY micro "&#181;">
+<!ENTITY middot "&#183;">
+<!ENTITY minus "&#8722;">
+<!ENTITY Mu "&#924;">
+<!ENTITY mu "&#956;">
+<!ENTITY nabla "&#8711;">
+<!ENTITY nbsp "&#160;">
+<!ENTITY ndash "&#8211;">
+<!ENTITY ne "&#8800;">
+<!ENTITY ni "&#8715;">
+<!ENTITY not "&#172;">
+<!ENTITY notin "&#8713;">
+<!ENTITY nsub "&#8836;">
+<!ENTITY Ntilde "&#209;">
+<!ENTITY ntilde "&#241;">
+<!ENTITY Nu "&#925;">
+<!ENTITY nu "&#957;">
+<!ENTITY Oacute "&#211;">
+<!ENTITY oacute "&#243;">
+<!ENTITY Ocirc "&#212;">
+<!ENTITY ocirc "&#244;">
+<!ENTITY OElig "&#338;">
+<!ENTITY oelig "&#339;">
+<!ENTITY Ograve "&#210;">
+<!ENTITY ograve "&#242;">
+<!ENTITY oline "&#8254;">
+<!ENTITY Omega "&#937;">
+<!ENTITY omega "&#969;">
+<!ENTITY Omicron "&#927;">
+<!ENTITY omicron "&#959;">
+<!ENTITY oplus "&#8853;">
+<!ENTITY or "&#8870;">
+<!ENTITY ordf "&#170;">
+<!ENTITY ordm "&#186;">
+<!ENTITY Oslash "&#216;">
+<!ENTITY oslash "&#248;">
+<!ENTITY Otilde "&#213;">
+<!ENTITY otilde "&#245;">
+<!ENTITY otimes "&#8855;">
+<!ENTITY Ouml "&#214;">
+<!ENTITY ouml "&#246;">
+<!ENTITY para "&#182;">
+<!ENTITY part "&#8706;">
+<!ENTITY permil "&#8240;">
+<!ENTITY perp "&#8869;">
+<!ENTITY Phi "&#934;">
+<!ENTITY phi "&#966;">
+<!ENTITY Pi "&#928;">
+<!ENTITY pi "&#960;">
+<!ENTITY piv "&#982;">
+<!ENTITY plusmn "&#177;">
+<!ENTITY pound "&#163;">
+<!ENTITY prime "&#8242;">
+<!ENTITY Prime "&#8243;">
+<!ENTITY prod "&#8719;">
+<!ENTITY prop "&#8733;">
+<!ENTITY Psi "&#936;">
+<!ENTITY psi "&#968;">
+<!ENTITY quot "&#34;">
+<!ENTITY radic "&#8730;">
+<!ENTITY rang "&#9002;">
+<!ENTITY raquo "&#187;">
+<!ENTITY rarr "&#8594;">
+<!ENTITY rArr "&#8658;">
+<!ENTITY rceil "&#8969;">
+<!ENTITY rdquo "&#8221;">
+<!ENTITY real "&#8476;">
+<!ENTITY reg "&#174;">
+<!ENTITY rfloor "&#8971;">
+<!ENTITY Rho "&#929;">
+<!ENTITY rho "&#961;">
+<!ENTITY rlm "&#8207;">
+<!ENTITY rsaquo "&#8250;">
+<!ENTITY rsquo "&#8217;">
+<!ENTITY sbquo "&#8218;">
+<!ENTITY Scaron "&#352;">
+<!ENTITY scaron "&#353;">
+<!ENTITY sdot "&#8901;">
+<!ENTITY sect "&#167;">
+<!ENTITY shy "&#173;">
+<!ENTITY Sigma "&#931;">
+<!ENTITY sigma "&#963;">
+<!ENTITY sigmaf "&#962;">
+<!ENTITY sim "&#8764;">
+<!ENTITY spades "&#9824;">
+<!ENTITY sub "&#8834;">
+<!ENTITY sube "&#8838;">
+<!ENTITY sum "&#8721;">
+<!ENTITY sup "&#8835;">
+<!ENTITY sup1 "&#185;">
+<!ENTITY sup2 "&#178;">
+<!ENTITY sup3 "&#179;">
+<!ENTITY supe "&#8839;">
+<!ENTITY szlig "&#223;">
+<!ENTITY Tau "&#932;">
+<!ENTITY tau "&#964;">
+<!ENTITY there4 "&#8756;">
+<!ENTITY Theta "&#920;">
+<!ENTITY theta "&#952;">
+<!ENTITY thetasym "&#977;">
+<!ENTITY thinsp "&#8201;">
+<!ENTITY THORN "&#222;">
+<!ENTITY thorn "&#254;">
+<!ENTITY tilde "&#732;">
+<!ENTITY times "&#215;">
+<!ENTITY trade "&#8482;">
+<!ENTITY Uacute "&#218;">
+<!ENTITY uacute "&#250;">
+<!ENTITY uarr "&#8593;">
+<!ENTITY uArr "&#8657;">
+<!ENTITY Ucirc "&#219;">
+<!ENTITY ucirc "&#251;">
+<!ENTITY Ugrave "&#217;">
+<!ENTITY ugrave "&#249;">
+<!ENTITY uml "&#168;">
+<!ENTITY upsih "&#978;">
+<!ENTITY Upsilon "&#933;">
+<!ENTITY upsilon "&#965;">
+<!ENTITY Uuml "&#220;">
+<!ENTITY uuml "&#252;">
+<!ENTITY weierp "&#8472;">
+<!ENTITY Xi "&#926;">
+<!ENTITY xi "&#958;">
+<!ENTITY Yacute "&#221;">
+<!ENTITY yacute "&#253;">
+<!ENTITY yen "&#165;">
+<!ENTITY Yuml "&#376;">
+<!ENTITY yuml "&#255;">
+<!ENTITY Zeta "&#918;">
+<!ENTITY zeta "&#950;">
+<!ENTITY zwj "&#8205;">
+<!ENTITY zwnj "&#8204;">`.replace(/\n/g, ' ');
+
+  /**
+   * A reasonably strict xml declaration.
+   */
+  const XML_DECL = '<?xml version="1.0" standalone="no"?>';
+
+  /**
+   * The beginning of the XML doctype declaration.
+   */
+  const DOCTYPE_START = `<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" [`;
+
+  /**
+   * The end of the XML docype declaration.
+   */
+  const DOCTYPE_END = ']>';
+
+  /**
+   * A full header for an SVG XML document.
+   */
+  const SVG_XML_HEADER = `${XML_DECL}
+    ${DOCTYPE_START}${HTML_ENTITIES}${DOCTYPE_END}`;
 
     void Promise.all([...diagrams].map(renderOneMarmaid));
   });
@@ -8405,7 +8690,7 @@ a.anchor-link {
 </div>
 <div class="jp-InputArea jp-Cell-inputArea"><div class="jp-InputPrompt jp-InputArea-prompt">
 </div><div class="jp-RenderedHTMLCommon jp-RenderedMarkdown jp-MarkdownOutput" data-mime-type="text/markdown">
-<h4 id="Find-a-set-of-QSOs">Find a set of QSOs<a class="anchor-link" href="#Find-a-set-of-QSOs">¶</a></h4><p>There are two different sets of QSO templates, <code>LOZ</code> and <code>HIZ</code>, corresponding to different subtypes for <code>QSO</code> spectypes. This query will return a set of spectra with both <code>LOZ</code> and <code>HIZ</code> subtypes.</p>
+<h4 id="Find-a-set-of-QSOs">Find a set of QSOs<a class="anchor-link" href="#Find-a-set-of-QSOs">¶</a></h4><p>There are two different sets of QSO templates, <code>LOZ</code> and <code>HIZ</code>, corresponding to different subtypes for <code>QSO</code> spectypes. This query will return a set of spectra with both <code>LOZ</code> and <code>HIZ</code> subtypes. In addition, the coefficients of the template model are retrieved, <em>e.g.</em> <code>z.coeff_0</code>.</p>
 </div>
 </div>
 </div>
@@ -8419,7 +8704,9 @@ a.anchor-link {
 <div class="cm-editor cm-s-jupyter">
 <div class="highlight hl-ipython3"><pre><span></span><span class="n">q</span> <span class="o">=</span> <span class="s2">"""</span>
 <span class="s2">SELECT z.targetid, z.chi2, z.z, z.zerr, z.zwarn, z.spectype, z.subtype,</span>
-<span class="s2">       z.coadd_numexp, z.coadd_exptime, z.healpix, z.deltachi2</span>
+<span class="s2">       z.coadd_numexp, z.coadd_exptime, z.healpix, z.deltachi2,</span>
+<span class="s2">       z.coeff_0, z.coeff_1, z.coeff_2, z.coeff_3, z.coeff_4,</span>
+<span class="s2">       z.coeff_5, z.coeff_6, z.coeff_7, z.coeff_8, z.coeff_9</span>
 <span class="s2">FROM desi_dr1.zpix AS z</span>
 <span class="s2">WHERE z.zcat_primary</span>
 <span class="s2">    AND z.survey = 'main'</span>
@@ -8432,87 +8719,6 @@ a.anchor-link {
 <span class="s2">LIMIT 50</span>
 <span class="s2">"""</span>
 <span class="n">desi_qso_ids</span> <span class="o">=</span> <span class="n">qc</span><span class="o">.</span><span class="n">query</span><span class="p">(</span><span class="n">sql</span><span class="o">=</span><span class="n">q</span><span class="p">,</span> <span class="n">fmt</span><span class="o">=</span><span class="s1">'table'</span><span class="p">)</span>
-<span class="n">desi_qso_ids</span>
-</pre></div>
-</div>
-</div>
-</div>
-</div>
-</div>
-<div class="jp-Cell jp-MarkdownCell jp-Notebook-cell">
-<div class="jp-Cell-inputWrapper" tabindex="0">
-<div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
-</div>
-<div class="jp-InputArea jp-Cell-inputArea"><div class="jp-InputPrompt jp-InputArea-prompt">
-</div><div class="jp-RenderedHTMLCommon jp-RenderedMarkdown jp-MarkdownOutput" data-mime-type="text/markdown">
-<h4 id="Fetch-the-redrock-file-to-get-the-model-coefficients">Fetch the redrock file to get the model coefficients<a class="anchor-link" href="#Fetch-the-redrock-file-to-get-the-model-coefficients">¶</a></h4><p>This will also store the file locally so that it should only need to be downloaded once.</p>
-</div>
-</div>
-</div>
-</div><div class="jp-Cell jp-CodeCell jp-Notebook-cell jp-mod-noOutputs">
-<div class="jp-Cell-inputWrapper" tabindex="0">
-<div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
-</div>
-<div class="jp-InputArea jp-Cell-inputArea">
-<div class="jp-InputPrompt jp-InputArea-prompt">In [ ]:</div>
-<div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
-<div class="cm-editor cm-s-jupyter">
-<div class="highlight hl-ipython3"><pre><span></span><span class="n">overwrite</span> <span class="o">=</span> <span class="kc">False</span>
-<span class="n">redrock_path</span> <span class="o">=</span> <span class="n">findfile</span><span class="p">(</span><span class="s1">'redrock'</span><span class="p">,</span> <span class="n">survey</span><span class="o">=</span><span class="s1">'main'</span><span class="p">,</span> <span class="n">faprogram</span><span class="o">=</span><span class="s1">'dark'</span><span class="p">,</span> <span class="n">healpix</span><span class="o">=</span><span class="mi">26067</span><span class="p">)</span>
-<span class="n">redrock_file</span> <span class="o">=</span> <span class="n">os</span><span class="o">.</span><span class="n">path</span><span class="o">.</span><span class="n">basename</span><span class="p">(</span><span class="n">redrock_path</span><span class="p">)</span>
-<span class="k">if</span> <span class="n">overwrite</span><span class="p">:</span>
-    <span class="n">sc</span><span class="o">.</span><span class="n">rm</span><span class="p">(</span><span class="sa">f</span><span class="s2">"vos://</span><span class="si">{</span><span class="n">redrock_file</span><span class="si">}</span><span class="s2">"</span><span class="p">)</span>
-<span class="k">if</span> <span class="n">sc</span><span class="o">.</span><span class="n">access</span><span class="p">(</span><span class="sa">f</span><span class="s2">"vos://</span><span class="si">{</span><span class="n">redrock_file</span><span class="si">}</span><span class="s2">"</span><span class="p">):</span>
-    <span class="nb">print</span><span class="p">(</span><span class="sa">f</span><span class="s2">"INFO: </span><span class="si">{</span><span class="n">redrock_file</span><span class="si">}</span><span class="s2"> has already been downloaded."</span><span class="p">)</span>
-<span class="k">else</span><span class="p">:</span>
-    <span class="n">specprod_root</span> <span class="o">=</span> <span class="n">os</span><span class="o">.</span><span class="n">path</span><span class="o">.</span><span class="n">join</span><span class="p">(</span><span class="n">os</span><span class="o">.</span><span class="n">environ</span><span class="p">[</span><span class="s1">'DESI_SPECTRO_REDUX'</span><span class="p">],</span> <span class="n">os</span><span class="o">.</span><span class="n">environ</span><span class="p">[</span><span class="s1">'SPECPROD'</span><span class="p">])</span>
-    <span class="n">redrock_url</span> <span class="o">=</span> <span class="n">redrock_path</span><span class="o">.</span><span class="n">replace</span><span class="p">(</span><span class="n">specprod_root</span><span class="p">,</span> <span class="sa">f</span><span class="s1">'https://data.desi.lbl.gov/public/dr1/spectro/redux/</span><span class="si">{</span><span class="n">specprod</span><span class="si">}</span><span class="s1">'</span><span class="p">)</span>
-    <span class="n">result</span> <span class="o">=</span> <span class="n">sc</span><span class="o">.</span><span class="n">load</span><span class="p">(</span><span class="sa">f</span><span class="s2">"vos://</span><span class="si">{</span><span class="n">redrock_file</span><span class="si">}</span><span class="s2">"</span><span class="p">,</span> <span class="n">redrock_url</span><span class="p">)</span>
-</pre></div>
-</div>
-</div>
-</div>
-</div>
-</div>
-<div class="jp-Cell jp-MarkdownCell jp-Notebook-cell">
-<div class="jp-Cell-inputWrapper" tabindex="0">
-<div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
-</div>
-<div class="jp-InputArea jp-Cell-inputArea"><div class="jp-InputPrompt jp-InputArea-prompt">
-</div><div class="jp-RenderedHTMLCommon jp-RenderedMarkdown jp-MarkdownOutput" data-mime-type="text/markdown">
-<h4 id="Append-the-model-coefficients-to-the-table-of-QSOs.">Append the model coefficients to the table of QSOs.<a class="anchor-link" href="#Append-the-model-coefficients-to-the-table-of-QSOs.">¶</a></h4>
-</div>
-</div>
-</div>
-</div><div class="jp-Cell jp-CodeCell jp-Notebook-cell jp-mod-noOutputs">
-<div class="jp-Cell-inputWrapper" tabindex="0">
-<div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
-</div>
-<div class="jp-InputArea jp-Cell-inputArea">
-<div class="jp-InputPrompt jp-InputArea-prompt">In [ ]:</div>
-<div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
-<div class="cm-editor cm-s-jupyter">
-<div class="highlight hl-ipython3"><pre><span></span><span class="k">with</span> <span class="n">fits</span><span class="o">.</span><span class="n">open</span><span class="p">(</span><span class="n">sc</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="sa">f</span><span class="s2">"vos://</span><span class="si">{</span><span class="n">redrock_file</span><span class="si">}</span><span class="s2">"</span><span class="p">,</span> <span class="n">mode</span><span class="o">=</span><span class="s1">'fileobj'</span><span class="p">),</span> <span class="n">mode</span><span class="o">=</span><span class="s1">'readonly'</span><span class="p">)</span> <span class="k">as</span> <span class="n">hdulist</span><span class="p">:</span>
-    <span class="n">redrock_table</span> <span class="o">=</span> <span class="n">hdulist</span><span class="p">[</span><span class="s1">'REDSHIFTS'</span><span class="p">]</span><span class="o">.</span><span class="n">data</span>
-<span class="n">i</span> <span class="o">=</span> <span class="n">redrock_table</span><span class="p">[</span><span class="s1">'TARGETID'</span><span class="p">]</span><span class="o">.</span><span class="n">argsort</span><span class="p">()</span>
-<span class="n">redrock_table</span> <span class="o">=</span> <span class="n">redrock_table</span><span class="p">[</span><span class="n">i</span><span class="p">]</span>
-</pre></div>
-</div>
-</div>
-</div>
-</div>
-</div><div class="jp-Cell jp-CodeCell jp-Notebook-cell jp-mod-noOutputs">
-<div class="jp-Cell-inputWrapper" tabindex="0">
-<div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
-</div>
-<div class="jp-InputArea jp-Cell-inputArea">
-<div class="jp-InputPrompt jp-InputArea-prompt">In [ ]:</div>
-<div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
-<div class="cm-editor cm-s-jupyter">
-<div class="highlight hl-ipython3"><pre><span></span><span class="n">w</span> <span class="o">=</span> <span class="n">np</span><span class="o">.</span><span class="n">isin</span><span class="p">(</span><span class="n">redrock_table</span><span class="p">[</span><span class="s1">'TARGETID'</span><span class="p">],</span> <span class="n">desi_qso_ids</span><span class="p">[</span><span class="s1">'targetid'</span><span class="p">])</span>
-<span class="k">assert</span> <span class="n">w</span><span class="o">.</span><span class="n">sum</span><span class="p">()</span> <span class="o">==</span> <span class="mi">50</span>
-<span class="k">assert</span> <span class="p">(</span><span class="n">redrock_table</span><span class="p">[</span><span class="s1">'TARGETID'</span><span class="p">][</span><span class="n">w</span><span class="p">]</span> <span class="o">==</span> <span class="n">desi_qso_ids</span><span class="p">[</span><span class="s1">'targetid'</span><span class="p">])</span><span class="o">.</span><span class="n">all</span><span class="p">()</span>
-<span class="n">desi_qso_ids</span><span class="p">[</span><span class="s1">'coeff'</span><span class="p">]</span> <span class="o">=</span> <span class="n">redrock_table</span><span class="p">[</span><span class="s1">'COEFF'</span><span class="p">][</span><span class="n">w</span><span class="p">,</span> <span class="p">:]</span>
 <span class="n">desi_qso_ids</span>
 </pre></div>
 </div>
@@ -8613,10 +8819,11 @@ a.anchor-link {
 <span class="n">qso_hiz</span> <span class="o">=</span> <span class="n">templates</span><span class="p">[(</span><span class="s1">'QSO'</span><span class="p">,</span> <span class="s1">'HIZ'</span><span class="p">)]</span>
 <span class="n">tmpl_model_flux</span> <span class="o">=</span> <span class="n">np</span><span class="o">.</span><span class="n">zeros</span><span class="p">((</span><span class="nb">len</span><span class="p">(</span><span class="n">desi_qso_ids</span><span class="p">),</span> <span class="nb">len</span><span class="p">(</span><span class="n">desi_qso_specutils</span><span class="o">.</span><span class="n">spectral_axis</span><span class="p">)),</span> <span class="n">dtype</span><span class="o">=</span><span class="n">desi_qso_specutils</span><span class="o">.</span><span class="n">meta</span><span class="p">[</span><span class="s1">'model'</span><span class="p">]</span><span class="o">.</span><span class="n">dtype</span><span class="p">)</span>
 <span class="k">for</span> <span class="n">i</span><span class="p">,</span> <span class="n">row</span> <span class="ow">in</span> <span class="nb">enumerate</span><span class="p">(</span><span class="n">desi_qso_ids</span><span class="p">):</span>
+    <span class="n">row_coeff</span> <span class="o">=</span> <span class="n">np</span><span class="o">.</span><span class="n">array</span><span class="p">([</span><span class="n">row</span><span class="p">[</span><span class="sa">f</span><span class="s1">'coeff_</span><span class="si">{</span><span class="n">j</span><span class="si">:</span><span class="s1">d</span><span class="si">}</span><span class="s1">'</span><span class="p">]</span> <span class="k">for</span> <span class="n">j</span> <span class="ow">in</span> <span class="nb">range</span><span class="p">(</span><span class="mi">10</span><span class="p">)])</span>
     <span class="k">if</span> <span class="n">row</span><span class="p">[</span><span class="s1">'subtype'</span><span class="p">]</span> <span class="o">==</span> <span class="s1">'LOZ'</span><span class="p">:</span>
-        <span class="n">tmpl_model_flux</span><span class="p">[</span><span class="n">i</span><span class="p">,</span> <span class="p">:]</span> <span class="o">=</span> <span class="n">qso_loz</span><span class="o">.</span><span class="n">eval</span><span class="p">(</span><span class="n">row</span><span class="p">[</span><span class="s1">'coeff'</span><span class="p">],</span> <span class="n">desi_qso_specutils</span><span class="o">.</span><span class="n">spectral_axis</span><span class="p">,</span> <span class="n">row</span><span class="p">[</span><span class="s1">'z'</span><span class="p">])</span>
+        <span class="n">tmpl_model_flux</span><span class="p">[</span><span class="n">i</span><span class="p">,</span> <span class="p">:]</span> <span class="o">=</span> <span class="n">qso_loz</span><span class="o">.</span><span class="n">eval</span><span class="p">(</span><span class="n">row_coeff</span><span class="p">,</span> <span class="n">desi_qso_specutils</span><span class="o">.</span><span class="n">spectral_axis</span><span class="p">,</span> <span class="n">row</span><span class="p">[</span><span class="s1">'z'</span><span class="p">])</span>
     <span class="k">else</span><span class="p">:</span>
-        <span class="n">tmpl_model_flux</span><span class="p">[</span><span class="n">i</span><span class="p">,</span> <span class="p">:]</span> <span class="o">=</span> <span class="n">qso_hiz</span><span class="o">.</span><span class="n">eval</span><span class="p">(</span><span class="n">row</span><span class="p">[</span><span class="s1">'coeff'</span><span class="p">],</span> <span class="n">desi_qso_specutils</span><span class="o">.</span><span class="n">spectral_axis</span><span class="p">,</span> <span class="n">row</span><span class="p">[</span><span class="s1">'z'</span><span class="p">])</span>
+        <span class="n">tmpl_model_flux</span><span class="p">[</span><span class="n">i</span><span class="p">,</span> <span class="p">:]</span> <span class="o">=</span> <span class="n">qso_hiz</span><span class="o">.</span><span class="n">eval</span><span class="p">(</span><span class="n">row_coeff</span><span class="p">,</span> <span class="n">desi_qso_specutils</span><span class="o">.</span><span class="n">spectral_axis</span><span class="p">,</span> <span class="n">row</span><span class="p">[</span><span class="s1">'z'</span><span class="p">])</span>
 </pre></div>
 </div>
 </div>
@@ -8643,7 +8850,7 @@ a.anchor-link {
 <div class="cm-editor cm-s-jupyter">
 <div class="highlight hl-ipython3"><pre><span></span><span class="n">fig</span> <span class="o">=</span> <span class="n">plt</span><span class="o">.</span><span class="n">figure</span><span class="p">(</span><span class="n">figsize</span><span class="o">=</span><span class="p">(</span><span class="mi">16</span><span class="p">,</span> <span class="mi">9</span><span class="p">),</span> <span class="n">dpi</span><span class="o">=</span><span class="mi">100</span><span class="p">)</span>
 <span class="n">ax</span> <span class="o">=</span> <span class="n">fig</span><span class="o">.</span><span class="n">add_subplot</span><span class="p">(</span><span class="mi">111</span><span class="p">)</span>
-<span class="n">spectrum_index</span> <span class="o">=</span> <span class="mi">12</span>  <span class="c1"># Step through spectra here.</span>
+<span class="n">spectrum_index</span> <span class="o">=</span> <span class="mi">24</span>  <span class="c1"># Step through spectra here.</span>
 <span class="n">pl0</span> <span class="o">=</span> <span class="n">ax</span><span class="o">.</span><span class="n">plot</span><span class="p">(</span><span class="n">desi_qso_specutils</span><span class="o">.</span><span class="n">spectral_axis</span><span class="p">,</span> <span class="n">desi_qso_specutils</span><span class="o">.</span><span class="n">flux</span><span class="p">[</span><span class="n">spectrum_index</span><span class="p">,</span> <span class="p">:],</span> <span class="s1">'k-'</span><span class="p">,</span> <span class="n">alpha</span><span class="o">=</span><span class="mf">0.3</span><span class="p">,</span> <span class="n">lw</span><span class="o">=</span><span class="mf">0.5</span><span class="p">,</span> <span class="n">label</span><span class="o">=</span><span class="s1">'SPARCL flux'</span><span class="p">)</span>
 <span class="n">pl1</span> <span class="o">=</span> <span class="n">ax</span><span class="o">.</span><span class="n">plot</span><span class="p">(</span><span class="n">desi_qso_specutils</span><span class="o">.</span><span class="n">spectral_axis</span><span class="p">,</span> <span class="n">desi_qso_specutils</span><span class="o">.</span><span class="n">meta</span><span class="p">[</span><span class="s1">'model'</span><span class="p">][</span><span class="n">spectrum_index</span><span class="p">,</span> <span class="p">:],</span> <span class="s1">'r-'</span><span class="p">,</span> <span class="n">label</span><span class="o">=</span><span class="s1">'SPARCL model'</span><span class="p">)</span>
 <span class="n">pl2</span> <span class="o">=</span> <span class="n">ax</span><span class="o">.</span><span class="n">plot</span><span class="p">(</span><span class="n">desi_qso_specutils</span><span class="o">.</span><span class="n">spectral_axis</span><span class="p">,</span> <span class="n">tmpl_model_flux</span><span class="p">[</span><span class="n">spectrum_index</span><span class="p">,</span> <span class="p">:],</span> <span class="s1">'b-'</span><span class="p">,</span> <span class="n">label</span><span class="o">=</span><span class="s1">'Redrock model'</span><span class="p">)</span>

--- a/04_HowTos/SPARCL/Plot_SPARCL_Spectra_with_Prospect.html
+++ b/04_HowTos/SPARCL/Plot_SPARCL_Spectra_with_Prospect.html
@@ -7805,7 +7805,7 @@ a.anchor-link {
 <div class="cm-editor cm-s-jupyter">
 <div class="highlight hl-ipython3"><pre><span></span><span class="n">__nbid__</span> <span class="o">=</span> <span class="s1">'0053'</span>
 <span class="n">__author__</span> <span class="o">=</span> <span class="s1">'Eric Armengaud, Benjamin Weaver &lt;benjamin.weaver@noirlab.edu&gt;, Alice Jacques &lt;alice.jacques@noirlab.edu&gt;'</span>
-<span class="n">__version__</span> <span class="o">=</span> <span class="s1">'20251215'</span> <span class="c1"># yyyymmdd</span>
+<span class="n">__version__</span> <span class="o">=</span> <span class="s1">'20260505'</span> <span class="c1"># yyyymmdd</span>
 <span class="n">__datasets__</span> <span class="o">=</span> <span class="p">[</span><span class="s1">'boss_dr17'</span><span class="p">,</span> <span class="s1">'desi_dr1'</span><span class="p">,</span> <span class="s1">'sdss_dr17'</span><span class="p">]</span>
 <span class="n">__keywords__</span> <span class="o">=</span> <span class="p">[</span><span class="s1">'sparcl'</span><span class="p">,</span> <span class="s1">'spectroscopy'</span><span class="p">,</span> <span class="s1">'sdss spectra'</span><span class="p">,</span> <span class="s1">'desi spectra'</span><span class="p">,</span> <span class="s1">'tutorial'</span><span class="p">,</span> <span class="s1">'prospect'</span><span class="p">,</span> <span class="s1">'specutils'</span><span class="p">]</span>
 </pre></div>

--- a/04_HowTos/SPARCL/Plot_SPARCL_Spectra_with_Prospect.ipynb
+++ b/04_HowTos/SPARCL/Plot_SPARCL_Spectra_with_Prospect.ipynb
@@ -697,7 +697,7 @@
    "source": [
     "#### Find a set of QSOs\n",
     "\n",
-    "There are two different sets of QSO templates, `LOZ` and `HIZ`, corresponding to different subtypes for `QSO` spectypes. This query will return a set of spectra with both `LOZ` and `HIZ` subtypes."
+    "There are two different sets of QSO templates, `LOZ` and `HIZ`, corresponding to different subtypes for `QSO` spectypes. This query will return a set of spectra with both `LOZ` and `HIZ` subtypes. In addition, the coefficients of the template model are retrieved, *e.g.* `z.coeff_0`."
    ]
   },
   {
@@ -708,7 +708,9 @@
    "source": [
     "q = \"\"\"\n",
     "SELECT z.targetid, z.chi2, z.z, z.zerr, z.zwarn, z.spectype, z.subtype,\n",
-    "       z.coadd_numexp, z.coadd_exptime, z.healpix, z.deltachi2\n",
+    "       z.coadd_numexp, z.coadd_exptime, z.healpix, z.deltachi2,\n",
+    "       z.coeff_0, z.coeff_1, z.coeff_2, z.coeff_3, z.coeff_4,\n",
+    "       z.coeff_5, z.coeff_6, z.coeff_7, z.coeff_8, z.coeff_9\n",
     "FROM desi_dr1.zpix AS z\n",
     "WHERE z.zcat_primary\n",
     "    AND z.survey = 'main'\n",
@@ -721,66 +723,6 @@
     "LIMIT 50\n",
     "\"\"\"\n",
     "desi_qso_ids = qc.query(sql=q, fmt='table')\n",
-    "desi_qso_ids"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "#### Fetch the redrock file to get the model coefficients\n",
-    "\n",
-    "This will also store the file locally so that it should only need to be downloaded once."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "overwrite = False\n",
-    "redrock_path = findfile('redrock', survey='main', faprogram='dark', healpix=26067)\n",
-    "redrock_file = os.path.basename(redrock_path)\n",
-    "if overwrite:\n",
-    "    sc.rm(f\"vos://{redrock_file}\")\n",
-    "if sc.access(f\"vos://{redrock_file}\"):\n",
-    "    print(f\"INFO: {redrock_file} has already been downloaded.\")\n",
-    "else:\n",
-    "    specprod_root = os.path.join(os.environ['DESI_SPECTRO_REDUX'], os.environ['SPECPROD'])\n",
-    "    redrock_url = redrock_path.replace(specprod_root, f'https://data.desi.lbl.gov/public/dr1/spectro/redux/{specprod}')\n",
-    "    result = sc.load(f\"vos://{redrock_file}\", redrock_url)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "#### Append the model coefficients to the table of QSOs."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "with fits.open(sc.get(f\"vos://{redrock_file}\", mode='fileobj'), mode='readonly') as hdulist:\n",
-    "    redrock_table = hdulist['REDSHIFTS'].data\n",
-    "i = redrock_table['TARGETID'].argsort()\n",
-    "redrock_table = redrock_table[i]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "w = np.isin(redrock_table['TARGETID'], desi_qso_ids['targetid'])\n",
-    "assert w.sum() == 50\n",
-    "assert (redrock_table['TARGETID'][w] == desi_qso_ids['targetid']).all()\n",
-    "desi_qso_ids['coeff'] = redrock_table['COEFF'][w, :]\n",
     "desi_qso_ids"
    ]
   },
@@ -849,10 +791,11 @@
     "qso_hiz = templates[('QSO', 'HIZ')]\n",
     "tmpl_model_flux = np.zeros((len(desi_qso_ids), len(desi_qso_specutils.spectral_axis)), dtype=desi_qso_specutils.meta['model'].dtype)\n",
     "for i, row in enumerate(desi_qso_ids):\n",
+    "    row_coeff = np.array([row[f'coeff_{j:d}'] for j in range(10)])\n",
     "    if row['subtype'] == 'LOZ':\n",
-    "        tmpl_model_flux[i, :] = qso_loz.eval(row['coeff'], desi_qso_specutils.spectral_axis, row['z'])\n",
+    "        tmpl_model_flux[i, :] = qso_loz.eval(row_coeff, desi_qso_specutils.spectral_axis, row['z'])\n",
     "    else:\n",
-    "        tmpl_model_flux[i, :] = qso_hiz.eval(row['coeff'], desi_qso_specutils.spectral_axis, row['z'])"
+    "        tmpl_model_flux[i, :] = qso_hiz.eval(row_coeff, desi_qso_specutils.spectral_axis, row['z'])"
    ]
   },
   {
@@ -870,7 +813,7 @@
    "source": [
     "fig = plt.figure(figsize=(16, 9), dpi=100)\n",
     "ax = fig.add_subplot(111)\n",
-    "spectrum_index = 12  # Step through spectra here.\n",
+    "spectrum_index = 24  # Step through spectra here.\n",
     "pl0 = ax.plot(desi_qso_specutils.spectral_axis, desi_qso_specutils.flux[spectrum_index, :], 'k-', alpha=0.3, lw=0.5, label='SPARCL flux')\n",
     "pl1 = ax.plot(desi_qso_specutils.spectral_axis, desi_qso_specutils.meta['model'][spectrum_index, :], 'r-', label='SPARCL model')\n",
     "pl2 = ax.plot(desi_qso_specutils.spectral_axis, tmpl_model_flux[spectrum_index, :], 'b-', label='Redrock model')\n",

--- a/04_HowTos/SPARCL/Plot_SPARCL_Spectra_with_Prospect.ipynb
+++ b/04_HowTos/SPARCL/Plot_SPARCL_Spectra_with_Prospect.ipynb
@@ -2,16 +2,8 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2025-12-15T16:59:47.112695Z",
-     "iopub.status.busy": "2025-12-15T16:59:47.112460Z",
-     "iopub.status.idle": "2025-12-15T16:59:47.118485Z",
-     "shell.execute_reply": "2025-12-15T16:59:47.117994Z",
-     "shell.execute_reply.started": "2025-12-15T16:59:47.112682Z"
-    }
-   },
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": [
     "__nbid__ = '0053'\n",
@@ -121,34 +113,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2025-12-15T16:59:47.119416Z",
-     "iopub.status.busy": "2025-12-15T16:59:47.119148Z",
-     "iopub.status.idle": "2025-12-15T16:59:49.695448Z",
-     "shell.execute_reply": "2025-12-15T16:59:49.694831Z",
-     "shell.execute_reply.started": "2025-12-15T16:59:47.119404Z"
-    },
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "astro-datalab==2.24.0\n",
-      "specutils==1.13.0\n",
-      "bokeh==2.4.3\n",
-      "prospect==1.3.3\n",
-      "desispec==0.69.0\n",
-      "redrock==0.20.4\n",
-      "sparcl==1.2.7\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import os\n",
+    "import sys\n",
+    "sys.path.insert(1, os.path.join(os.environ['HOME'], 'Documents', 'Code', 'git', 'nsf-noirlab', 'csdc', 'datalab', 'sparcl', 'sparclclient'))\n",
     "from numba import NumbaDeprecationWarning\n",
     "import warnings\n",
     "warnings.filterwarnings(\"ignore\", category=NumbaDeprecationWarning, message=r'.*numba\\.jit.*')\n",
@@ -191,21 +164,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2025-12-15T16:59:49.696621Z",
-     "iopub.status.busy": "2025-12-15T16:59:49.696213Z",
-     "iopub.status.idle": "2025-12-15T16:59:49.698936Z",
-     "shell.execute_reply": "2025-12-15T16:59:49.698496Z",
-     "shell.execute_reply.started": "2025-12-15T16:59:49.696605Z"
-    }
-   },
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": [
     "# from getpass import getpass\n",
     "# token = ac.login(input(\"Enter user name: (+ENTER) \"), getpass(\"Enter password: (+ENTER) \"))\n",
-    "# ac.whoAmI()"
+    "ac.whoAmI()"
    ]
   },
   {
@@ -217,36 +182,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2025-12-15T16:59:49.699667Z",
-     "iopub.status.busy": "2025-12-15T16:59:49.699522Z",
-     "iopub.status.idle": "2025-12-15T16:59:49.884857Z",
-     "shell.execute_reply": "2025-12-15T16:59:49.884403Z",
-     "shell.execute_reply.started": "2025-12-15T16:59:49.699655Z"
-    },
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "announcement=Data set deprecation notice: on November 19, 2025 the SDSS/BOSS DR16 data sets were deprecated. Please use the new SDSS/BOSS DR17 data sets instead.\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "(sparclclient:1.2.7, api:13.0, https://astrosparcl.datalab.noirlab.edu/api, client_hash=, verbose=False, connect_timeout=1.1, read_timeout=5400.0, announcement=True)"
-      ]
-     },
-     "execution_count": 4,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "client = SparclClient()\n",
     "client"
@@ -263,29 +203,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2025-12-15T16:59:49.885616Z",
-     "iopub.status.busy": "2025-12-15T16:59:49.885470Z",
-     "iopub.status.idle": "2025-12-15T16:59:49.888862Z",
-     "shell.execute_reply": "2025-12-15T16:59:49.888453Z",
-     "shell.execute_reply.started": "2025-12-15T16:59:49.885603Z"
-    },
     "tags": []
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "'default'"
-      ]
-     },
-     "execution_count": 5,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "qc.get_profile()"
    ]
@@ -309,80 +231,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2025-12-15T16:59:49.890519Z",
-     "iopub.status.busy": "2025-12-15T16:59:49.890329Z",
-     "iopub.status.idle": "2025-12-15T16:59:50.003049Z",
-     "shell.execute_reply": "2025-12-15T16:59:50.002578Z",
-     "shell.execute_reply.started": "2025-12-15T16:59:49.890507Z"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div><i>Table length=50</i>\n",
-       "<table id=\"table140047155214128\" class=\"table-striped table-bordered table-condensed\">\n",
-       "<thead><tr><th>targetid</th><th>chi2</th><th>z</th><th>zerr</th><th>zwarn</th><th>spectype</th><th>subtype</th><th>coadd_numexp</th><th>coadd_exptime</th><th>healpix</th><th>deltachi2</th></tr></thead>\n",
-       "<thead><tr><th>int64</th><th>float64</th><th>float64</th><th>float64</th><th>int64</th><th>str6</th><th>int64</th><th>int64</th><th>float64</th><th>int64</th><th>float64</th></tr></thead>\n",
-       "<tr><td>2204871004520448</td><td>7502.786605030298</td><td>0.8806668589719826</td><td>9.349553024613176e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>1</td><td>1046.75</td><td>25978</td><td>9.219138950109482</td></tr>\n",
-       "<tr><td>2209099441766401</td><td>8006.957153789699</td><td>0.5376416668826327</td><td>8.224065899198639e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>1</td><td>1260.4886</td><td>25557</td><td>23.28271762281656</td></tr>\n",
-       "<tr><td>2253218688008192</td><td>8434.394513607025</td><td>0.7807731132992886</td><td>9.001776300184597e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>1</td><td>949.2782</td><td>27650</td><td>80.38463451713324</td></tr>\n",
-       "<tr><td>2253239848271873</td><td>8068.217628836632</td><td>0.8138682719950381</td><td>9.584803411923739e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>2</td><td>2201.3787</td><td>19462</td><td>11.19063480198383</td></tr>\n",
-       "<tr><td>2253330273271809</td><td>8256.472001791</td><td>0.6026842080317678</td><td>2.811214761433289e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>1</td><td>1320.7625</td><td>19505</td><td>54.08813303161878</td></tr>\n",
-       "<tr><td>2253938946473984</td><td>7914.019844397902</td><td>0.6929688143203399</td><td>6.916722607803487e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>1</td><td>824.6894</td><td>9161</td><td>11.24665383994579</td></tr>\n",
-       "<tr><td>2315501380304901</td><td>8566.17580628395</td><td>0.7495491546701545</td><td>1.825370572872369e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>1</td><td>1023.1347</td><td>9160</td><td>157.1781300567091</td></tr>\n",
-       "<tr><td>2323576464080897</td><td>10608.37604570389</td><td>0.6669901455530606</td><td>3.139990965279613e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>2</td><td>2315.1829</td><td>31319</td><td>28.90390665084124</td></tr>\n",
-       "<tr><td>2349509577277441</td><td>8195.99036064744</td><td>0.6498143137995088</td><td>5.352659428856206e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>2</td><td>2919.674</td><td>36254</td><td>30.97397623211145</td></tr>\n",
-       "<tr><td>2349509761826816</td><td>8478.736439570785</td><td>0.8820070608865096</td><td>9.368813688864787e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>2</td><td>2245.1704</td><td>36188</td><td>130.2464992851019</td></tr>\n",
-       "<tr><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td></tr>\n",
-       "<tr><td>2349804344573952</td><td>7783.598225384951</td><td>0.5971152109671497</td><td>9.467301428688893e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>1</td><td>1171.4036</td><td>17682</td><td>131.8656653612852</td></tr>\n",
-       "<tr><td>2349804344573953</td><td>8384.117335557938</td><td>0.7734874911207676</td><td>5.094545938524808e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>2</td><td>2935.748</td><td>17682</td><td>191.5378779172897</td></tr>\n",
-       "<tr><td>2349804403294209</td><td>8085.365272082388</td><td>0.6009882470468554</td><td>0.0001366930623599175</td><td>0</td><td>GALAXY</td><td>--</td><td>1</td><td>1129.9557</td><td>36799</td><td>9.397019170224667</td></tr>\n",
-       "<tr><td>2349807154757633</td><td>7759.752056121826</td><td>0.8914747499370891</td><td>9.489360515236133e-06</td><td>0</td><td>GALAXY</td><td>--</td><td>1</td><td>1032.7631</td><td>25810</td><td>1990.393577575684</td></tr>\n",
-       "<tr><td>2349810006884353</td><td>7813.356772936881</td><td>0.5897161345295494</td><td>8.995718391886062e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>1</td><td>1453.8173</td><td>17937</td><td>11.0996535718441</td></tr>\n",
-       "<tr><td>2349810040438785</td><td>7739.014853719622</td><td>0.526467324140909</td><td>0.0001221272443611522</td><td>0</td><td>GALAXY</td><td>--</td><td>1</td><td>1121.3942</td><td>17599</td><td>12.56454463675618</td></tr>\n",
-       "<tr><td>2349810086576128</td><td>9086.101851679385</td><td>0.5865114083692732</td><td>0.0001223150017235855</td><td>0</td><td>GALAXY</td><td>--</td><td>2</td><td>2988.0767</td><td>17635</td><td>523.5175925977528</td></tr>\n",
-       "<tr><td>2349810359205889</td><td>7593.425254285336</td><td>0.7735598685660158</td><td>8.465901340157139e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>1</td><td>1171.4036</td><td>17683</td><td>73.9402380771935</td></tr>\n",
-       "<tr><td>2349812292780033</td><td>9227.264025635086</td><td>0.7168970122818812</td><td>0.0002657236839550565</td><td>0</td><td>GALAXY</td><td>--</td><td>3</td><td>4244.771</td><td>26815</td><td>28.39506733883172</td></tr>\n",
-       "<tr><td>2349816101208064</td><td>7941.910046570003</td><td>0.7993679938346777</td><td>0.0001038058256018967</td><td>0</td><td>GALAXY</td><td>--</td><td>1</td><td>1117.1798</td><td>17635</td><td>103.0777635909617</td></tr>\n",
-       "</table></div>"
-      ],
-      "text/plain": [
-       "<Table length=50>\n",
-       "    targetid            chi2       ... healpix     deltachi2    \n",
-       "     int64            float64      ...  int64       float64     \n",
-       "---------------- ----------------- ... ------- -----------------\n",
-       "2204871004520448 7502.786605030298 ...   25978 9.219138950109482\n",
-       "2209099441766401 8006.957153789699 ...   25557 23.28271762281656\n",
-       "2253218688008192 8434.394513607025 ...   27650 80.38463451713324\n",
-       "2253239848271873 8068.217628836632 ...   19462 11.19063480198383\n",
-       "2253330273271809    8256.472001791 ...   19505 54.08813303161878\n",
-       "2253938946473984 7914.019844397902 ...    9161 11.24665383994579\n",
-       "2315501380304901  8566.17580628395 ...    9160 157.1781300567091\n",
-       "2323576464080897 10608.37604570389 ...   31319 28.90390665084124\n",
-       "2349509577277441  8195.99036064744 ...   36254 30.97397623211145\n",
-       "2349509761826816 8478.736439570785 ...   36188 130.2464992851019\n",
-       "             ...               ... ...     ...               ...\n",
-       "2349804344573952 7783.598225384951 ...   17682 131.8656653612852\n",
-       "2349804344573953 8384.117335557938 ...   17682 191.5378779172897\n",
-       "2349804403294209 8085.365272082388 ...   36799 9.397019170224667\n",
-       "2349807154757633 7759.752056121826 ...   25810 1990.393577575684\n",
-       "2349810006884353 7813.356772936881 ...   17937  11.0996535718441\n",
-       "2349810040438785 7739.014853719622 ...   17599 12.56454463675618\n",
-       "2349810086576128 9086.101851679385 ...   17635 523.5175925977528\n",
-       "2349810359205889 7593.425254285336 ...   17683  73.9402380771935\n",
-       "2349812292780033 9227.264025635086 ...   26815 28.39506733883172\n",
-       "2349816101208064 7941.910046570003 ...   17635 103.0777635909617"
-      ]
-     },
-     "execution_count": 6,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "q = \"\"\"\n",
     "SELECT z.targetid, z.chi2, z.z, z.zerr, z.zwarn, z.spectype, z.subtype,\n",
@@ -412,16 +263,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2025-12-15T16:59:50.003908Z",
-     "iopub.status.busy": "2025-12-15T16:59:50.003660Z",
-     "iopub.status.idle": "2025-12-15T16:59:50.006540Z",
-     "shell.execute_reply": "2025-12-15T16:59:50.006137Z",
-     "shell.execute_reply.started": "2025-12-15T16:59:50.003895Z"
-    }
-   },
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": [
     "assert (np.unique(desi_ids['targetid']) == desi_ids['targetid']).all()"
@@ -438,31 +281,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2025-12-15T16:59:50.007428Z",
-     "iopub.status.busy": "2025-12-15T16:59:50.007067Z",
-     "iopub.status.idle": "2025-12-15T16:59:52.111347Z",
-     "shell.execute_reply": "2025-12-15T16:59:52.110828Z",
-     "shell.execute_reply.started": "2025-12-15T16:59:50.007416Z"
-    },
     "tags": []
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'status': {'success': True,\n",
-       "  'info': [\"Successfully found 50 records in dr_list=['DESI-DR1']\"],\n",
-       "  'warnings': []}}"
-      ]
-     },
-     "execution_count": 8,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "include = client.get_all_fields(dataset_list=['DESI-DR1'])\n",
     "desi_spectra = client.retrieve_by_specid(specid_list=desi_ids['targetid'].value.tolist(),\n",
@@ -482,22 +305,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2025-12-15T16:59:52.112262Z",
-     "iopub.status.busy": "2025-12-15T16:59:52.112022Z",
-     "iopub.status.idle": "2025-12-15T16:59:52.115486Z",
-     "shell.execute_reply": "2025-12-15T16:59:52.115058Z",
-     "shell.execute_reply.started": "2025-12-15T16:59:52.112249Z"
-    }
-   },
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": [
-    "desi_records = sorted(desi_spectra.records, key=lambda x: x.targetid)\n",
-    "assert (np.array([r.targetid for r in desi_records]) == desi_ids['targetid']).all()\n",
-    "assert all([r.survey == 'main' for r in desi_records])\n",
-    "assert all([r.program == 'dark' for r in desi_records])"
+    "desi_spectra = desi_spectra.reorder(desi_ids['targetid'].value.tolist())\n",
+    "assert (np.array([r.targetid for r in desi_spectra.records]) == desi_ids['targetid']).all()\n",
+    "assert all([r.survey == 'main' for r in desi_spectra.records])\n",
+    "assert all([r.program == 'dark' for r in desi_spectra.records])"
    ]
   },
   {
@@ -509,19 +324,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2025-12-15T16:59:52.116131Z",
-     "iopub.status.busy": "2025-12-15T16:59:52.116002Z",
-     "iopub.status.idle": "2025-12-15T16:59:52.121135Z",
-     "shell.execute_reply": "2025-12-15T16:59:52.120662Z",
-     "shell.execute_reply.started": "2025-12-15T16:59:52.116120Z"
-    }
-   },
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": [
-    "assert all([(r.wavelength == desi_records[0].wavelength).all() for r in desi_records])"
+    "assert all([(r.wavelength == desi_spectra.records[0].wavelength).all() for r in desi_spectra.records])"
    ]
   },
   {
@@ -533,25 +340,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2025-12-15T16:59:52.122129Z",
-     "iopub.status.busy": "2025-12-15T16:59:52.121802Z",
-     "iopub.status.idle": "2025-12-15T16:59:52.134141Z",
-     "shell.execute_reply": "2025-12-15T16:59:52.133695Z",
-     "shell.execute_reply.started": "2025-12-15T16:59:52.122117Z"
-    },
     "tags": []
    },
    "outputs": [],
    "source": [
-    "desi_fully_masked = np.zeros((len(desi_records), ), dtype=bool)\n",
+    "desi_fully_masked = np.zeros((len(desi_spectra.records), ), dtype=bool)\n",
     "\n",
-    "for k in range(len(desi_records)):\n",
-    "    assert np.isfinite(desi_records[k].flux).all()\n",
-    "    assert np.isfinite(desi_records[k].ivar).all()\n",
-    "    if (desi_records[k].mask > 0).all():\n",
+    "for k in range(len(desi_spectra.records)):\n",
+    "    assert np.isfinite(desi_spectra.records[k].flux).all()\n",
+    "    assert np.isfinite(desi_spectra.records[k].ivar).all()\n",
+    "    if (desi_spectra.records[k].mask > 0).all():\n",
     "        print(f\"WARNING: Spectrum record {k:d} is fully masked!\")\n",
     "        desi_fully_masked[k] = True"
    ]
@@ -565,137 +365,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2025-12-15T16:59:52.134835Z",
-     "iopub.status.busy": "2025-12-15T16:59:52.134694Z",
-     "iopub.status.idle": "2025-12-15T16:59:52.139956Z",
-     "shell.execute_reply": "2025-12-15T16:59:52.139504Z",
-     "shell.execute_reply.started": "2025-12-15T16:59:52.134824Z"
-    },
     "scrolled": true
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'redshift_err': 9.349553024613176e-05,\n",
-       " 'specprimary': True,\n",
-       " 'specid': 2204871004520448,\n",
-       " 'wavemin': 3600.0,\n",
-       " 'targetid': 2204871004520448,\n",
-       " 'sparcl_id': '28f2f25e-85f2-11ef-bad2-525400f334e1',\n",
-       " 'instrument': 'DESI',\n",
-       " 'spectype': 'GALAXY',\n",
-       " 'ra': 217.225839,\n",
-       " 'data_release': 'DESI-DR1',\n",
-       " 'datasetgroup': 'DESI',\n",
-       " 'wavemax': 9800.0,\n",
-       " 'telescope': 'kp4m',\n",
-       " 'dec': 2.51927,\n",
-       " 'redshift_warning': 0,\n",
-       " 'exptime': 1046.75,\n",
-       " 'site': 'kpno',\n",
-       " 'redshift': 0.8806668589719826,\n",
-       " 'subpriority': 0.5145195405365304,\n",
-       " 'chi2': 7502.786605030298,\n",
-       " 'scnd_target': 2,\n",
-       " 'bgs_target': 0,\n",
-       " 'rms_delta_x': 0.0027702876832336187,\n",
-       " 'tsnr2_gpbdark': 11978.5859375,\n",
-       " 'sv2_bgs_target': 0,\n",
-       " 'sv3_bgs_target': 0,\n",
-       " 'tsnr2_elg': 115.0233154296875,\n",
-       " 'healpix': 25978,\n",
-       " 'mean_delta_x': 0.0027702876832336187,\n",
-       " 'objtype': 'TGT',\n",
-       " 'ncoeff': 10,\n",
-       " 'spgrpval': 25978,\n",
-       " 'coadd_numexp': 1,\n",
-       " 'obsconditions': 63,\n",
-       " 'fa_type': 1,\n",
-       " 'sv1_scnd_target': 0,\n",
-       " 'pmdec': 0.0,\n",
-       " 'sv3_desi_target': 0,\n",
-       " 'subtype': '',\n",
-       " 'sv2_mws_target': 0,\n",
-       " 'survey': 'main',\n",
-       " 'npixels': 7825,\n",
-       " 'mean_delta_y': -0.0011232448741793633,\n",
-       " 'coadd_numtile': 1,\n",
-       " 'coeff': [25.44093808554416,\n",
-       "  -3.6410153295212315,\n",
-       "  0.9725984367631926,\n",
-       "  11.240508979723524,\n",
-       "  -0.2209052469004468,\n",
-       "  -1.0802661550478518,\n",
-       "  -7.258869651654611,\n",
-       "  -0.3844962869827613,\n",
-       "  -2.419508464923245,\n",
-       "  -5.71567123041432],\n",
-       " 'mean_fiber_dec': 2.51927430279325,\n",
-       " 'tsnr2_qso': 29.331745147705078,\n",
-       " 'plate_ra': 217.225839,\n",
-       " 'sv1_mws_target': 0,\n",
-       " 'fa_target': 4611686018427387904,\n",
-       " 'mean_mjd': 59673.39638014,\n",
-       " 'main_primary': True,\n",
-       " 'sv_primary': False,\n",
-       " 'tsnr2_lrg': 80.06736755371094,\n",
-       " 'tsnr2_lya': 112.58667755126953,\n",
-       " 'sv_nspec': 0,\n",
-       " 'coadd_numnight': 1,\n",
-       " 'ref_epoch': 2000.0,\n",
-       " 'zcat_nspec': 1,\n",
-       " 'sv2_desi_target': 0,\n",
-       " 'desi_target': 4611686018427387904,\n",
-       " 'tsnr2_bgs': 6585.67626953125,\n",
-       " 'numobs_init': 1,\n",
-       " 'rms_delta_y': 0.0011232448741793633,\n",
-       " 'pmra': 0.0,\n",
-       " 'cmx_target': 0,\n",
-       " 'mws_target': 0,\n",
-       " 'main_nspec': 1,\n",
-       " 'sv1_desi_target': 0,\n",
-       " 'coadd_fiberstatus': 0,\n",
-       " 'std_fiber_ra': 0.0,\n",
-       " 'desiname': 'DESI J217.2258+02.5192',\n",
-       " 'sv3_mws_target': 0,\n",
-       " 'priority_init': 1900,\n",
-       " 'sv1_bgs_target': 0,\n",
-       " 'plate_dec': 2.51927,\n",
-       " 'deltachi2': 9.219138950109482,\n",
-       " 'sv2_scnd_target': 0,\n",
-       " 'std_fiber_dec': 0.0,\n",
-       " 'tsnr2_gpbbright': 2042.88525390625,\n",
-       " 'program': 'dark',\n",
-       " 'mean_psf_to_fiber_specflux': 0.7923550605773926,\n",
-       " 'mean_fiber_ra': 217.2258500531933,\n",
-       " 'tsnr2_gpbbackup': 12749.2490234375,\n",
-       " 'sv3_scnd_target': 0,\n",
-       " 'mask': array([0, 0, 0, ..., 0, 0, 0]),\n",
-       " 'wave_sigma': array([0.68404573, 0.68069285, 0.67530686, ..., 0.7782045 , 0.79153621,\n",
-       "        0.81834054]),\n",
-       " 'model': array([0.11206556, 0.14871655, 0.15365456, ..., 0.0821958 , 0.07696503,\n",
-       "        0.05125701]),\n",
-       " 'wavelength': array([3600. , 3600.8, 3601.6, ..., 9822.4, 9823.2, 9824. ]),\n",
-       " 'ivar': array([ 0.09025028,  0.09778932,  0.09730244, ..., 12.65768719,\n",
-       "        16.33502579, 25.78590393]),\n",
-       " 'flux': array([-1.75440347, -5.81356716,  0.2588788 , ..., -0.42552659,\n",
-       "         0.03952634,  0.13771901]),\n",
-       " 'dateobs': '[\"2022-04-04 09:30:47.244+00\",\"2022-04-04 09:30:47.244+00\"]',\n",
-       " 'dateobs_center': '2022-04-04 09:30:47.244096+00',\n",
-       " '_dr': 'DESI-DR1'}"
-      ]
-     },
-     "execution_count": 12,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "desi_records[0]"
+    "desi_spectra.records[0]"
    ]
   },
   {
@@ -714,61 +390,29 @@
     "\n",
     "#### Spectrum object\n",
     "\n",
-    "First we assemble the components of the spectrum object"
+    "First we assemble the components of the spectrum object. Most of the work is done simply by converting the retrieved results to a `specutils` object."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2025-12-15T16:59:52.140830Z",
-     "iopub.status.busy": "2025-12-15T16:59:52.140490Z",
-     "iopub.status.idle": "2025-12-15T16:59:52.147799Z",
-     "shell.execute_reply": "2025-12-15T16:59:52.147340Z",
-     "shell.execute_reply.started": "2025-12-15T16:59:52.140818Z"
-    }
-   },
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": [
-    "flux = np.zeros((len(desi_records), desi_records[0].flux.shape[0]),\n",
-    "                dtype=desi_records[0].flux.dtype)\n",
-    "uncertainty = np.zeros((len(desi_records), desi_records[0].ivar.shape[0]),\n",
-    "                       dtype=desi_records[0].ivar.dtype)\n",
-    "mask = np.zeros((len(desi_records), desi_records[0].mask.shape[0]),\n",
-    "                dtype=desi_records[0].mask.dtype)\n",
-    "\n",
-    "meta = {'sparcl_id': list(), 'data_release': list()}\n",
-    "sparcl_id = list()\n",
-    "data_release = list()\n",
-    "\n",
-    "for k in range(len(desi_records)):\n",
-    "    flux[k, :] = desi_records[k].flux\n",
-    "    uncertainty[k, :] = desi_records[k].ivar\n",
-    "    mask[k, :] = desi_records[k].mask\n",
-    "    meta['sparcl_id'].append(desi_records[k].sparcl_id)\n",
-    "    meta['data_release'].append(desi_records[k].data_release)"
+    "desi_specutils = desi_spectra.to_specutils()"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "And the \"fibermap\" table. We'll start with photometric quantities."
+    "We need a \"fibermap\" table. We'll start with photometric quantities."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2025-12-15T16:59:52.148768Z",
-     "iopub.status.busy": "2025-12-15T16:59:52.148373Z",
-     "iopub.status.idle": "2025-12-15T16:59:52.232367Z",
-     "shell.execute_reply": "2025-12-15T16:59:52.231908Z",
-     "shell.execute_reply.started": "2025-12-15T16:59:52.148756Z"
-    }
-   },
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": [
     "columns = ('targetid', 'ra', 'dec', 'ref_epoch', 'pmra', 'pmdec', 'ebv',\n",
@@ -792,16 +436,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2025-12-15T16:59:52.233178Z",
-     "iopub.status.busy": "2025-12-15T16:59:52.233047Z",
-     "iopub.status.idle": "2025-12-15T16:59:52.235993Z",
-     "shell.execute_reply": "2025-12-15T16:59:52.235531Z",
-     "shell.execute_reply.started": "2025-12-15T16:59:52.233167Z"
-    }
-   },
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": [
     "for col in fibermap.colnames:\n",
@@ -820,16 +456,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2025-12-15T16:59:52.236911Z",
-     "iopub.status.busy": "2025-12-15T16:59:52.236524Z",
-     "iopub.status.idle": "2025-12-15T16:59:52.239684Z",
-     "shell.execute_reply": "2025-12-15T16:59:52.239240Z",
-     "shell.execute_reply.started": "2025-12-15T16:59:52.236899Z"
-    }
-   },
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": [
     "assert (fibermap['TARGETID'] == desi_ids['targetid']).all()"
@@ -844,16 +472,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2025-12-15T16:59:52.240637Z",
-     "iopub.status.busy": "2025-12-15T16:59:52.240299Z",
-     "iopub.status.idle": "2025-12-15T16:59:52.321158Z",
-     "shell.execute_reply": "2025-12-15T16:59:52.320710Z",
-     "shell.execute_reply.started": "2025-12-15T16:59:52.240625Z"
-    }
-   },
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": [
     "columns = ('targetid', 'desi_target', 'bgs_target', 'mws_target', 'scnd_target')\n",
@@ -876,16 +496,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2025-12-15T16:59:52.321982Z",
-     "iopub.status.busy": "2025-12-15T16:59:52.321848Z",
-     "iopub.status.idle": "2025-12-15T16:59:52.324414Z",
-     "shell.execute_reply": "2025-12-15T16:59:52.323968Z",
-     "shell.execute_reply.started": "2025-12-15T16:59:52.321971Z"
-    }
-   },
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": [
     "for col in targeting.colnames:\n",
@@ -901,16 +513,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2025-12-15T16:59:52.325233Z",
-     "iopub.status.busy": "2025-12-15T16:59:52.324959Z",
-     "iopub.status.idle": "2025-12-15T16:59:52.329098Z",
-     "shell.execute_reply": "2025-12-15T16:59:52.328604Z",
-     "shell.execute_reply.started": "2025-12-15T16:59:52.325222Z"
-    }
-   },
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": [
     "assert (targeting['TARGETID'] == fibermap['TARGETID']).all()"
@@ -925,19 +529,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2025-12-15T16:59:52.330085Z",
-     "iopub.status.busy": "2025-12-15T16:59:52.329744Z",
-     "iopub.status.idle": "2025-12-15T16:59:52.332906Z",
-     "shell.execute_reply": "2025-12-15T16:59:52.332466Z",
-     "shell.execute_reply.started": "2025-12-15T16:59:52.330073Z"
-    }
-   },
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": [
-    "assert (np.array([r.targetid for r in desi_records]) == fibermap['TARGETID']).all()"
+    "assert (np.array([r.targetid for r in desi_spectra.records]) == fibermap['TARGETID']).all()"
    ]
   },
   {
@@ -949,80 +545,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2025-12-15T16:59:52.336339Z",
-     "iopub.status.busy": "2025-12-15T16:59:52.336060Z",
-     "iopub.status.idle": "2025-12-15T16:59:52.341628Z",
-     "shell.execute_reply": "2025-12-15T16:59:52.341205Z",
-     "shell.execute_reply.started": "2025-12-15T16:59:52.336327Z"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div><i>Table length=50</i>\n",
-       "<table id=\"table140046329411424\" class=\"table-striped table-bordered table-condensed\">\n",
-       "<thead><tr><th>TARGETID</th><th>TARGET_RA</th><th>TARGET_DEC</th><th>REF_EPOCH</th><th>PMRA</th><th>PMDEC</th><th>EBV</th><th>FLUX_G</th><th>FLUX_R</th><th>FLUX_Z</th><th>FLUX_W1</th><th>FLUX_W2</th><th>DESI_TARGET</th><th>BGS_TARGET</th><th>MWS_TARGET</th><th>SCND_TARGET</th></tr></thead>\n",
-       "<thead><tr><th>int64</th><th>float64</th><th>float64</th><th>float64</th><th>int64</th><th>int64</th><th>float64</th><th>float64</th><th>float64</th><th>float64</th><th>float64</th><th>float64</th><th>int64</th><th>int64</th><th>int64</th><th>int64</th></tr></thead>\n",
-       "<tr><td>2204871004520448</td><td>217.225839</td><td>2.51927</td><td>2000.0</td><td>0</td><td>0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>4611686018427387904</td><td>0</td><td>0</td><td>2</td></tr>\n",
-       "<tr><td>2209099441766401</td><td>184.69048046</td><td>-4.38150356</td><td>2015.5</td><td>0</td><td>0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>4611686018427387904</td><td>0</td><td>0</td><td>4</td></tr>\n",
-       "<tr><td>2253218688008192</td><td>179.5754362869344</td><td>1.28294636937531</td><td>0.0</td><td>0</td><td>0</td><td>0.016607514</td><td>0.21799669</td><td>1.6909436</td><td>6.8204284</td><td>1.5204644</td><td>0.1144698</td><td>4611686018427387904</td><td>0</td><td>0</td><td>4096</td></tr>\n",
-       "<tr><td>2253239848271873</td><td>0.9572810349043309</td><td>2.144423462609681</td><td>0.0</td><td>0</td><td>0</td><td>0.034726426</td><td>0.30583543</td><td>1.0512924</td><td>2.7048514</td><td>0.95714384</td><td>0.10165523</td><td>4611686018427387904</td><td>0</td><td>0</td><td>4096</td></tr>\n",
-       "<tr><td>2253330273271809</td><td>0.1660861096769561</td><td>6.104126419350009</td><td>0.0</td><td>0</td><td>0</td><td>0.05873131</td><td>0.55434924</td><td>2.0805817</td><td>8.749854</td><td>5.905693</td><td>1.927108</td><td>4611686018427387904</td><td>0</td><td>0</td><td>4096</td></tr>\n",
-       "<tr><td>2253938946473984</td><td>224.6519905758737</td><td>32.74748369472182</td><td>0.0</td><td>0</td><td>0</td><td>0.015478675</td><td>1.128178</td><td>2.2834258</td><td>12.134571</td><td>9.021092</td><td>3.7852304</td><td>4611686018427387904</td><td>0</td><td>0</td><td>4096</td></tr>\n",
-       "<tr><td>2315501380304901</td><td>223.9962846929875</td><td>32.34797052240934</td><td>2015.5</td><td>0</td><td>0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>4611686018427387904</td><td>0</td><td>0</td><td>67108864</td></tr>\n",
-       "<tr><td>2323576464080897</td><td>245.796399002067</td><td>0.809652204860224</td><td>2015.5</td><td>0</td><td>0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>4611686018427387904</td><td>0</td><td>0</td><td>268435456</td></tr>\n",
-       "<tr><td>2349509577277441</td><td>52.91607559005856</td><td>-18.21333492638648</td><td>0.0</td><td>0</td><td>0</td><td>0.042202096</td><td>0.27590653</td><td>0.39503357</td><td>0.44176143</td><td>3.9339137</td><td>8.551368</td><td>4611686018427387904</td><td>0</td><td>0</td><td>17179869184</td></tr>\n",
-       "<tr><td>2349509761826816</td><td>64.63882388910243</td><td>-18.29809033472808</td><td>0.0</td><td>0</td><td>0</td><td>0.04455217</td><td>1.9623269</td><td>5.5475426</td><td>27.947685</td><td>39.58498</td><td>16.831314</td><td>4611686018427387904</td><td>0</td><td>0</td><td>17179869184</td></tr>\n",
-       "<tr><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td></tr>\n",
-       "<tr><td>2349804344573952</td><td>35.9184965505417</td><td>-5.84530583399778</td><td>0.0</td><td>0</td><td>0</td><td>0.02338664</td><td>1.2835658</td><td>4.7132916</td><td>13.472958</td><td>50.203278</td><td>38.516064</td><td>4611686018427387904</td><td>0</td><td>0</td><td>17179869184</td></tr>\n",
-       "<tr><td>2349804344573953</td><td>35.91783811022479</td><td>-5.845063171501605</td><td>0.0</td><td>0</td><td>0</td><td>0.023381557</td><td>0.32031807</td><td>0.49168012</td><td>0.8512743</td><td>-4.455745</td><td>-7.842182</td><td>4611686018427387904</td><td>0</td><td>0</td><td>17179869184</td></tr>\n",
-       "<tr><td>2349804403294209</td><td>39.5739</td><td>-5.765</td><td>2015.5</td><td>0</td><td>0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>4611686018427387904</td><td>0</td><td>0</td><td>17179869184</td></tr>\n",
-       "<tr><td>2349807154757633</td><td>204.1660126643467</td><td>-5.782052431296652</td><td>0.0</td><td>0</td><td>0</td><td>0.02748748</td><td>0.692519</td><td>1.0083932</td><td>2.4016192</td><td>12.692081</td><td>11.705431</td><td>4611686018427387904</td><td>0</td><td>0</td><td>17179869184</td></tr>\n",
-       "<tr><td>2349810006884353</td><td>14.95797496950264</td><td>-5.583761128538709</td><td>0.0</td><td>0</td><td>0</td><td>0.057812985</td><td>1.7276545</td><td>2.5348349</td><td>3.9569442</td><td>-10.098145</td><td>-0.743038</td><td>4611686018427387904</td><td>0</td><td>0</td><td>17179869184</td></tr>\n",
-       "<tr><td>2349810040438785</td><td>16.9193527455842</td><td>-5.39187562193212</td><td>0.0</td><td>0</td><td>0</td><td>0.04618287</td><td>0.39203063</td><td>0.25528747</td><td>0.08371848</td><td>5.4100323</td><td>20.09819</td><td>4611686018427387904</td><td>0</td><td>0</td><td>17179869184</td></tr>\n",
-       "<tr><td>2349810086576128</td><td>19.66075203568845</td><td>-5.444409844626712</td><td>0.0</td><td>0</td><td>0</td><td>0.05566529</td><td>1.0205576</td><td>5.9033976</td><td>21.924006</td><td>61.201687</td><td>32.800064</td><td>4611686018427387904</td><td>0</td><td>0</td><td>17179869184</td></tr>\n",
-       "<tr><td>2349810359205889</td><td>36.1456</td><td>-5.4993</td><td>2015.5</td><td>0</td><td>0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>4611686018427387904</td><td>0</td><td>0</td><td>17179869184</td></tr>\n",
-       "<tr><td>2349812292780033</td><td>151.8450879264672</td><td>-5.385951487253016</td><td>0.0</td><td>0</td><td>0</td><td>0.045914873</td><td>1.0359656</td><td>1.3913673</td><td>1.7665042</td><td>-4.595202</td><td>-3.8645167</td><td>4611686018427387904</td><td>0</td><td>0</td><td>17179869184</td></tr>\n",
-       "<tr><td>2349816101208064</td><td>19.78856241203688</td><td>-5.218958968010406</td><td>0.0</td><td>0</td><td>0</td><td>0.050802644</td><td>2.6151247</td><td>5.0622296</td><td>12.391033</td><td>47.07424</td><td>38.79583</td><td>4611686018427387904</td><td>0</td><td>0</td><td>17179869184</td></tr>\n",
-       "</table></div>"
-      ],
-      "text/plain": [
-       "<Table length=50>\n",
-       "    TARGETID         TARGET_RA      ... MWS_TARGET SCND_TARGET\n",
-       "     int64            float64       ...   int64       int64   \n",
-       "---------------- ------------------ ... ---------- -----------\n",
-       "2204871004520448         217.225839 ...          0           2\n",
-       "2209099441766401       184.69048046 ...          0           4\n",
-       "2253218688008192  179.5754362869344 ...          0        4096\n",
-       "2253239848271873 0.9572810349043309 ...          0        4096\n",
-       "2253330273271809 0.1660861096769561 ...          0        4096\n",
-       "2253938946473984  224.6519905758737 ...          0        4096\n",
-       "2315501380304901  223.9962846929875 ...          0    67108864\n",
-       "2323576464080897   245.796399002067 ...          0   268435456\n",
-       "2349509577277441  52.91607559005856 ...          0 17179869184\n",
-       "2349509761826816  64.63882388910243 ...          0 17179869184\n",
-       "             ...                ... ...        ...         ...\n",
-       "2349804344573952   35.9184965505417 ...          0 17179869184\n",
-       "2349804344573953  35.91783811022479 ...          0 17179869184\n",
-       "2349804403294209            39.5739 ...          0 17179869184\n",
-       "2349807154757633  204.1660126643467 ...          0 17179869184\n",
-       "2349810006884353  14.95797496950264 ...          0 17179869184\n",
-       "2349810040438785   16.9193527455842 ...          0 17179869184\n",
-       "2349810086576128  19.66075203568845 ...          0 17179869184\n",
-       "2349810359205889            36.1456 ...          0 17179869184\n",
-       "2349812292780033  151.8450879264672 ...          0 17179869184\n",
-       "2349816101208064  19.78856241203688 ...          0 17179869184"
-      ]
-     },
-     "execution_count": 21,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "for col in ('DESI_TARGET', 'BGS_TARGET', 'MWS_TARGET', 'SCND_TARGET'):\n",
     "    fibermap.add_column(targeting[col])\n",
@@ -1033,30 +558,22 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Finally assemble the object."
+    "Finally assemble the object. Although we already created a `specutils.Spectrum` object above, Prospect expects a slightly different version of a `specutils` object."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2025-12-15T16:59:52.342515Z",
-     "iopub.status.busy": "2025-12-15T16:59:52.342177Z",
-     "iopub.status.idle": "2025-12-15T16:59:52.376809Z",
-     "shell.execute_reply": "2025-12-15T16:59:52.376276Z",
-     "shell.execute_reply.started": "2025-12-15T16:59:52.342503Z"
-    }
-   },
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": [
     "desi_prospect = Spectra(bands=['coadd'],\n",
-    "                        wave={'coadd': desi_records[0].wavelength},\n",
-    "                        flux={'coadd': flux[~desi_fully_masked, :]},\n",
-    "                        ivar={'coadd': uncertainty[~desi_fully_masked, :]},\n",
-    "                        mask={'coadd': mask[~desi_fully_masked, :]},\n",
+    "                        wave={'coadd': desi_specutils.spectral_axis.value},\n",
+    "                        flux={'coadd': desi_specutils.flux[~desi_fully_masked, :]},\n",
+    "                        ivar={'coadd': desi_specutils.uncertainty[~desi_fully_masked, :].array},\n",
+    "                        mask={'coadd': desi_specutils.mask[~desi_fully_masked, :]},\n",
     "                        fibermap=fibermap[~desi_fully_masked],\n",
-    "                        meta={'coadd': meta})"
+    "                        meta={'coadd': desi_specutils.meta})"
    ]
   },
   {
@@ -1070,80 +587,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2025-12-15T16:59:52.377542Z",
-     "iopub.status.busy": "2025-12-15T16:59:52.377405Z",
-     "iopub.status.idle": "2025-12-15T16:59:52.384331Z",
-     "shell.execute_reply": "2025-12-15T16:59:52.383919Z",
-     "shell.execute_reply.started": "2025-12-15T16:59:52.377530Z"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div><i>Table length=50</i>\n",
-       "<table id=\"table140046329412672\" class=\"table-striped table-bordered table-condensed\">\n",
-       "<thead><tr><th>TARGETID</th><th>CHI2</th><th>Z</th><th>ZERR</th><th>ZWARN</th><th>SPECTYPE</th><th>SUBTYPE</th><th>COADD_NUMEXP</th><th>COADD_EXPTIME</th><th>HPXPIXEL</th><th>DELTACHI2</th></tr></thead>\n",
-       "<thead><tr><th>int64</th><th>float64</th><th>float64</th><th>float64</th><th>int64</th><th>str6</th><th>int64</th><th>int64</th><th>float64</th><th>int64</th><th>float64</th></tr></thead>\n",
-       "<tr><td>2204871004520448</td><td>7502.786605030298</td><td>0.8806668589719826</td><td>9.349553024613176e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>1</td><td>1046.75</td><td>25978</td><td>9.219138950109482</td></tr>\n",
-       "<tr><td>2209099441766401</td><td>8006.957153789699</td><td>0.5376416668826327</td><td>8.224065899198639e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>1</td><td>1260.4886</td><td>25557</td><td>23.28271762281656</td></tr>\n",
-       "<tr><td>2253218688008192</td><td>8434.394513607025</td><td>0.7807731132992886</td><td>9.001776300184597e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>1</td><td>949.2782</td><td>27650</td><td>80.38463451713324</td></tr>\n",
-       "<tr><td>2253239848271873</td><td>8068.217628836632</td><td>0.8138682719950381</td><td>9.584803411923739e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>2</td><td>2201.3787</td><td>19462</td><td>11.19063480198383</td></tr>\n",
-       "<tr><td>2253330273271809</td><td>8256.472001791</td><td>0.6026842080317678</td><td>2.811214761433289e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>1</td><td>1320.7625</td><td>19505</td><td>54.08813303161878</td></tr>\n",
-       "<tr><td>2253938946473984</td><td>7914.019844397902</td><td>0.6929688143203399</td><td>6.916722607803487e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>1</td><td>824.6894</td><td>9161</td><td>11.24665383994579</td></tr>\n",
-       "<tr><td>2315501380304901</td><td>8566.17580628395</td><td>0.7495491546701545</td><td>1.825370572872369e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>1</td><td>1023.1347</td><td>9160</td><td>157.1781300567091</td></tr>\n",
-       "<tr><td>2323576464080897</td><td>10608.37604570389</td><td>0.6669901455530606</td><td>3.139990965279613e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>2</td><td>2315.1829</td><td>31319</td><td>28.90390665084124</td></tr>\n",
-       "<tr><td>2349509577277441</td><td>8195.99036064744</td><td>0.6498143137995088</td><td>5.352659428856206e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>2</td><td>2919.674</td><td>36254</td><td>30.97397623211145</td></tr>\n",
-       "<tr><td>2349509761826816</td><td>8478.736439570785</td><td>0.8820070608865096</td><td>9.368813688864787e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>2</td><td>2245.1704</td><td>36188</td><td>130.2464992851019</td></tr>\n",
-       "<tr><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td></tr>\n",
-       "<tr><td>2349804344573952</td><td>7783.598225384951</td><td>0.5971152109671497</td><td>9.467301428688893e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>1</td><td>1171.4036</td><td>17682</td><td>131.8656653612852</td></tr>\n",
-       "<tr><td>2349804344573953</td><td>8384.117335557938</td><td>0.7734874911207676</td><td>5.094545938524808e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>2</td><td>2935.748</td><td>17682</td><td>191.5378779172897</td></tr>\n",
-       "<tr><td>2349804403294209</td><td>8085.365272082388</td><td>0.6009882470468554</td><td>0.0001366930623599175</td><td>0</td><td>GALAXY</td><td>--</td><td>1</td><td>1129.9557</td><td>36799</td><td>9.397019170224667</td></tr>\n",
-       "<tr><td>2349807154757633</td><td>7759.752056121826</td><td>0.8914747499370891</td><td>9.489360515236133e-06</td><td>0</td><td>GALAXY</td><td>--</td><td>1</td><td>1032.7631</td><td>25810</td><td>1990.393577575684</td></tr>\n",
-       "<tr><td>2349810006884353</td><td>7813.356772936881</td><td>0.5897161345295494</td><td>8.995718391886062e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>1</td><td>1453.8173</td><td>17937</td><td>11.0996535718441</td></tr>\n",
-       "<tr><td>2349810040438785</td><td>7739.014853719622</td><td>0.526467324140909</td><td>0.0001221272443611522</td><td>0</td><td>GALAXY</td><td>--</td><td>1</td><td>1121.3942</td><td>17599</td><td>12.56454463675618</td></tr>\n",
-       "<tr><td>2349810086576128</td><td>9086.101851679385</td><td>0.5865114083692732</td><td>0.0001223150017235855</td><td>0</td><td>GALAXY</td><td>--</td><td>2</td><td>2988.0767</td><td>17635</td><td>523.5175925977528</td></tr>\n",
-       "<tr><td>2349810359205889</td><td>7593.425254285336</td><td>0.7735598685660158</td><td>8.465901340157139e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>1</td><td>1171.4036</td><td>17683</td><td>73.9402380771935</td></tr>\n",
-       "<tr><td>2349812292780033</td><td>9227.264025635086</td><td>0.7168970122818812</td><td>0.0002657236839550565</td><td>0</td><td>GALAXY</td><td>--</td><td>3</td><td>4244.771</td><td>26815</td><td>28.39506733883172</td></tr>\n",
-       "<tr><td>2349816101208064</td><td>7941.910046570003</td><td>0.7993679938346777</td><td>0.0001038058256018967</td><td>0</td><td>GALAXY</td><td>--</td><td>1</td><td>1117.1798</td><td>17635</td><td>103.0777635909617</td></tr>\n",
-       "</table></div>"
-      ],
-      "text/plain": [
-       "<Table length=50>\n",
-       "    TARGETID            CHI2       ... HPXPIXEL     DELTACHI2    \n",
-       "     int64            float64      ...  int64        float64     \n",
-       "---------------- ----------------- ... -------- -----------------\n",
-       "2204871004520448 7502.786605030298 ...    25978 9.219138950109482\n",
-       "2209099441766401 8006.957153789699 ...    25557 23.28271762281656\n",
-       "2253218688008192 8434.394513607025 ...    27650 80.38463451713324\n",
-       "2253239848271873 8068.217628836632 ...    19462 11.19063480198383\n",
-       "2253330273271809    8256.472001791 ...    19505 54.08813303161878\n",
-       "2253938946473984 7914.019844397902 ...     9161 11.24665383994579\n",
-       "2315501380304901  8566.17580628395 ...     9160 157.1781300567091\n",
-       "2323576464080897 10608.37604570389 ...    31319 28.90390665084124\n",
-       "2349509577277441  8195.99036064744 ...    36254 30.97397623211145\n",
-       "2349509761826816 8478.736439570785 ...    36188 130.2464992851019\n",
-       "             ...               ... ...      ...               ...\n",
-       "2349804344573952 7783.598225384951 ...    17682 131.8656653612852\n",
-       "2349804344573953 8384.117335557938 ...    17682 191.5378779172897\n",
-       "2349804403294209 8085.365272082388 ...    36799 9.397019170224667\n",
-       "2349807154757633 7759.752056121826 ...    25810 1990.393577575684\n",
-       "2349810006884353 7813.356772936881 ...    17937  11.0996535718441\n",
-       "2349810040438785 7739.014853719622 ...    17599 12.56454463675618\n",
-       "2349810086576128 9086.101851679385 ...    17635 523.5175925977528\n",
-       "2349810359205889 7593.425254285336 ...    17683  73.9402380771935\n",
-       "2349812292780033 9227.264025635086 ...    26815 28.39506733883172\n",
-       "2349816101208064 7941.910046570003 ...    17635 103.0777635909617"
-      ]
-     },
-     "execution_count": 23,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "desi_zcatalog = desi_ids.copy()\n",
     "\n",
@@ -1168,25 +614,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2025-12-15T16:59:52.385261Z",
-     "iopub.status.busy": "2025-12-15T16:59:52.384892Z",
-     "iopub.status.idle": "2025-12-15T16:59:52.388348Z",
-     "shell.execute_reply": "2025-12-15T16:59:52.387930Z",
-     "shell.execute_reply.started": "2025-12-15T16:59:52.385250Z"
-    }
-   },
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": [
-    "model_flux = np.zeros((len(desi_records), desi_records[0].model.shape[0]),\n",
-    "                      dtype=desi_records[0].model.dtype)\n",
-    "\n",
-    "for k in range(len(desi_records)):\n",
-    "        model_flux[k, :] = desi_records[k].model\n",
-    "\n",
-    "desi_model = (desi_records[0].wavelength, model_flux[~desi_fully_masked, :])"
+    "desi_model = (desi_specutils.spectral_axis, desi_specutils.meta['model'][~desi_fully_masked, :])"
    ]
   },
   {
@@ -1250,37 +682,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2025-12-15T16:59:53.355351Z",
-     "iopub.status.busy": "2025-12-15T16:59:53.354908Z",
-     "iopub.status.idle": "2025-12-15T16:59:53.395269Z",
-     "shell.execute_reply": "2025-12-15T16:59:53.394621Z",
-     "shell.execute_reply.started": "2025-12-15T16:59:53.355320Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "DEBUG: Reading templates from /data0/sw/desi/code/redrock-templates/0.9.1/templates-iron.txt\n",
-      "Reading templates from ['/data0/sw/desi/code/redrock-templates/0.9.1/rrtemplate-GALAXY-None-v2.6.fits', '/data0/sw/desi/code/redrock-templates/0.9.1/rrtemplate-QSO-LOZ-v1.0.fits', '/data0/sw/desi/code/redrock-templates/0.9.1/rrtemplate-QSO-HIZ-v1.0.fits', '/data0/sw/desi/code/redrock-templates/0.9.1/rrtemplate-STAR-A-v0.1.fits', '/data0/sw/desi/code/redrock-templates/0.9.1/rrtemplate-STAR-B-v0.1.fits', '/data0/sw/desi/code/redrock-templates/0.9.1/rrtemplate-STAR-CV-v0.1.fits', '/data0/sw/desi/code/redrock-templates/0.9.1/rrtemplate-STAR-F-v0.1.fits', '/data0/sw/desi/code/redrock-templates/0.9.1/rrtemplate-STAR-G-v0.1.fits', '/data0/sw/desi/code/redrock-templates/0.9.1/rrtemplate-STAR-K-v0.1.fits', '/data0/sw/desi/code/redrock-templates/0.9.1/rrtemplate-STAR-M-v0.1.fits', '/data0/sw/desi/code/redrock-templates/0.9.1/rrtemplate-STAR-WD-v0.1.fits']\n",
-      "INFO: rrtemplate-GALAXY-None-v2.6.fits GALAXY  PCA IGM=Calura12 z=-0.005-1.6997\n",
-      "INFO: rrtemplate-QSO-LOZ-v1.0.fits QSO LOZ PCA IGM=Calura12 z=0.05-1.5983\n",
-      "INFO: rrtemplate-QSO-HIZ-v1.0.fits QSO HIZ PCA IGM=Calura12 z=1.4-6.993\n",
-      "INFO: rrtemplate-STAR-A-v0.1.fits STAR A PCA IGM=None z=-0.002-0.002\n",
-      "INFO: rrtemplate-STAR-B-v0.1.fits STAR B PCA IGM=None z=-0.002-0.002\n",
-      "INFO: rrtemplate-STAR-CV-v0.1.fits STAR CV PCA IGM=None z=-0.002-0.002\n",
-      "INFO: rrtemplate-STAR-F-v0.1.fits STAR F PCA IGM=None z=-0.002-0.002\n",
-      "INFO: rrtemplate-STAR-G-v0.1.fits STAR G PCA IGM=None z=-0.002-0.002\n",
-      "INFO: rrtemplate-STAR-K-v0.1.fits STAR K PCA IGM=None z=-0.002-0.002\n",
-      "INFO: rrtemplate-STAR-M-v0.1.fits STAR M PCA IGM=None z=-0.002-0.002\n",
-      "INFO: rrtemplate-STAR-WD-v0.1.fits STAR WD PCA IGM=None z=-0.002-0.002\n"
-     ]
-    }
-   ],
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "specprod = 'iron'\n",
     "template_dir = get_template_dir()\n",
@@ -1298,80 +702,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2025-12-15T16:59:53.396599Z",
-     "iopub.status.busy": "2025-12-15T16:59:53.396122Z",
-     "iopub.status.idle": "2025-12-15T16:59:53.511967Z",
-     "shell.execute_reply": "2025-12-15T16:59:53.511463Z",
-     "shell.execute_reply.started": "2025-12-15T16:59:53.396582Z"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div><i>Table length=50</i>\n",
-       "<table id=\"table140046316383504\" class=\"table-striped table-bordered table-condensed\">\n",
-       "<thead><tr><th>targetid</th><th>chi2</th><th>z</th><th>zerr</th><th>zwarn</th><th>spectype</th><th>subtype</th><th>coadd_numexp</th><th>coadd_exptime</th><th>healpix</th><th>deltachi2</th></tr></thead>\n",
-       "<thead><tr><th>int64</th><th>float64</th><th>float64</th><th>float64</th><th>int64</th><th>str3</th><th>str3</th><th>int64</th><th>float64</th><th>int64</th><th>float64</th></tr></thead>\n",
-       "<tr><td>2323666519982080</td><td>7940.44324403163</td><td>1.01858912554479</td><td>0.0005063431152249177</td><td>0</td><td>QSO</td><td>LOZ</td><td>1</td><td>1087.1151</td><td>26067</td><td>263.9076617443934</td></tr>\n",
-       "<tr><td>39627878932942560</td><td>8335.446058448404</td><td>2.084154835064079</td><td>0.0004919943903500216</td><td>0</td><td>QSO</td><td>HIZ</td><td>1</td><td>985.1372</td><td>26067</td><td>501.6483456520364</td></tr>\n",
-       "<tr><td>39627878932942604</td><td>10689.24974483252</td><td>3.339810398350544</td><td>0.0001490083348571413</td><td>0</td><td>QSO</td><td>HIZ</td><td>4</td><td>4641.9043</td><td>26067</td><td>5881.092526368797</td></tr>\n",
-       "<tr><td>39627878932942685</td><td>20918.29606822133</td><td>3.188253891582343</td><td>0.0002155015216669195</td><td>0</td><td>QSO</td><td>HIZ</td><td>4</td><td>4553.441</td><td>26067</td><td>5321.518189035356</td></tr>\n",
-       "<tr><td>39627878932943381</td><td>8048.144335032906</td><td>1.553018226863044</td><td>0.0009553295219897059</td><td>0</td><td>QSO</td><td>LOZ</td><td>1</td><td>1588.0327</td><td>26067</td><td>123.9187949164771</td></tr>\n",
-       "<tr><td>39627878932943432</td><td>9122.350275153294</td><td>1.904317327483292</td><td>0.0005995273278721958</td><td>0</td><td>QSO</td><td>HIZ</td><td>2</td><td>2521.5537</td><td>26067</td><td>2872.772595795803</td></tr>\n",
-       "<tr><td>39627878932943978</td><td>7987.874932071194</td><td>1.364028348046452</td><td>0.0004469391317056302</td><td>0</td><td>QSO</td><td>LOZ</td><td>1</td><td>1588.0327</td><td>26067</td><td>460.0579781077759</td></tr>\n",
-       "<tr><td>39627878932944212</td><td>8004.350115722045</td><td>2.073681407390898</td><td>0.0008730420754907552</td><td>0</td><td>QSO</td><td>HIZ</td><td>1</td><td>776.1867</td><td>26067</td><td>635.2639014068991</td></tr>\n",
-       "<tr><td>39627878932944261</td><td>28702.7694542408</td><td>2.192523223619755</td><td>4.743985838549377e-05</td><td>0</td><td>QSO</td><td>HIZ</td><td>3</td><td>2940.6423</td><td>26067</td><td>61997.69142409414</td></tr>\n",
-       "<tr><td>39627878937133282</td><td>7914.727749031503</td><td>1.265982016374455</td><td>0.0007305455225758035</td><td>0</td><td>QSO</td><td>LOZ</td><td>1</td><td>1588.0327</td><td>26067</td><td>54.72999359993264</td></tr>\n",
-       "<tr><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td></tr>\n",
-       "<tr><td>39627884964351430</td><td>7880.307208256796</td><td>1.530018797438126</td><td>0.0007701658089210037</td><td>0</td><td>QSO</td><td>LOZ</td><td>1</td><td>1588.0327</td><td>26067</td><td>51.04182653650059</td></tr>\n",
-       "<tr><td>39627884964351840</td><td>12109.0949293226</td><td>1.724605914607025</td><td>0.0002530880648034863</td><td>0</td><td>QSO</td><td>HIZ</td><td>1</td><td>1046.75</td><td>26067</td><td>14113.81066407263</td></tr>\n",
-       "<tr><td>39627884964352646</td><td>11419.19160956144</td><td>2.530359882740409</td><td>0.0001210345134363178</td><td>0</td><td>QSO</td><td>HIZ</td><td>4</td><td>4237.8677</td><td>26067</td><td>6898.001569449902</td></tr>\n",
-       "<tr><td>39627884964352701</td><td>8454.852106619626</td><td>1.993434120662715</td><td>0.0006816445401734544</td><td>0</td><td>QSO</td><td>HIZ</td><td>1</td><td>985.1372</td><td>26067</td><td>1232.56845942419</td></tr>\n",
-       "<tr><td>39627884968542328</td><td>7950.021198839881</td><td>1.090441838720727</td><td>0.0004893229583096889</td><td>0</td><td>QSO</td><td>LOZ</td><td>2</td><td>2031.8872</td><td>26067</td><td>43.9582922863774</td></tr>\n",
-       "<tr><td>39627884968542943</td><td>7862.406741758808</td><td>1.369502480002289</td><td>0.0008113573399067251</td><td>0</td><td>QSO</td><td>LOZ</td><td>1</td><td>985.1372</td><td>26067</td><td>17.37617605691776</td></tr>\n",
-       "<tr><td>39627884968544053</td><td>7930.376330034807</td><td>1.086379223516902</td><td>0.0003497958478828536</td><td>0</td><td>QSO</td><td>LOZ</td><td>1</td><td>1046.75</td><td>26067</td><td>90.67648637853563</td></tr>\n",
-       "<tr><td>39627884968544592</td><td>8810.533645922318</td><td>1.345892246473962</td><td>0.0004434832754342202</td><td>0</td><td>QSO</td><td>LOZ</td><td>1</td><td>985.1372</td><td>26067</td><td>2182.636438595131</td></tr>\n",
-       "<tr><td>39627884968544665</td><td>8459.563079636544</td><td>2.466465377286688</td><td>0.0007200640119503051</td><td>0</td><td>QSO</td><td>HIZ</td><td>5</td><td>5171.3887</td><td>26067</td><td>1353.180157978088</td></tr>\n",
-       "<tr><td>39627884968546458</td><td>7807.179519087076</td><td>2.475831244048027</td><td>0.0006337414625701554</td><td>0</td><td>QSO</td><td>HIZ</td><td>5</td><td>5146.6226</td><td>26067</td><td>359.9049236541614</td></tr>\n",
-       "</table></div>"
-      ],
-      "text/plain": [
-       "<Table length=50>\n",
-       "     targetid            chi2       ... healpix     deltachi2    \n",
-       "      int64            float64      ...  int64       float64     \n",
-       "----------------- ----------------- ... ------- -----------------\n",
-       " 2323666519982080  7940.44324403163 ...   26067 263.9076617443934\n",
-       "39627878932942560 8335.446058448404 ...   26067 501.6483456520364\n",
-       "39627878932942604 10689.24974483252 ...   26067 5881.092526368797\n",
-       "39627878932942685 20918.29606822133 ...   26067 5321.518189035356\n",
-       "39627878932943381 8048.144335032906 ...   26067 123.9187949164771\n",
-       "39627878932943432 9122.350275153294 ...   26067 2872.772595795803\n",
-       "39627878932943978 7987.874932071194 ...   26067 460.0579781077759\n",
-       "39627878932944212 8004.350115722045 ...   26067 635.2639014068991\n",
-       "39627878932944261  28702.7694542408 ...   26067 61997.69142409414\n",
-       "39627878937133282 7914.727749031503 ...   26067 54.72999359993264\n",
-       "              ...               ... ...     ...               ...\n",
-       "39627884964351430 7880.307208256796 ...   26067 51.04182653650059\n",
-       "39627884964351840  12109.0949293226 ...   26067 14113.81066407263\n",
-       "39627884964352646 11419.19160956144 ...   26067 6898.001569449902\n",
-       "39627884964352701 8454.852106619626 ...   26067  1232.56845942419\n",
-       "39627884968542328 7950.021198839881 ...   26067  43.9582922863774\n",
-       "39627884968542943 7862.406741758808 ...   26067 17.37617605691776\n",
-       "39627884968544053 7930.376330034807 ...   26067 90.67648637853563\n",
-       "39627884968544592 8810.533645922318 ...   26067 2182.636438595131\n",
-       "39627884968544665 8459.563079636544 ...   26067 1353.180157978088\n",
-       "39627884968546458 7807.179519087076 ...   26067 359.9049236541614"
-      ]
-     },
-     "execution_count": 27,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "q = \"\"\"\n",
     "SELECT z.targetid, z.chi2, z.z, z.zerr, z.zwarn, z.spectype, z.subtype,\n",
@@ -1402,25 +735,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2025-12-15T16:59:53.512830Z",
-     "iopub.status.busy": "2025-12-15T16:59:53.512616Z",
-     "iopub.status.idle": "2025-12-15T16:59:53.570803Z",
-     "shell.execute_reply": "2025-12-15T16:59:53.570359Z",
-     "shell.execute_reply.started": "2025-12-15T16:59:53.512817Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "INFO: redrock-main-dark-26067.fits has already been downloaded.\n"
-     ]
-    }
-   ],
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "overwrite = False\n",
     "redrock_path = findfile('redrock', survey='main', faprogram='dark', healpix=26067)\n",
@@ -1444,16 +761,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2025-12-15T16:59:53.571741Z",
-     "iopub.status.busy": "2025-12-15T16:59:53.571539Z",
-     "iopub.status.idle": "2025-12-15T16:59:54.711060Z",
-     "shell.execute_reply": "2025-12-15T16:59:54.710519Z",
-     "shell.execute_reply.started": "2025-12-15T16:59:53.571723Z"
-    }
-   },
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": [
     "with fits.open(sc.get(f\"vos://{redrock_file}\", mode='fileobj'), mode='readonly') as hdulist:\n",
@@ -1464,80 +773,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2025-12-15T16:59:54.711931Z",
-     "iopub.status.busy": "2025-12-15T16:59:54.711694Z",
-     "iopub.status.idle": "2025-12-15T16:59:54.717882Z",
-     "shell.execute_reply": "2025-12-15T16:59:54.717431Z",
-     "shell.execute_reply.started": "2025-12-15T16:59:54.711919Z"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div><i>Table length=50</i>\n",
-       "<table id=\"table140046316383504\" class=\"table-striped table-bordered table-condensed\">\n",
-       "<thead><tr><th>targetid</th><th>chi2</th><th>z</th><th>zerr</th><th>zwarn</th><th>spectype</th><th>subtype</th><th>coadd_numexp</th><th>coadd_exptime</th><th>healpix</th><th>deltachi2</th><th>coeff</th></tr></thead>\n",
-       "<thead><tr><th>int64</th><th>float64</th><th>float64</th><th>float64</th><th>int64</th><th>str3</th><th>str3</th><th>int64</th><th>float64</th><th>int64</th><th>float64</th><th>float64[10]</th></tr></thead>\n",
-       "<tr><td>2323666519982080</td><td>7940.44324403163</td><td>1.01858912554479</td><td>0.0005063431152249177</td><td>0</td><td>QSO</td><td>LOZ</td><td>1</td><td>1087.1151</td><td>26067</td><td>263.9076617443934</td><td>0.46278203127056666 .. 0.0</td></tr>\n",
-       "<tr><td>39627878932942560</td><td>8335.446058448404</td><td>2.084154835064079</td><td>0.0004919943903500216</td><td>0</td><td>QSO</td><td>HIZ</td><td>1</td><td>985.1372</td><td>26067</td><td>501.6483456520364</td><td>0.46900606150188273 .. 0.0</td></tr>\n",
-       "<tr><td>39627878932942604</td><td>10689.24974483252</td><td>3.339810398350544</td><td>0.0001490083348571413</td><td>0</td><td>QSO</td><td>HIZ</td><td>4</td><td>4641.9043</td><td>26067</td><td>5881.092526368797</td><td>0.3487386921332749 .. 0.0</td></tr>\n",
-       "<tr><td>39627878932942685</td><td>20918.29606822133</td><td>3.188253891582343</td><td>0.0002155015216669195</td><td>0</td><td>QSO</td><td>HIZ</td><td>4</td><td>4553.441</td><td>26067</td><td>5321.518189035356</td><td>0.7089294177913054 .. 0.0</td></tr>\n",
-       "<tr><td>39627878932943381</td><td>8048.144335032906</td><td>1.553018226863044</td><td>0.0009553295219897059</td><td>0</td><td>QSO</td><td>LOZ</td><td>1</td><td>1588.0327</td><td>26067</td><td>123.9187949164771</td><td>0.5111103511178886 .. 0.0</td></tr>\n",
-       "<tr><td>39627878932943432</td><td>9122.350275153294</td><td>1.904317327483292</td><td>0.0005995273278721958</td><td>0</td><td>QSO</td><td>HIZ</td><td>2</td><td>2521.5537</td><td>26067</td><td>2872.772595795803</td><td>1.6841626276509625 .. 0.0</td></tr>\n",
-       "<tr><td>39627878932943978</td><td>7987.874932071194</td><td>1.364028348046452</td><td>0.0004469391317056302</td><td>0</td><td>QSO</td><td>LOZ</td><td>1</td><td>1588.0327</td><td>26067</td><td>460.0579781077759</td><td>0.8564574006318391 .. 0.0</td></tr>\n",
-       "<tr><td>39627878932944212</td><td>8004.350115722045</td><td>2.073681407390898</td><td>0.0008730420754907552</td><td>0</td><td>QSO</td><td>HIZ</td><td>1</td><td>776.1867</td><td>26067</td><td>635.2639014068991</td><td>0.7120721064231844 .. 0.0</td></tr>\n",
-       "<tr><td>39627878932944261</td><td>28702.7694542408</td><td>2.192523223619755</td><td>4.743985838549377e-05</td><td>0</td><td>QSO</td><td>HIZ</td><td>3</td><td>2940.6423</td><td>26067</td><td>61997.69142409414</td><td>4.527475756944605 .. 0.0</td></tr>\n",
-       "<tr><td>39627878937133282</td><td>7914.727749031503</td><td>1.265982016374455</td><td>0.0007305455225758035</td><td>0</td><td>QSO</td><td>LOZ</td><td>1</td><td>1588.0327</td><td>26067</td><td>54.72999359993264</td><td>0.4284378761846193 .. 0.0</td></tr>\n",
-       "<tr><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td></tr>\n",
-       "<tr><td>39627884964351430</td><td>7880.307208256796</td><td>1.530018797438126</td><td>0.0007701658089210037</td><td>0</td><td>QSO</td><td>LOZ</td><td>1</td><td>1588.0327</td><td>26067</td><td>51.04182653650059</td><td>0.25267447913834246 .. 0.0</td></tr>\n",
-       "<tr><td>39627884964351840</td><td>12109.0949293226</td><td>1.724605914607025</td><td>0.0002530880648034863</td><td>0</td><td>QSO</td><td>HIZ</td><td>1</td><td>1046.75</td><td>26067</td><td>14113.81066407263</td><td>9.99656282009574 .. 0.0</td></tr>\n",
-       "<tr><td>39627884964352646</td><td>11419.19160956144</td><td>2.530359882740409</td><td>0.0001210345134363178</td><td>0</td><td>QSO</td><td>HIZ</td><td>4</td><td>4237.8677</td><td>26067</td><td>6898.001569449902</td><td>0.9364761348951793 .. 0.0</td></tr>\n",
-       "<tr><td>39627884964352701</td><td>8454.852106619626</td><td>1.993434120662715</td><td>0.0006816445401734544</td><td>0</td><td>QSO</td><td>HIZ</td><td>1</td><td>985.1372</td><td>26067</td><td>1232.56845942419</td><td>1.0533242226365125 .. 0.0</td></tr>\n",
-       "<tr><td>39627884968542328</td><td>7950.021198839881</td><td>1.090441838720727</td><td>0.0004893229583096889</td><td>0</td><td>QSO</td><td>LOZ</td><td>2</td><td>2031.8872</td><td>26067</td><td>43.9582922863774</td><td>0.4091075354768971 .. 0.0</td></tr>\n",
-       "<tr><td>39627884968542943</td><td>7862.406741758808</td><td>1.369502480002289</td><td>0.0008113573399067251</td><td>0</td><td>QSO</td><td>LOZ</td><td>1</td><td>985.1372</td><td>26067</td><td>17.37617605691776</td><td>0.2571714739209084 .. 0.0</td></tr>\n",
-       "<tr><td>39627884968544053</td><td>7930.376330034807</td><td>1.086379223516902</td><td>0.0003497958478828536</td><td>0</td><td>QSO</td><td>LOZ</td><td>1</td><td>1046.75</td><td>26067</td><td>90.67648637853563</td><td>0.2996873131543996 .. 0.0</td></tr>\n",
-       "<tr><td>39627884968544592</td><td>8810.533645922318</td><td>1.345892246473962</td><td>0.0004434832754342202</td><td>0</td><td>QSO</td><td>LOZ</td><td>1</td><td>985.1372</td><td>26067</td><td>2182.636438595131</td><td>1.5846460956680948 .. 0.0</td></tr>\n",
-       "<tr><td>39627884968544665</td><td>8459.563079636544</td><td>2.466465377286688</td><td>0.0007200640119503051</td><td>0</td><td>QSO</td><td>HIZ</td><td>5</td><td>5171.3887</td><td>26067</td><td>1353.180157978088</td><td>0.26766853805066454 .. 0.0</td></tr>\n",
-       "<tr><td>39627884968546458</td><td>7807.179519087076</td><td>2.475831244048027</td><td>0.0006337414625701554</td><td>0</td><td>QSO</td><td>HIZ</td><td>5</td><td>5146.6226</td><td>26067</td><td>359.9049236541614</td><td>0.11142200735206872 .. 0.0</td></tr>\n",
-       "</table></div>"
-      ],
-      "text/plain": [
-       "<Table length=50>\n",
-       "     targetid            chi2       ...           coeff           \n",
-       "      int64            float64      ...        float64[10]        \n",
-       "----------------- ----------------- ... --------------------------\n",
-       " 2323666519982080  7940.44324403163 ... 0.46278203127056666 .. 0.0\n",
-       "39627878932942560 8335.446058448404 ... 0.46900606150188273 .. 0.0\n",
-       "39627878932942604 10689.24974483252 ...  0.3487386921332749 .. 0.0\n",
-       "39627878932942685 20918.29606822133 ...  0.7089294177913054 .. 0.0\n",
-       "39627878932943381 8048.144335032906 ...  0.5111103511178886 .. 0.0\n",
-       "39627878932943432 9122.350275153294 ...  1.6841626276509625 .. 0.0\n",
-       "39627878932943978 7987.874932071194 ...  0.8564574006318391 .. 0.0\n",
-       "39627878932944212 8004.350115722045 ...  0.7120721064231844 .. 0.0\n",
-       "39627878932944261  28702.7694542408 ...   4.527475756944605 .. 0.0\n",
-       "39627878937133282 7914.727749031503 ...  0.4284378761846193 .. 0.0\n",
-       "              ...               ... ...                        ...\n",
-       "39627884964351430 7880.307208256796 ... 0.25267447913834246 .. 0.0\n",
-       "39627884964351840  12109.0949293226 ...    9.99656282009574 .. 0.0\n",
-       "39627884964352646 11419.19160956144 ...  0.9364761348951793 .. 0.0\n",
-       "39627884964352701 8454.852106619626 ...  1.0533242226365125 .. 0.0\n",
-       "39627884968542328 7950.021198839881 ...  0.4091075354768971 .. 0.0\n",
-       "39627884968542943 7862.406741758808 ...  0.2571714739209084 .. 0.0\n",
-       "39627884968544053 7930.376330034807 ...  0.2996873131543996 .. 0.0\n",
-       "39627884968544592 8810.533645922318 ...  1.5846460956680948 .. 0.0\n",
-       "39627884968544665 8459.563079636544 ... 0.26766853805066454 .. 0.0\n",
-       "39627884968546458 7807.179519087076 ... 0.11142200735206872 .. 0.0"
-      ]
-     },
-     "execution_count": 30,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "w = np.isin(redrock_table['TARGETID'], desi_qso_ids['targetid'])\n",
     "assert w.sum() == 50\n",
@@ -1555,30 +793,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2025-12-15T16:59:54.718722Z",
-     "iopub.status.busy": "2025-12-15T16:59:54.718405Z",
-     "iopub.status.idle": "2025-12-15T16:59:56.670353Z",
-     "shell.execute_reply": "2025-12-15T16:59:56.669859Z",
-     "shell.execute_reply.started": "2025-12-15T16:59:54.718710Z"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'status': {'success': True,\n",
-       "  'info': [\"Successfully found 51 records in dr_list=['DESI-DR1']\"],\n",
-       "  'warnings': []}}"
-      ]
-     },
-     "execution_count": 31,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "include = client.get_all_fields(dataset_list=['DESI-DR1'])\n",
     "desi_qso_spectra = client.retrieve_by_specid(specid_list=desi_qso_ids['targetid'].value.tolist(),\n",
@@ -1596,44 +813,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2025-12-15T16:59:56.671268Z",
-     "iopub.status.busy": "2025-12-15T16:59:56.671024Z",
-     "iopub.status.idle": "2025-12-15T16:59:56.674309Z",
-     "shell.execute_reply": "2025-12-15T16:59:56.673892Z",
-     "shell.execute_reply.started": "2025-12-15T16:59:56.671256Z"
-    }
-   },
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": [
-    "desi_qso_records = sorted([r for r in desi_qso_spectra.records if r.survey == 'main' and r.program == 'dark'], key=lambda x: x.targetid)\n",
-    "assert (np.array([r.targetid for r in desi_qso_records]) == desi_qso_ids['targetid']).all()"
+    "desi_qso_spectra = desi_qso_spectra.reorder(desi_qso_ids['targetid'].value.tolist())\n",
+    "assert (np.array([r.targetid for r in desi_qso_spectra.records if r.survey == 'main' and r.program == 'dark']) == desi_qso_ids['targetid']).all()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2025-12-15T16:59:56.675162Z",
-     "iopub.status.busy": "2025-12-15T16:59:56.674870Z",
-     "iopub.status.idle": "2025-12-15T16:59:56.689313Z",
-     "shell.execute_reply": "2025-12-15T16:59:56.688925Z",
-     "shell.execute_reply.started": "2025-12-15T16:59:56.675150Z"
-    }
-   },
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": [
-    "qso_flux = np.zeros((len(desi_qso_records), desi_qso_records[0].flux.shape[0]),\n",
-    "                    dtype=desi_qso_records[0].flux.dtype)\n",
-    "qso_model_flux = np.zeros((len(desi_qso_records), desi_qso_records[0].flux.shape[0]),\n",
-    "                          dtype=desi_qso_records[0].model.dtype)\n",
-    "qso_wavelength = desi_qso_records[0].wavelength\n",
-    "for k in range(len(desi_qso_records)):\n",
-    "    qso_flux[k, :] = desi_qso_records[k].flux\n",
-    "    qso_model_flux[k, :] = desi_qso_records[k].model        "
+    "desi_qso_specutils = desi_qso_spectra.to_specutils()"
    ]
   },
   {
@@ -1645,28 +839,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2025-12-15T16:59:56.690090Z",
-     "iopub.status.busy": "2025-12-15T16:59:56.689835Z",
-     "iopub.status.idle": "2025-12-15T16:59:57.213845Z",
-     "shell.execute_reply": "2025-12-15T16:59:57.213251Z",
-     "shell.execute_reply.started": "2025-12-15T16:59:56.690079Z"
-    }
-   },
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": [
     "assert (desi_qso_ids['spectype'] == 'QSO').all()\n",
     "assert ((desi_qso_ids['subtype'] == 'HIZ') | (desi_qso_ids['subtype'] == 'LOZ')).all()\n",
     "qso_loz = templates[('QSO', 'LOZ')]\n",
     "qso_hiz = templates[('QSO', 'HIZ')]\n",
-    "tmpl_model_flux = np.zeros((len(desi_qso_ids), len(qso_wavelength)), dtype=qso_model_flux.dtype)\n",
+    "tmpl_model_flux = np.zeros((len(desi_qso_ids), len(desi_qso_specutils.spectral_axis)), dtype=desi_qso_specutils.meta['model'].dtype)\n",
     "for i, row in enumerate(desi_qso_ids):\n",
     "    if row['subtype'] == 'LOZ':\n",
-    "        tmpl_model_flux[i, :] = qso_loz.eval(row['coeff'], qso_wavelength, row['z'])\n",
+    "        tmpl_model_flux[i, :] = qso_loz.eval(row['coeff'], desi_qso_specutils.spectral_axis, row['z'])\n",
     "    else:\n",
-    "        tmpl_model_flux[i, :] = qso_hiz.eval(row['coeff'], qso_wavelength, row['z'])"
+    "        tmpl_model_flux[i, :] = qso_hiz.eval(row['coeff'], desi_qso_specutils.spectral_axis, row['z'])"
    ]
   },
   {
@@ -1678,35 +864,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2025-12-15T16:59:57.214831Z",
-     "iopub.status.busy": "2025-12-15T16:59:57.214574Z",
-     "iopub.status.idle": "2025-12-15T16:59:57.506204Z",
-     "shell.execute_reply": "2025-12-15T16:59:57.505628Z",
-     "shell.execute_reply.started": "2025-12-15T16:59:57.214817Z"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAABSQAAAMMCAYAAABKQKkcAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjguMywgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/H5lhTAAAACXBIWXMAAA9hAAAPYQGoP6dpAAEAAElEQVR4nOzdd3gU5drH8d+mdzqEEjpIR7rKEbBiwUpXxIJdxIqK7Xg8egB97ShYEFEBGxZ6Uem9907oLT2kl533j7BrlmySzWZLyvdzXXtdycwzz9wzOzu7e+9TTIZhGAIAAAAAAAAAD/DxdgAAAAAAAAAAKg8SkgAAAAAAAAA8hoQkAAAAAAAAAI8hIQkAAAAAAADAY0hIAgAAAAAAAPAYEpIAAAAAAAAAPIaEJAAAAAAAAACPISEJAAAAAAAAwGNISAIAAAAAAADwGBKSAAAAAAAAADyGhCQAlHMmk8mhx9KlS63bfPbZZzKZTOrRo4fD9UZERKh3796aO3duodtER0dr5MiRatmypUJCQhQSEqI2bdroiSee0Pbt223KvvHGG0XGe+bMGfXp08ehY3vjjTckSY0bN1a/fv0KPQ4/Pz9Vr15dXbp00VNPPaXdu3eX/IQX4tSpUxo2bJguueQShYeHq2rVqurevbumTp0qwzAKlP/hhx/UuXNnBQUFqVatWhoxYoRiY2Pt1n327Fk98sgjql+/voKCgtS4cWONGDHCpsyvv/6qwYMHq2nTpgoJCdEll1yi5557TomJiTblli5dWuS5fPvtt23Kb9q0Sf369VNkZKTCwsLUoUMHffzxx8rNzXVrnZKUkpKip59+Wg0aNFBgYKBat26tiRMnFjg/y5cv16233qqoqCgFBQUpMjJSN9xwg1atWmVT7siRI0XG+dBDD9ns+9///rduuOEGVa9eXSaTSd98843d5+fLL79U7969VadOHQUGBqpJkya6//77deTIEbvlLVauXGnd98XP/W+//aa+ffuqXr16CgwMVIMGDTRgwADt3LmzQD3PPPOMOnfurOrVqyskJEStW7fWG2+8oZSUFJtyGzZs0MiRI9W2bVuFhoaqYcOGGjRokPbv319knEX55ptvHHqNFncuinP69Gm99NJLuuqqqxQeHl7gnuaIP//8U1dddZVq1qxpfX1+9913BcqdPXtW999/v2rXrq3g4GB17txZP//8c6nqLImYmBg99dRTatWqlYKDg1W7dm11795dL774os1zet999xW4R3fs2FHvvfeeMjMzreUcudfml5ycrP/85z/q2LGjwsLCFBwcrHbt2unFF1/UqVOnin2953/ceOONqlatms6ePVvgOJOSklS3bl316NFDZrO5QL3+/v5q2rSphg8frsOHD1u3K+51PG7cuFKdf4vs7Gx9/PHH6tatm8LDwxUWFqZu3brpk08+UU5OToHyWVlZ+uijj9SpUydFRESoatWqatu2rR5++GHt3bu3QPldu3Zp2LBhql+/vgIDA1WvXj3dfffd2rVrV6lj37FjhwYMGKBGjRopKChI9evX13XXXadPPvnEppzJZNLIkSPt1vHLL78UeJ1dfM35+fkpKipKQ4YMsXk/bdy4sUPXx7hx42QymfT555/bjeGxxx6Tv7+/tm3bZrfe2rVr68orr9Rvv/1ms11Rnx1atWrlzCm1YXlNFfaeXdhnkfzn2pHPN3369Cl1rABQlvl5OwAAQOlc/OX322+/1eLFiwssb926tfXvadOmqXHjxlq/fr0OHjyo5s2b2637uuuu0/Dhw2UYho4ePaqJEyfqlltu0fz589W3b1+bsnPmzNHgwYPl5+enu+++Wx07dpSPj4/27t2rX3/9VRMnTlR0dLQaNWpks93EiRMVFhZWYN9Vq1bVK6+8ogcffNC6bMOGDfr444/18ssv2xxPhw4dijxH+Y8jKSlJ27Zt09SpU/XZZ59p/PjxevbZZ4vc3hGxsbE6ceKEBgwYoIYNGyo7O1uLFy/Wfffdp3379ul///ufzTE//vjjuuaaa/T+++/rxIkT+uijj7Rx40atW7dOQUFB1rLHjx9Xz549JUmPPvqo6tevr1OnTmn9+vU2+3/44YdVr149DRs2TA0bNtSOHTs0YcIEzZs3T5s3b1ZwcLCkvOvAXsLku+++06JFi3T99ddbl23atElXXHGFWrRooRdffFEhISGaP3++nnrqKR06dEgfffSR2+rMzc1V3759tXHjRj3xxBNq0aKFFi5cqMcff1wJCQl6+eWXrXXu379fPj4+evTRRxUZGamEhAR9//336tWrl+bOnasbbrhBklSrVi27cS5YsEDTpk2ziTM2NlZvvvmmGjZsqI4dOxaZ/NqyZYuaNGmiW2+9VdWqVVN0dLS+/PJLzZkzR9u2bVO9evUKbGM2m/Xkk08qNDRUqampBdbv2LFD1apV01NPPaWaNWvqzJkz+vrrr9W9e3etWbNGHTt2tJbdsGGDrrzySt1///0KCgrSli1bNG7cOP35559avny5fHzyfn8eP368Vq1apYEDB6pDhw46c+aMJkyYoM6dO2vt2rVq165docdYmF69ehWagDt58qTGjBmjxo0bq3bt2iWuO799+/Zp/PjxatGihdq3b681a9aUaPtZs2bp9ttv1+WXX25NJvz0008aPny4YmNj9cwzz0jKS8b961//0tmzZ/XUU08pMjJSP/30kwYNGqRp06bprrvuKnGdJREfH6+uXbsqOTlZDzzwgFq1aqW4uDht375dEydO1GOPPWZzvwwMDNRXX30lSUpMTNTMmTP1/PPPa8OGDfrhhx9s6i7qXmtx+PBhXXvttTp27JgGDhyohx9+WAEBAdq+fbsmT56s3377TStWrCjwnI8ZM0ZhYWF65ZVXbJb37NlT7dq10zPPPKPp06fbrHv55ZcVGxurBQsWWK9RSRo1apS6deum7Oxsbd68WV988YXmzp2rHTt22LyWhg4dqptuuqnA8XTq1Kmw0+uw1NRU3XzzzVq2bJn69eun++67Tz4+PlqwYIFGjRql33//XbNnz1ZISIh1m/79+2v+/PkaOnSoHnroIWVnZ2vv3r2aM2eOrrjiCptE2K+//qqhQ4eqevXqGjFihJo0aaIjR45o8uTJ+uWXX/TDDz/ojjvucCr21atX66qrrlLDhg310EMPKTIyUsePH9fatWv10Ucf6cknnyzVucl/zeXk5OjQoUOaNGmSFixYoN27d6tevXr68MMPbZLn8+bN04wZM/TBBx+oZs2a1uVXXHGFli1bppdeekm333676tSpY123fv16ffHFF3ruueds7neXXnqpnnvuOUl5PwR+/vnnuvPOOzVx4kQ9+uij1nINGjTQ2LFjC8RfpUqVUh2/q1z8+Sa/H3/8UXPmzNFll13m4agAwMMMAECF8sQTTxhF3d4PHz5sSDJ+/fVXo1atWsYbb7xht5wk44knnrBZtnv3bkOSceONN9osP3jwoBEaGmq0bt3aOHXqVIG6srOzjY8++sg4duyYddm///1vQ5IRExPj8LH9/PPPhiRjyZIldtc3atTIuPnmm4s9DsMwjNjYWOPyyy83JBlz5851OIaS6tevnxEaGmrk5OQYhmEYmZmZRtWqVY1evXoZZrPZWm727NmGJOPjjz+22f7GG280mjRpYsTGxha5H3vnZOrUqYYk48svvyw2zubNmxstWrSwWfbQQw8ZAQEBRlxcnM3yXr16GREREW6t86effjIkGZMnT7Yp179/fyMoKMg4e/ZskftOTU016tSpY/Tt27fYOK+55hojIiLCSE9Pty7LyMgwTp8+bRiGYWzYsMGQZEyZMqXYuiw2btxoSDLGjh1rd/3EiRONGjVqGE899ZTDr4MzZ84Yfn5+xiOPPFJs2f/7v/8zJBlr1qyxLlu1apWRmZlpU27//v1GYGCgcffddxdbZ0nk5OQYvXr1Mvz9/Y21a9eWur7k5GTrNVPcfcCe6667zqhXr56RkZFhXZadnW00a9bM6NChg3XZO++8Y0gy/vrrL+uy3Nxco1u3bkZkZKTN+XO0zpKw7H/VqlUF1iUlJdlco/fee68RGhpqUyY3N9fo2rWrIck4efKkYRiO32uzs7ONjh07GiEhIcaKFSvs7v/ll1+2u23btm2N3r172103fvx4Q5KxcOFC67L169cbPj4+xgsvvGBdtmTJEkOS8fPPP9ts//HHHxuSjP/973+GYRhGdHS0Icl49913izye0nj44YcNScYnn3xSYN2ECRMMScbjjz9uXbZ+/XpDkvH2228XKJ+Tk2Nz/z548KAREhJitGrVyjh37pxN2ZiYGKNVq1ZGaGiocejQIadiv+mmm4xatWoZCQkJBdZdfN8s7P3RMOy/zuxdc4ZhGHPmzDEkGV988YXdut59911DkhEdHV1gXXR0tBESEmIMHTrUuiwnJ8e49NJLjcaNGxupqanW5fbe40+fPm2EhoYaLVu2tC7r3bu30bZtW7uxuEJxr6mSfBa52Pbt242goCCjS5cuBe7XAFDR0GUbACqZadOmqVq1arr55ps1YMAATZs2zeFtW7durZo1a+rQoUM2y9955x2lpqZqypQpqlu3boHt/Pz8NGrUKEVFRZU6flepUaOGfvjhB/n5+RXoUuxKjRs3VlpamrKysiRJO3fuVGJiogYPHiyTyWQt169fP4WFhdm0atq7d6/mz5+v0aNHq0aNGsrIyFB2drbd/djr2mVpYbNnz54iY7S0lL377rttlicnJysoKMimBZUk1a1b19ri0l11rlixQpI0ZMgQm3JDhgxRRkaG/vjjjyL3HxISolq1ahXosn6x06dPa8mSJbrzzjttWqYGBgYqMjKyyG2L0rhxY0myu//4+Hi9+uqrevPNNwuch6LUrl1bISEhxR5TYfu/4oorFBAQYFOuRYsWatu2bYFrJCkpSXv37lVSUpLD8eX3n//8R8uXL9dbb71V5NAQjgoPD1f16tWd3j45OVnVqlVTYGCgdZmfn59q1qxZ4LqrVauWrr76ausyHx8fDRo0SGfOnNGyZctKXKckHTt2zG633YsdOnRIvr6+dltGRURE2Fyj9vj4+FjvBSXtJj9z5kxt27ZNr7zyiv71r3/Z3b8z98pnn31WHTp00OOPP66MjAzl5ubq0UcfVaNGjfTvf/+72O0tz0V0dHSJ9+2MEydOaPLkybr66qvtdmd+4okndNVVV+mLL77QyZMnJcn6nmhpzZ6fr6+vatSoYf3/3XffVVpamr744gvVqlXLpmzNmjX1+eefKzU1Ve+8847Nur179+rYsWPFxn/o0CG1bdvW7r2ltC2VC2O5V/r5lbzzXePGjfXGG29oxowZWrx4sSTp448/1tatWzVx4kSbVqiF7bt169Yeuz7cKTU1VYMHD5a/v79+/PHHAvdrAKhoSEgCQCUzbdo03XnnnQoICNDQoUN14MABbdiwwaFtk5KSlJCQoGrVqtksnzNnjpo3b+5U4iE+Pl6xsbE2D0cSLq7QsGFD9e7dW2vXrlVycrJ1+cXxFPbIP06bRXp6umJjY3XkyBFNnTpVU6ZM0eWXX25NUFi2sZfQCw4O1pYtW2Q2myXljU8nSXXq1NE111yj4OBgBQcH68Ybb3Qo2WAZGy5/Fzl7LEnpi5OHffr0UXJysh555BHt2bNHR48e1aRJk/Trr79qzJgxbq0zMzNTvr6+Bb6QWb6cbtq0qcA+k5OTFRsbq7179+rll1/Wzp07dc011xQZ5w8//CCz2VwgTmfExcXp3Llz2rhxo+6//35Jsrv/1157TZGRkXrkkUeKrTMxMVExMTHasWOHHnzwQSUnJ9utMycnR7GxsTp16pQWLVqkV199VeHh4erevXuR9RuGobNnzxa4Rn777Te1bt26wNhsjvj777/19ttvq2/fvho9erTNuuzsbIdfX5bXgSv06dNHu3bt0muvvaaDBw/q0KFD+u9//6uNGzfqhRdesJbLzMy0+9q0d905WqckDR8+3GaYicI0atRIubm5pRqH0pIcy58Ek4q/186aNUuSdM899zi9b3v8/Pz0xRdfKDo6Wv/97381YcIEbd682aFkk1T48aSlpdm9bvKP75iSkuLQtZY/8T5//nzl5uZq+PDhhcY0fPhw5eTkaMGCBZJkHYpk2rRpdseXzG/27Nlq3LixrrzySrvre/XqpcaNGxcYr7l169ZFxmTRqFEjbdq0ye54s65iOW9nz57VmjVr9Mwzz6hGjRoFxk101DPPPKOOHTvqscce08GDB/X6669ryJAh1uE2ipKdna3jx48XuD5yc3PtPtf5h8go7f3I3muqNPeukSNHas+ePZo0aZKaNWvmVB0AUK54u4kmAMC1iuqybelGunjxYsMwDMNsNhsNGjQwnnrqqQJlJRkjRowwYmJijHPnzhkbN240brjhhgJd5ZKSkgxJxu23316gjoSEBCMmJsb6SEtLs66zdHmy97jkkkvsxu/KLtsWli6z27Zts9nGkYe9Lrxjx461KXPNNdfYdFWPiYkxTCaTMWLECJvt9u7da93G0r1v1KhRhiSjRo0axg033GD8+OOPxrvvvmuEhYUZzZo1s+nKZs+IESMMX19fY//+/YWWycnJMerUqWN0797d7rqRI0ca/v7+1th8fX2NiRMnFrlfV9T53nvvGZIKdB196aWXDElGv379CtTdt29fa50BAQHGI488YtPF1Z4uXboYdevWNXJzcwst42iX7cDAQOv+a9SoUaD7vWEYxrZt2wxfX19r99Xiuv5dcskl1jrDwsKMV1991W6sa9asKfAacqRL83fffWe3a/yUKVNK3E3dMPK6hNatW9eIjIy0263e0i3XkYe97p2G4VyX7ZSUFGPQoEGGyWSy1h8SEmL8/vvvNuWefPJJw8fHxzhy5IjN8iFDhhiSjJEjR5a4TsPI60LqyMfuM2fOGLVq1TIkGa1atTIeffRRY/r06UZiYmKBspbus5b768GDB43//e9/hslksuky7ui9tlOnTkaVKlWKjdGeorpsW1he92FhYTbdcy0s18bXX39txMTEGKdOnTLmzp1rNG7c2DCZTMaGDRsMw/iny3Zhj/zDFNx7770OXWv5Y3/66acNScaWLVsKPZbNmzcbkoxnn33WMIy891LLc1ynTh1j6NChxqeffmocPXrUZrvExERDknHbbbcVea5uvfVWQ5KRnJxsXXZxnIVZtGiR4evra/j6+hqXX3658cILLxgLFy40srKyCpQt6v2xsC7b9s5f/fr1jU2bNhUaU1Fdti3WrVtn+Pj4GNWrVzeqVq1qnDlzpkCZRo0aGddff731mt+2bZv1tfnkk09ay1meC3uP/ENeOHs/Kuo1ZXmU9LOI5V58//33F1oGACoaJrUBgEpk2rRpqlOnjq666ipJebM+Dh48WN9//73ee+89+fr62pSfPHmyJk+ebP3f399fL7zwgs0kMJaWhfYmS+jTp491dkwpr6va888/b1Nm5syZioiIsFkWGhrq5BGWnCXu8+fPW5dZuo0Vp23btgWWDR06VF27dlVMTIzmzJmjs2fPKj093bq+Zs2aGjRokKZOnarWrVvrjjvu0MmTJ/Xkk0/K399f2dnZ1vKWSQEiIyM1d+5c68QPDRo00NChQzV9+vRCB8WfPn26Jk+erBdeeEEtWrQo9Bj++usvnT171maSGAtfX181a9ZMffv21cCBAxUUFKQZM2boySefVGRkpG6//Xa31XnXXXfpzTff1AMPPKBPP/1ULVq00KJFi/TZZ59Jks05tRg3bpyee+45HT9+XFOnTlVWVlaRrZX279+vTZs26ZlnnrGZVMNZ8+fPV0ZGhvbs2aPvv//e7mQ1o0aN0o033mgzgU5RpkyZouTkZB0+fFhTpkxRenq6cnNzC8Tbpk0bLV68WKmpqVq9erX+/PPPArNsX2zv3r164okndPnll+vee++1WXfffffpvvvucyhGC8MwNHz4cJ09e1YLFy602z20Y8eODr++StNl/mKBgYFq2bKlBgwYoDvvvFO5ubn64osvNGzYMC1evNjaRfrBBx/UpEmTNGjQIH3wwQeqU6eOfvrpJ2tL0fzXnaN1SnJ4RvA6depo27ZtevPNN/Xbb79p0qRJmjRpkgICAvTqq6/q1VdftRnqITU1tUC33yuuuMJuC8vi7rXJyckKDw93KE5nvP322/rll1+UlpamDz74oNByDzzwgM3/tWrV0tSpU9W1a1eb5Q8//LAGDhxYYPs2bdpY/37hhRc0bNiwYmPL3+rf8l5Q1LmwrLOUNZlMWrhwof7v//5P33//vWbMmKEZM2boiSee0KBBg/T555+ratWqDtWdf33+58QwjGKPQ8qbxG3NmjUaO3asFi5cqDVr1uidd95RrVq19NVXX+nWW291qJ7CBAUFafbs2ZLyJuc6cuSI3n//fd10001avny5WrZs6VS93bt316OPPqrPPvtMEydOtJngJr9FixbZXPO+vr665557NH78eJtyjRs31pdffllg+wYNGlj/Lu39yN5rSpJD11x++/fv12OPPaZWrVoVmAkdACo0b2dEAQCuVVgLyZycHKNu3brGkCFDjAMHDlgflslD8k84YBiGtRXH4sWLjblz5xpvvPGGERAQYNNCyDD+afFhr4Xk2rVrjcWLFxvff/+9Idm2rPT2pDYW9lpIutJDDz1kREVF2bQOTUxMtLaAsTyGDRtm3HnnnYYk62QElufyP//5j02dOTk5hp+fX6EtKZYvX24EBQUZffv2NbKzs4uMb/jw4Yavr6/d1ihjx441IiMjjfPnz9ss79Onj1GvXr1C63ZVncuWLTMaNmxoPUcRERHWiXqKa2GUmZlptG3b1ujfv3+hZV5//XVDkrFx48Yi63JmUpuDBw8aQUFBNpNi/PDDD4a/v7+xb98+67KSvA7i4+ONOnXqGM8991yxZadNm2b4+PgYW7dutbv+9OnTRtOmTY2oqCjr5CelZWkdPGbMGJfUVxhnWkg+8sgjRseOHW1al2ZlZRktWrQo0JL3559/NmrUqGG97iIjI42JEycakmxak5ekTmeYzWZj3759xscff2zUr1/fkGwnqLr33nuNoKAgY/HixcbixYuN5cuXG8ePHy9Qj6PXmLtbSBpG0ZONWFqrvf7668bixYuNv//+29i+fXuB+4y7J7UpSQvJV155xe76U6dOGTNmzDAuu+wyQ5J10qiStpBMSkpy9jAMw8i7D65fv94YM2aMERQUZPj7+xu7du2yri/q/dHyOlu6dKl1WWGT2hw/ftwICgoy7rzzTrt1OdJC0jD+aZltaQ17sUaNGhk9evQwFi9ebPz555/G6tWr7U7eU54mtcnIyDA6duxoBAUFue1zCACUVbSQBIBK4u+//9bp06f1ww8/2EycYjFt2rQCrbYaNGiga6+9VpJ00003qWbNmho5cqSuuuoq3XnnnZKkKlWqqG7dunbHq7KMKVnSyRU8aefOnfL19VWTJk2syyxjLxanSpUqxU7uMmDAAH355Zdavny5+vbta93ujz/+0LFjx3TkyBE1atRIjRo10hVXXKFatWpZJyOoV6+eJBVoKWKZJCEhIaHA/rZt26Zbb71V7dq10y+//FLkJAPp6en67bffdO2119ptjfLZZ5/p6quvLtD69dZbb9Wzzz6rI0eOqHnz5m6rs1evXjp8+LB27Nih1NRUdezYUadOnZKkYlvhBAQE6NZbb9W4ceOUnp5u93maPn26LrnkEnXp0qXIupzRrFkzderUSdOmTbNOjDF69GgNHDhQAQEB1teEZQy/48ePKysry/qc21OtWjVdffXVmjZtmv7v//6vyP3feeeduueee/TDDz+oY8eONuuSkpJ04403KjExUStWrChyn45as2aNXnvtNV1xxRV68803Cy2XlZWl+Ph4h+qsVatWgVbbzsjKyrK2Fs7fstTf31833nijJkyYoKysLOt4pQMGDNCtt96qbdu2KTc3V507d7a2cLRcdyWt0xkmk0ktW7ZUy5YtdfPNN6tFixaaNm2aTatoX19f6z26tFq1aqUtW7bo+PHjXp2ArH379i47pqSkJLutqS8WEBBgnTTJ0sJy+/btuvTSS+2W3759uySpadOmdtfXrVtXQ4YMUf/+/dW2bVv99NNP+uabb6zvl5btC7N9+3bVr1/fbuu7kggICFC3bt3UrVs3tWzZUvfff79+/vln62RCgYGBhZ6ftLQ0SSp2IiUp77PCJZdcouXLl5cqXkfUrFnTZdeHN+5HF3v22We1bds2ffrpp+rQoYPL6weAsoyEJABUEtOmTVPt2rX16aefFlj366+/WrsHFpVge+SRR/TBBx/o1Vdf1R133GHtOnjzzTfrq6++0vr164udRKMsOXbsmJYtW6bLL7/cpgudvZnC7ZkyZUqx3VotX/bszVbcsGFDNWzYUFJeYmrTpk3q37+/db0lUWaZydUiKytLsbGxBbpqHjp0SDfccINq166tefPm2e1Gn9+sWbN0/vz5Qid0OXv2rHJzcwsst8z0ba87tKvr9PX1tUkKWCb6ceQLaXp6ugzD0Pnz5wtc1+vWrdPBgweLTJ6VVnp6us3ER8ePH9f06dM1ffr0AmU7d+6sjh07auvWrcXW6cjM15mZmTKbzQXKZmRk6JZbbtH+/fv1559/2nRvdVZCQoKGDBmisLAwTZ8+vcgk+OrVq61DRhQnOjraOlt4acTFxSknJ6fQ685sNhdYZ0nkWFx83TlTZ2k0bdpU1apV0+nTp11W58VuueUWzZgxQ99//32xk1aVF0899ZSmTp1abLnevXtbk8433nijfH199d133xU6icy3336rgIAA3XbbbUXW6+/vrw4dOujAgQOKjY1VZGSk+vXrpy+//FIrV660O5v5ihUrdOTIEYcmvSoJS5f3/NdQo0aNtG/fPrvlLcstE/YUJycnp9hhIsoab9yP8ps5c6Y+++wz3XnnnXr88cddWjcAlAckJAGgEkhPT9evv/6qgQMHasCAAQXW16tXTzNmzNCsWbM0ePDgQuvx8/PTc889p8cff1x//PGHdby/F154QdOnT9cDDzygv/76q0DLOMPBsa88KT4+XkOHDlVubq5eeeUVm3XOjCEZExNTIEEo5Y3DaTKZ1Llz5yLrGjNmjHJycvTMM89Yl/Xp00e1a9fWtGnT9PLLL1tbqnzzzTfKzc3VddddZy175swZXX/99fLx8dHChQvtxnKx6dOnKyQkRHfccYfd9S1bttTixYsVFxdnncE0NzdXP/30k8LDw+3OAuqOOi1iYmI0fvx4dejQwSYhee7cuQLjFSYmJmrmzJmKioqyO5ahJSl41113Fbo/R+Tk5Oj8+fMFZp5fv369duzYYVO/vRmrf/jhB/3444/69ttvbcY2s3dMR44c0V9//WUzll5iYqJCQ0Pl7+9vU/arr76SJJuyubm5Gjx4sNasWaM//vhDl19+uRNHXNADDzygY8eOaebMmcUmLzwxhuSxY8eUlpamVq1aSZJq166tqlWr6rffftObb75pbbWYkpKi2bNnq1WrVkX+EHPgwAFNmjRJ/fr1s7aQLG2dhVm3bp3atWtXYBzd9evXKy4uTj179ixxnY4aMGCAxo4dq7ffflt9+vQpcH2cP39e48aN09tvv+22GFzNmTEkGzRooBEjRuiLL77QxIkT9dhjj9mUnTRpkv7++289+eST1nvYgQMHFBgYaP2BySIxMVFr1qxRtWrVrPfk0aNH6/vvv9cjjzyi5cuX28wOHR8fr0cffVQhISEFZqh31JIlS9SnTx+bsUYlad68eZKkSy65xLrspptu0ieffKJNmzbZtBRPTEzUtGnTdOmllzr0Oty/f7/27dvnltbm7uStMW2lvPv5gw8+qEaNGlnv1wBQ2ZCQBIBKwNJqrbDB7C+77DLVqlVL06ZNKzIhKeVNdvH6669r/Pjx1oRkixYtNH36dA0dOlSXXHKJ7r77bnXs2FGGYSg6OlrTp0+Xj4+PTcLF4pdffrHbku+6664rdFD7ktq/f7++//57GYah5ORkbdu2TT///LNSUlL0/vvv64YbbrAp70x3sLffflurVq3SDTfcoIYNGyo+Pl4zZ87Uhg0b9OSTT9p0bR43bpx27typHj16yM/PT7///rsWLVqkt956y6ZVVmBgoN59913de++96tWrl+655x4dO3ZMH330ka688kprt3lJuuGGG3T48GG98MILWrlypVauXGldV6dOHZvkpZT3xXf+/Pnq379/oS0pX3rpJQ0bNkw9evTQww8/rODgYM2YMUObNm3SW2+9VSAJ5uo6e/furcsvv1zNmzfXmTNn9MUXXyglJUVz5syx6SZ74403qkGDBurRo4dq166tY8eOacqUKTp16pR+/PHHAjHk5ubqxx9/1GWXXVZkAnTChAlKTEy0dhOfPXu2Tpw4IUl68sknVaVKFaWkpCgqKkqDBw9W27ZtFRoaqh07dmjKlCmqUqWKXnvtNWt99iYBsrSIvPHGG1WzZk3r8vbt2+uaa67RpZdeqmrVqunAgQOaPHmysrOzNW7cOGu5pUuXatSoURowYIBatGihrKwsrVixQr/++qu6du1qk4x57rnnNGvWLN1yyy2Kj4/X999/bxNL/rLffPON7r///mJbAU+aNEm///67OnTooLS0tAJ1Wlhez9WqVXO6u+Vbb70lSdq1a5ck6bvvvrNe56+++qq13PDhw7Vs2TLrDyG+vr56/vnn9eqrr+qyyy7T8OHDlZubq8mTJ+vEiRMFYm7Tpo0GDhyohg0bKjo6WhMnTlT16tU1adIka5mS1tmnTx+bmArz3Xffadq0abrjjjvUpUsXBQQEaM+ePfr6668VFBRkd6IoRxV3r/X399evv/6qa6+9Vr169dKgQYPUs2dP+fv7a9euXZo+fbqqVatWZhKSmzdvtnu9NWvWzJpMbdOmjVOtgN9//33t3btXjz/+uBYsWGB9j1i4cKH++OMPXX311Xr33Xet5bdt26a77rpLN954o6688kpVr15dJ0+e1NSpU3Xq1Cl9+OGH1u6+LVq00NSpU3X33Xerffv2GjFihJo0aaIjR45o8uTJio2N1YwZMwrcm0wmk01LzsI8+eSTSktL0x133KFWrVopKytLq1ev1o8//qjGjRvr/vvvt5Z96aWX9PPPP6tXr1565JFH1KpVK506dUrffPONTp8+rSlTphSoPycnx3reLZPaTJo0SWaz2doVvCxISkoq9H5kudeV5n5UWkOGDFFiYqLuvvtuzZ07126ZsLCwQiePA4AKwZsDWAIAXM/epDa33HKLERQUZKSmpha63X333Wf4+/sbsbGxhmEUPdj9G2+8YXdSiYMHDxqPPfaY0bx5cyMoKMgIDg42WrVqZTz66KMFJtewDApf2MPehBXOTmpjefj4+BhVq1Y1OnXqZDz11FM2g/uX1qJFi4x+/foZ9erVM/z9/Y3w8HCjZ8+expQpUwyz2WxTds6cOUb37t2N8PBwIyQkxLjsssuMn376qdC6Z8yYYXTs2NEIDAw06tSpY4wcOdJITk4u9DgvftibbGLSpEmGJGPWrFlFHteCBQuM3r17GzVr1jQCAgKM9u3bG5MmTbJb1tV1PvPMM0bTpk2NwMBAo1atWsZdd91lHDp0qEC5CRMmGP/617+MmjVrGn5+fkatWrWMW265xVi+fHmh+5dkfPzxx0XG2ahRo0LPqWVyhszMTOOpp54yOnToYERERBj+/v5Go0aNjBEjRhQ7gYNhFD45wr///W+ja9euRrVq1Qw/Pz+jXr16xpAhQ4zt27fblDt48KAxfPhwo2nTpkZwcLARFBRktG3b1vj3v/9tpKSk2JTt3bt3kddJfp988okhyViwYEGR8d97771F1lnU67mkHI3dcpwXmzZtmtG9e3ejatWqRnBwsNGjRw/jl19+KVBuyJAhRlRUlBEQEGDUq1fPePTRR42zZ8/ajcnROrt06WJERkYWe4zbt283Ro8ebXTu3NmoXr264efnZ9StW9cYOHCgsXnzZpuyhU0wcrGS3msTEhKM119/3Wjfvr0REhJiBAUFGe3atTPGjBljnD592u4+XDmpzc8//1xkHZZJbQp73HvvvcXG4YisrCzjww8/NLp06WKEhITY1J9/IiPDMIyzZ88a48aNM3r37m3UrVvX8PPzM6pVq2ZcffXVdq8Hw8h7rocOHWrUrVvX8Pf3NyIjI42hQ4caO3bsKFD2/PnzhiRjyJAhxcY9f/5844EHHjBatWplhIWFGQEBAUbz5s2NJ5980u51fOLECePBBx806tevb/j5+RnVq1c3+vXrZ6xdu7ZAWXuv94iICOOaa64x/vzzz0JjcuWkNhe/x9tTknudM1wxqY0j981GjRqVOlYAKMtMhlEG+9EBAADAawYNGqQjR45o/fr13g6l3Dt//ryqV6+uDz/8UE888YS3w4GTkpOT1bt3bx06dEjLly8vdMIbd5g3b5769eunbdu2qX379h7bLwAA7uRTfBEAAABUFoZhaOnSpdYu0iid5cuXq379+nrooYe8HQpKISIiQvPnz1fNmjV100036ejRox7b95IlSzRkyBCSkQCACoUWkgAAAAAAAAA8hhaSAAAAAAAAADyGhCQAAAAAAAAAjyEhCQAAAAAAAMBjSEgCAAAAAAAA8Bg/bwdQVpjNZp06dUrh4eEymUzeDgcAAAAAAAAoVwzD0Pnz51WvXj35+BTeDpKE5AWnTp1SVFSUt8MAAAAAAAAAyrXjx4+rQYMGha4nIXlBeHi4pLwTFhER4eVoAAAAAAAAgPIlOTlZUVFR1jxbYUhIXmDpph0REUFCEgAAAAAAAHBSccMhMqkNAAAAAAAAAI8hIQkAAAAAAADAY0hIAgAAAAAAAPAYxpAEAAAAAACoQAzDUE5OjnJzc70dCioYX19f+fn5FTtGZHFISAIAAAAAAFQQWVlZOn36tNLS0rwdCiqokJAQ1a1bVwEBAU7XQUISAAAAAACgAjCbzYqOjpavr6/q1aungICAUrdkAywMw1BWVpZiYmIUHR2tFi1ayMfHudEgSUgCAAAAAABUAFlZWTKbzYqKilJISIi3w0EFFBwcLH9/fx09elRZWVkKCgpyqh4mtQEAAAAAAKhAnG21BjjCFdcXVygAAAAAAAAAjyEhCQAAAAAAAMBjSEgCAAAAAAAAbrZq1Sq1b99e/v7+uv3227V06VKZTCYlJiZ6OzSPIyEJAAAAAAAAr4qJidFjjz2mhg0bKjAwUJGRkerbt69WrVplLdO4cWOZTCaZTCaFhoaqc+fO+vnnn23qSU9PV/Xq1VWzZk1lZmYW2E/+OkJCQtS+fXt99dVXBcotWbJEN910k2rUqKGQkBC1adNGzz33nE6ePClJTiUTn332WV166aWKjo7WN9984/B2FREJSQAAAAAAAHhV//79tWXLFk2dOlX79+/XrFmz1KdPH8XFxdmUe/PNN3X69Glt2bJF3bp10+DBg7V69Wrr+pkzZ6pt27Zq1aqVfv/9d7v7stSxc+dODRs2TA899JDmz59vXf/555/r2muvVWRkpGbOnKndu3dr0qRJSkpK0nvvvef0MR46dEhXX321GjRooKpVqzpdT0VAQhIAAAAAAABek5iYqBUrVmj8+PG66qqr1KhRI3Xv3l1jxozRrbfealM2PDxckZGRatmypT799FMFBwdr9uzZ1vWTJ0/WsGHDNGzYME2ePNnu/ix1NG3aVC+++KKqV6+uxYsXS5JOnDihUaNGadSoUfr666/Vp08fNW7cWL169dJXX32l119/vcTHd+TIEZlMJsXFxemBBx6QyWSy20LyjTfe0KWXXmqz7MMPP1Tjxo0lSRkZGWrbtq0efvhh6/pDhw4pPDxcX3/9dYnj8iYSkgAAAAAAAPCasLAwhYWF6ffff7fbzbowfn5+8vf3V1ZWlqS85NyaNWs0aNAgDRo0SCtWrNDRo0cL3d5sNmvmzJlKSEhQQECAJOnnn39WVlaWXnjhBbvbONOyMSoqSqdPn1ZERIQ+/PBDnT59WoMHDy5xPUFBQZo2bZqmTp2qP/74Q7m5uRo2bJiuu+46PfDAAyWuz5v8vB0AAAAAAAAA3Gv79u3KyMjw2P6CgoLUoUMHh8r6+fnpm2++0UMPPaRJkyapc+fO6t27t4YMGVJoHVlZWXrvvfeUlJSkq6++WpL09ddf68Ybb1S1atUkSX379tWUKVP0xhtv2Gz74osv6tVXX1VmZqZycnJUvXp1Pfjgg5KkAwcOKCIiQnXr1nXyyAvy9fVVZGSkTCaTqlSposjISKfruvTSS/XWW2/pwQcf1JAhQ3T06FHNmTPHZbF6CglJAAAAAACACs7R5KC39O/fXzfffLNWrFihtWvXav78+XrnnXf01Vdf6b777rOWsyQTMzIyFBYWpnHjxunmm29Wbm6upk6dqo8++shadtiwYXr++ef1+uuvy8fnn07Co0eP1n333afTp09r9OjRevzxx9W8eXNJkmEYMplMHjtuZzz33HP6/fffNWHCBM2fP181atTwdkglRpdtAAAAAAAAeF1QUJCuu+46vfbaa1q9erXuu+8+/fvf/7YpM3r0aG3dulUnTpxQQkKCXnzxRUnSwoULdfLkSQ0ePFh+fn7y8/OztiD866+/bOqoWbOmmjdvriuvvFI///yzRo0apd27d0uSWrZsqaSkJJ0+fdozB52Pj4+PDMOwWZadnV2g3Llz57R//375+vrqwIEDngrPpUhIAgAAAAAAoMxp06aNUlNTbZZZkomWLtAWkydP1pAhQ7R161abx5AhQwqd3EbKG99x8ODBGjNmjCRpwIABCggI0DvvvGO3fGJiYukPrBC1atXSmTNnbJKSW7duLVDugQceUPv27TV16lS9+OKL2rNnj9tiche6bAMAAAAAAMBr4uLiNHDgQD3wwAPq0KGDwsPDtXHjRr3zzju67bbbit0+JiZGs2fP1qxZs9SuXTubdcOHD9cdd9yh+Ph4Va9e3e72Tz31lNq1a6eNGzeqa9eu+uCDDzRy5EglJydr+PDhaty4sU6cOKFvv/1WYWFheu+996zb7tixQ+Hh4db/TSaTOnbs6NR56NOnj2JiYvTOO+9owIABWrBggebPn6+IiAhrmU8//VRr1qzR9u3bFRUVpblz5+ruu+/W2rVrrRPzlAe0kAQAAAAAAIDXhIWFqUePHvrggw/Uq1cvtWvXTq+99poeeughTZgwodjtv/32W4WGhuqaa64psO6aa65RcHCwvv/++0K3b9Omja6//nq9/vrrkqTHH39cixYt0smTJ3XHHXeoVatWevDBBxUREaHnn3/eZttevXqpU6dO1keXLl1KePT/aN26tT777DN9+umn6tixo9avX2+zv71792r06NH67LPPFBUVJUn67LPPFBsbq9dee83p/XqDybi4c3ollZycrCpVqigpKckm8wwAAAAAAFAeZGRkKDo6Wk2aNFFQUJC3w0EFVdR15mh+jRaSAAAAAAAAADyGhCQAAAAAAAAAjyEhCQAAAAAAAMBjSEgCAAAAAAAA8BgSkgAAAAAAAAA8hoRkJcOk6gAAAAAAAPAmEpKVzIIFC5SQkODtMAAAAAAAAFBJkZCsZHJycpSTk+PtMAAAAAAAAFBJkZAEAAAAAAAA4DEkJAEAAAAAAIAKYunSpTKZTEpMTHR4m8aNG+vDDz90W0wXIyEJAAAAAAAAr4qJidFjjz2mhg0bKjAwUJGRkerbt69WrVplLdO4cWOZTCaZTCaFhoaqc+fO+vnnn23qSU9PV/Xq1VWzZk1lZmYW2E/+OkJCQtS+fXt99dVXBcotWbJEN910k2rUqKGQkBC1adNGzz33nE6ePCnJuaQf/kFCEgAAAAAAAF7Vv39/bdmyRVOnTtX+/fs1a9Ys9enTR3FxcTbl3nzzTZ0+fVpbtmxRt27dNHjwYK1evdq6fubMmWrbtq1atWql33//3e6+LHXs3LlTw4YN00MPPaT58+db13/++ee69tprFRkZqZkzZ2r37t2aNGmSkpKS9N5777nl+CsbEpIAAAAAAAAVlWFIqaneeRiGQyEmJiZqxYoVGj9+vK666io1atRI3bt315gxY3TrrbfalA0PD1dkZKRatmypTz/9VMHBwZo9e7Z1/eTJkzVs2DANGzZMkydPtrs/Sx1NmzbViy++qOrVq2vx4sWSpBMnTmjUqFEaNWqUvv76a/Xp00eNGzdWr1699NVXX+n111936mmwtKhcuHChOnXqpODgYF199dU6d+6c5s+fr9atWysiIkJ33XWX0tLSrNtlZmZq1KhRql27toKCgvSvf/1LGzZssKl73rx5atmypYKDg3XVVVfpyJEjBfa/cuVKXXnllQoODlZUVJRGjRql1NRUp47FFUhIAgAAAAAAVFRpaVJYmHce+RJrRQkLC1NYWJh+//13u92sC+Pn5yd/f39lZWVJkg4dOqQ1a9Zo0KBBGjRokFasWKGjR48Wur3ZbNbMmTOVkJCggIAASdLPP/+srKwsvfDCC3a3qVq1qsPx2fPGG29owoQJWr16tY4fP65Bgwbpww8/1PTp0zV37lwtWrRIn3zyibX8Cy+8oJkzZ2rq1KnavHmzmjdvrr59+yo+Pl6SdPz4cd1555265ZZbtHXrVj344IN66aWXbPZ56NAh3XDDDerfv7+2b9+uH3/8UStXrtTIkSNLdSylQUISAAAAAAAAXuPn56dvvvlGU6dOVdWqVdWzZ0+9/PLL2r59e6HbZGVlaezYsUpKStLVV18tSfr666914403qlq1aqpevbr69u2rKVOmFNj2xRdfVFhYmAIDAzVgwABVq1ZNDz74oCTpwIEDioiIUN26dd1yrG+99ZZ69uypTp06acSIEVq2bJkmTpyoTp066corr9SAAQO0ZMkSSVJqaqomTpyod999VzfeeKPatGmjL7/8UsHBwdbWnxMnTlSzZs303nvv6ZJLLtHdd9+t++67z2afY8eO1d13362nn35aLVq00BVXXKGPP/5Y3377rTIyMtxynMUhIQkAAAAAAFBRhYRIKSneeYSEOBxm//79derUKc2aNUs33HCDli5dqs6dO+ubb76xKWdJJoaEhGj8+PEaN26cbr75ZuXm5mrq1KkaNmyYteywYcP0zTffyGw229QxevRobd26VX///bd69OihDz74QM2bN5ckGYYhk8nk/PkuRocOHax/16lTRyEhIWratKnNsnPnzknKa9mYnZ2tnj17Wtf7+/ure/fu2rNnjyRpz5496tGjh80+Lr/8cpv/t23bpm+++cbaEjUsLEx9+/aV2WxWdHS0y4/REX5e2SsAAAAAAADcz2SSQkO9HYVDgoKCdN111+m6667Ta6+9pgcffFD//ve/bVr8jR49Wvfdd5/CwsJUp04da/Jw4cKFOnnypAYPHmxTZ25urv766y9dd9111mU1a9ZU8+bN1bx5c/38889q3769unbtqjZt2qhly5ZKSkrS6dOn3dJK0t/f3/q3yWSy+d+y7OIEammlpKTokUce0ahRowqsa9iwoUv35ShaSAIAAAAAAKDMadOmTYGJVyzJxMjISJuWjJMnT9aQIUO0detWm8eQIUMKndxGkqKiojR48GCNGTNGkjRgwAAFBATonXfesVs+MTGx9AfmoGbNmikgIECrVq2yLsvOztaGDRvUpk0bSVLr1q21fv16m+3Wrl1r83/nzp21e/duaxI2/8Mydqan0UISAAAAAAAAXhMXF6eBAwfqgQceUIcOHRQeHq6NGzfqnXfe0W233Vbs9jExMZo9e7ZmzZqldu3a2awbPny47rjjDsXHx6t69ep2t3/qqafUrl07bdy4UV27dtUHH3ygkSNHKjk5WcOHD1fjxo114sQJffvttwoLC9N7771n3XbHjh0KDw+3/m8ymdSxY0cnz4St0NBQPfbYYxo9erSqV6+uhg0b6p133lFaWppGjBghSXr00Uf13nvvafTo0XrwwQe1adMmu93cL7vsMo0cOVIPPvigQkNDtXv3bi1evFgTJkxwSawlRUISAAAAAAAAXhMWFmYdy9EybmJUVJQeeughvfzyy8Vu/+233yo0NFTXXHNNgXXXXHONgoOD9f3339vtsizltcS8/vrr9frrr2vevHl6/PHH1bJlS/3f//2f7rjjDqWnp6tx48bq16+fnn32WZtte/XqZfO/r6+vcnJySnD0RRs3bpzMZrPuuecenT9/Xl27dtXChQtVrVo1SXldrmfOnKlnnnlGn3zyibp3767//e9/euCBB6x1dOjQQcuWLdMrr7yiK6+8UoZhqFmzZgW6t3uSyTAMw2t7L0OSk5NVpUoVJSUlKSIiwtvhuM3s2bN12WWXqVatWt4OBQAAAAAAuFBGRoaio6PVpEkTBQUFeTscVFBFXWeO5tcYQxIAAAAAAACAx5CQBAAAAAAAAOAxJCQBAAAAAAAAeAwJSQAAAAAAAAAeQ0ISAAAAAAAAgMeQkAQAAAAAAADgMSQkKyGTyeTtEAAAAAAAAFBJkZAEAAAAAAAA4DEkJAEAAAAAAAB4DAnJSsgwDG+HAAAAAAAA4HZLly6VyWRSYmKiW/fTp08fPf30027dh7OcOQeNGzfWhx9+6LaYSEgCAAAAAADAq+677z6ZTCaZTCb5+/urSZMmeuGFF5SRkeHt0OAGft4OAJ7HpDYAAAAAAKCsueGGGzRlyhRlZ2dr06ZNuvfee2UymTR+/Hi37TM3N1cmk0k+PrTZ8yTONgAAAAAAQAVlGFJqqnceJR0xLjAwUJGRkYqKitLtt9+ua6+9VosXL7auN5vNGjt2rJo0aaLg4GB17NhRv/zyi00d8+bNU8uWLRUcHKyrrrpKR44csVn/zTffqGrVqpo1a5batGmjwMBAHTt2TAkJCRo+fLiqVaumkJAQ3XjjjTpw4IDNtqtWrVKfPn0UEhKiatWqqW/fvkpISLB7LHPnzlWVKlU0bdo0u+st3agXLlyoTp06KTg4WFdffbXOnTun+fPnq3Xr1oqIiNBdd92ltLQ063aZmZkaNWqUateuraCgIP3rX//Shg0bSnQOJGnlypW68sorFRwcrKioKI0aNUqpqal2Y3UHEpKV3Pnz5xUdHe3tMAAAAAAAgBukpUlhYd555MujldjOnTu1evVqBQQEWJeNHTtW3377rSZNmqRdu3bpmWee0bBhw7Rs2TJJ0vHjx3XnnXfqlltu0datW/Xggw/qpZdesnNO0jR+/Hh99dVX2rVrl2rXrq377rtPGzdu1KxZs7RmzRoZhqGbbrpJ2dnZkqStW7fqmmuuUZs2bbRmzRqtXLlSt9xyi3JzcwvUP336dA0dOlTTpk3T3XffXeRxvvHGG5owYYJWr16t48ePa9CgQfrwww81ffp0zZ07V4sWLdInn3xiLf/CCy9o5syZmjp1qjZv3qzmzZurb9++io+Pd/gcHDp0SDfccIP69++v7du368cff9TKlSs1cuRIB58dFzBgGIZhJCUlGZKMpKQkb4fiVrNmzTJiYmKs/x8+fNiYM2eOFyMCAAAAAACukJ6ebuzevdtIT0+3LktJMYy8toqef6SkOB77vffea/j6+hqhoaFGYGCgIcnw8fExfvnlF8MwDCMjI8MICQkxVq9ebbPdiBEjjKFDhxqGYRhjxowx2rRpY7P+xRdfNCQZCQkJhmEYxpQpUwxJxtatW61l9u/fb0gyVq1aZV0WGxtrBAcHGz/99JNhGIYxdOhQo2fPnoXG37t3b+Opp54yJkyYYFSpUsVYunRpkce7ZMkSQ5Lx559/WpeNHTvWkGQcOnTIuuyRRx4x+vbtaxiGYaSkpBj+/v7GtGnTrOuzsrKMevXqGe+8847D52DEiBHGww8/bFNmxYoVho+Pj/XaadSokfHBBx/Yjd3edWbhaH6NMSQBAAAAAAAqqJAQKSXFe/suiauuukoTJ05UamqqPvjgA/n5+al///6SpIMHDyotLU3XXXedzTZZWVnq1KmTJGnPnj3q0aOHzfrLL7+8wH4CAgLUoUMH6/979uyRn5+fzbY1atTQJZdcoj179kjKayE5cODAIuP/5ZdfdO7cOa1atUrdunVz6Jjzx1GnTh2FhISoadOmNsvWr18vKa9lY3Z2tnr27Gld7+/vr+7du1vjdOQcbNu2Tdu3b7fpTm4Yhsxms6Kjo9W6dWuHYi8NEpIAAAAAAAAVlMkkhYZ6OwrHhIaGqnnz5pKkr7/+Wh07dtTkyZM1YsQIpVzIqs6dO1f169e32S4wMLBE+wkODi7xhL/BwcHFlunUqZM2b96sr7/+Wl27dnVoH/7+/ta/LTOM52cymWQ2m0sUa3FSUlL0yCOPaNSoUQXWNWzY0KX7KgxjSAIAAAAAAKBM8fHx0csvv6xXX31V6enpNhPQNG/e3OYRFRUlSWrdurW1NaHF2rVri91X69atlZOTo3Xr1lmXxcXFad++fWrTpo2kvJaMf/31V5H1NGvWTEuWLNEff/yhJ598sqSHXKxmzZopICBAq1atsi7Lzs7Whg0brHE6cg46d+6s3bt3FziPzZs3txmz051ISAIAAAAAAKDMGThwoHx9ffXpp58qPDxczz//vJ555hlNnTpVhw4d0ubNm/XJJ59o6tSpkqRHH31UBw4c0OjRo7Vv3z5Nnz5d33zzTbH7adGihW677TY99NBDWrlypbZt26Zhw4apfv36uu222yRJY8aM0YYNG/T4449r+/bt2rt3ryZOnKjY2Fibulq2bKklS5Zo5syZevrpp116PkJDQ/XYY49p9OjRWrBggXbv3q2HHnpIaWlpGjFihMPn4MUXX9Tq1as1cuRIbd26VQcOHNAff/zh0UltSEgCAAAAAACgzPHz89PIkSP1zjvvKDU1Vf/973/12muvaezYsWrdurVuuOEGzZ07V02aNJGU19145syZ+v3339WxY0dNmjRJ//vf/xza15QpU9SlSxf169dPl19+uQzD0Lx586xdqFu2bKlFixZp27Zt6t69uy6//HL98ccf8vMrOBriJZdcor///lszZszQc88957oTImncuHHq37+/7rnnHnXu3FkHDx7UwoULVa1aNUmOnYMOHTpo2bJl2r9/v6688kp16tRJr7/+uurVq+fSWItiMgzD8NjeyrDk5GRVqVJFSUlJioiI8HY4bjN79mxdfvnlqlmzpiQpOjpau3fv1s033+zlyAAAAAAAQGlkZGQoOjpaTZo0UVBQkLfDQQVV1HXmaH6NFpIAAAAAAAAAPIaEJAAAAAAAAACPISEJAAAAAAAAwGNISEImk8nbIQAAAAAAAKCSqBAJydzcXL322mtq0qSJgoOD1axZM/33v/8V8/U4hvMEAAAAAEDFwfd8uJMrrq+Cc5OXQ+PHj9fEiRM1depUtW3bVhs3btT999+vKlWqaNSoUd4ODwAAAAAAwO38/f0lSWlpaQoODvZyNKio0tLSJP1zvTmjQiQkV69erdtuu00333yzJKlx48aaMWOG1q9fX+g2mZmZyszMtP6fnJzs9jgBAAAAAADcxdfXV1WrVtW5c+ckSSEhIQzTBpcxDENpaWk6d+6cqlatKl9fX6frqhAJySuuuEJffPGF9u/fr5YtW2rbtm1auXKl3n///UK3GTt2rP7zn/94MEoAAAAAAAD3ioyMlCRrUhJwtapVq1qvM2dViITkSy+9pOTkZLVq1Uq+vr7Kzc3V22+/rbvvvrvQbcaMGaNnn33W+n9ycrKioqI8EW6Zw68lAAAAAABUDCaTSXXr1lXt2rWVnZ3t7XBQwfj7+5eqZaRFhUhI/vTTT5o2bZqmT5+utm3bauvWrXr66adVr1493XvvvXa3CQwMVGBgoIcjBQAAAAAAcD9fX1+XJI4Ad6gQCcnRo0frpZde0pAhQyRJ7du319GjRzV27NhCE5L4B7NvAQAAAAAAwFN8vB2AK6SlpcnHx/ZQfH19ZTabvRRR2XT+/HlvhwAAAAAAAIBKrkK0kLzlllv09ttvq2HDhmrbtq22bNmi999/Xw888IC3QytTjh496u0QAAAAAAAAUMlViITkJ598otdee02PP/64zp07p3r16umRRx7R66+/7u3QypTCWowyqQ0AAAAAAAA8pUIkJMPDw/Xhhx/qww8/9HYoZRpjRQIAAAAAAMDbKsQYknBMYQlJEpUAAAAAAADwFBKSlQiJRwAAAAAAAHgbCclKhIQkAAAAAAAAvI2EZCVSWEKSSW0AAAAAAADgKSQkKxFLQpIEJAAAAAAAALyFhGQlYklI0nUbAAAAAAAA3kJCshJhlm0AAAAAAAB4GwlJAAAAAAAAAB5DQhJ2x5SMiYlRdHS0F6IBAAAAAABARUZCshJyZFIbEpIAAAAAAABwBxKSAAAAAAAAADyGhCQAAAAAAAAAjyEhCQAAAAAAAMBjSEgCAAAAAAAA8BgSkgAAAAAAAAA8hoQkAAAAAAAAAI8hIQkAAAAAAADAY0hIVnKGYXg7BAAAAAAAAFQiJCRRIvPmzVNGRoa3wwAAAAAAAEA5RUKykjOZTCUqn5ubq9zcXDdFAwAAAAAAgIqOhCQAAAAAAAAAjyEhWckxhiQAAAAAAAA8iYRkJVLS7tkAAAAAAACAq5GQBAAAAAAAAOAxJCQBAAAAAAAAeAwJyUqObtwAAAAAAADwJBKSlRyT2gAAAAAAAMCTSEgCAAAAAAAA8BgSkgAAAAAAAAA8hoQkAAAAAAAAAI8hIVkJnTt3TtnZ2d4OAwAAAAAAAJUQCclK6ODBg4qPj/d2GAAAAAAAAKiESEgCAAAAAAAA8BgSkgAAAAAAAAA8hoQkAAAAAAAAAI8hIQkAAAAAAADAY0hIVlKpqamKiYnxdhgAAAAAAACoZPy8HQC849SpU0pLS1Pz5s29HQoAAAAAAAAqEVpIAgAAAAAAAPAYEpKVlGEY3g4BAAAAAAAAlRAJyUrKZDJ5OwQAAAAAAABUQiQkAQAAAAAAAHgMCUkAAAAAAAAAHkNCEgAAAAAAAIDHkJBEAbm5ud4OAQAAAAAAABUUCUnYiI2N1cKFC70dBgAAAAAAACooEpKVSP6ZtQ3DsFsmJyeHFpIAAAAAAABwGxKSAAAAAAAAADyGhGQllb+1JAAAAAAAAOApJCQrqcK6bAMAAAAAAADuREKykqKFJAAAAAAAALyBhCQAAAAAAAAAjyEhCbtoQQkAAAAAAAB3ICFZSRU3hiRjTAIAAAAAAMAdSEgCAAAAAAAA8BgSkpXcrl277C6nyzYAAAAAAADcgYQk7KLLNgAAAAAAANyBhCQAAAAAAAAAjyEhCbvosg0AAAAAAAB3ICEJAAAAAAAAwGNISFYip0+ftv5dXAtIxpAEAAAAAACAO5CQBAAAAAAAAOAxJCRhF2NIAgAAAAAAwB1ISAIAAAAAAADwGBKSAAAAAAAAADyGhGQlZRiGsrKyvB0GAAAAAAAAKhkSkpWYvZm0GTsSAAAAAAAA7kRCEmXavHnzvB0CAAAAAAAAXIiEJGzYazXpTbm5ud4OAQAAAAAAAC5EQhIAAAAAAACAx5CQBAAAAAAAAOAxJCRhg0ltAAAAAAAA4E4kJCspEo8AAAAAAADwBhKSAAAAAAAAADymwiQkT548qWHDhqlGjRoKDg5W+/bttXHjRm+HVWaVtdm0AQAAAAAAUDn4eTsAV0hISFDPnj111VVXaf78+apVq5YOHDigatWqeTu0codEJQAAAAAAANypQiQkx48fr6ioKE2ZMsW6rEmTJl6MqOxjDEkAAAAAAAB4Q4Xosj1r1ix17dpVAwcOVO3atdWpUyd9+eWXRW6TmZmp5ORkm0dlcnFLSLPZrP3795OoBAAAAAAAgFtViITk4cOHNXHiRLVo0UILFy7UY489plGjRmnq1KmFbjN27FhVqVLF+oiKivJgxGVPTk6O9u3b5+0wAAAAAAAAUMFViISk2WxW586d9b///U+dOnXSww8/rIceekiTJk0qdJsxY8YoKSnJ+jh+/LgHI/Y+WkICAAAAAADAGypEQrJu3bpq06aNzbLWrVvr2LFjhW4TGBioiIgIm0dlwuQ1AAAAAAAA8IYKkZDs2bNnge7G+/fvV6NGjbwUUflCa0kAAAAAAAB4SoVISD7zzDNau3at/ve//+ngwYOaPn26vvjiCz3xxBPeDq1coLUkAAAAAAAAPKVCJCS7deum3377TTNmzFC7du303//+Vx9++KHuvvtub4cGAAAAAAAAIB8/bwfgKv369VO/fv28HQYKsWHDBrVp00ahoaHeDgUAAAAAAABeVCFaSKLsO3PmjNLT070dBgAAAAAAALyMhCSY1AYAAAAAAAAeQ0ISAAAAAAAAgMeQkASzbAMAAAAAAMBjSEgCAAAAAAAA8BgSknBKamqqt0MAAAAAAABAOURCEk5NavP333+7IRIAAAAAAABUdCQkAQAAAAAAAHgMCUkAAAAAAAAAHkNCEoXOss04kQAAAAAAAHA1EpIAAAAAAAAAPIaEJJya1AYAAAAAAABwBglJAAAAAAAAAB5DQhIAAAAAAACAx5CQRKGT2gAAAAAAAACuRkISAAAAAAAAgMeQkKykEhMTrX+bTKYiW0nm5uYqIyPDA1EBAAAAAACgoiMhiWIdOXJES5cu9XYYAAAAAAAAqABISAIA4CX79+9nHF8AAAAAlQ4JSUjK67YNAPCsffv2kZAEAAAAUOmQkIQkZtoGAAAAAACAZ5CQBAAAAAAAAOAxJCQhKW8cMwAAAAAAAMDdSEhCUt5M2gAAAAAAAIC7kZAEAAAAAAAA4DEkJAEAAAAAAAB4DAlJAAAAAAAAAB5DQhIlZjKZvB0CAAAAAAAAyikSkrBBshEAAAAAAADuREISNgzD8HYIAAAAAAAAqMBISKLESFoCAAAAAADAWSQk4RCSkAAAAAAAAHAFEpIAAAAAAAAAPIaEJGwUNqkNk90AAAAAAADAFUhIwq6DBw/a/E+XbQAAAAAAALgCCUmUGK0lAQAAAAAA4CwSkrBBS0gAAAAAAAC4EwlJAAAAAAAAAB5DQhI26I4NAAAAAAAAdyIhCQAAAAAAAMBjSEiixBhnEgAAAAAAAM4iIQkAAAAAAADAY0hIAgAAAAAAAPAYEpIoMSa+AQAAAAAAgLNISAIAAAAAAMBjsrOzFRcX5+0w4EUkJAEAAAAAAOAxZ86c0erVq70dBryIhCSKRRdtAAAAAAAAuAoJSRTLMAxvhwAAAAAAAMqZnTt3ejsElFEkJAEAAAAAAOBy0dHRdpfTExMkJFGsi28UZanFZGxsrA4cOODtMAAAAAAAAOAgEpIo1+Li4nTkyBFvhwEAAAAAAAAHkZBEidG0GgAAAAAAAM4iIYkyJz4+XkePHvV2GAAAAAAAAHADEpKwURbGhzx79qwOHjzo7TAAAAAAAADgBiQkYWP9+vVurd9sNis7O9ut+wAAAAAAAEDZRUISHnX48GGtXLnS22EAAAAAAADAS0hIwqPMZrNycnK8HQYAAAAAAAC8hIQkyiRm8gYAAAAAAKiYSEjCo8rCpDkAAAAAAADwHhKSKNLJkye1a9cub4cBAAAAAACACoKEJIqUmprq8X2azWaP7xMAAAAAAACe4eftAFC2ubqLtSNjQx4+fNil+wQAAAAAAGUH80aAFpLwKG8kOAEAAAAAAFB2kJBEkZiEBgDci/ssAAAAgMqGhCQAAAAAAAAAjyEhiSKVpuVOcnKytm/f7vB+aCUEAAAAAABQ8ZGQhEOcSRaeP39eR48edajsvn37tHnz5hLvAwDKu5SUFG+HAAAAAAAeRUISRXJnq8WEhATr3+np6crIyHDbvuA5hmEoPT3d22EA5cbhw4e9HQIAAAAAeBQJSRTJkpB0x2zWK1eutNkPM2ZXDImJifrzzz+9HQYAAAAAACijSEjCIe4e39EwDPn4cDlWBIwFCgAAAAAAikIGCGVCUUksElzlW3JysrdDAAAAAAAAZQgJSRTJU8lAumxXPOnp6Vq4cKGWLVvm7VAAAAAAAEAZQkISZQJdtiuenJwcZWVleTsMoMyjFTgAAACAyoYMEIpEC0kAAAAAAAC4EglJFImEJJzF8wk4htcKAAAAgMqmQiYkx40bJ5PJpKefftrboZQLZeHLsNlsdjoOujuWTWXhugIAAAAAAGVPhUtIbtiwQZ9//rk6dOjg7VAqBJJ9AOBe3GcBAAAAVDYVKiGZkpKiu+++W19++aWqVavm7XBQCFrOAQAAAABQeZEXQIVKSD7xxBO6+eabde211xZbNjMzU8nJyTaPysrTN4L8rYEOHTrk0X3Dc3iDAQAAAAAA9lSYhOQPP/ygzZs3a+zYsQ6VHzt2rKpUqWJ9REVFuTnC8sndXQnj4+PdWj8AAAAAAADKlgqRkDx+/LieeuopTZs2TUFBQQ5tM2bMGCUlJVkfx48fd3OUZVdZb8nG+GrlU1m/rgAAAAAAgHf4eTsAV9i0aZPOnTunzp07W5fl5uZq+fLlmjBhgjIzM+Xr62uzTWBgoAIDAz0dKmSbqCLZWHGRkAQAAAAAAPZUiITkNddcox07dtgsu//++9WqVSu9+OKLBZKRsOWuxJGjycaDBw8qISFBdevWdUscAAAAAACg9FJSUhQQEKCAgABvh4JyrkIkJMPDw9WuXTubZaGhoapRo0aB5fC84hKTBw8elNls9lA0AAAAAADAGWvXrlVUVJQuueQSb4eCcq5CjCEJ9ykrY2sahqGsrCxvh4ESoDs+AAAAAACwp0K0kLRn6dKl3g6h3CgrY/0VFcfJkye1fft23XTTTQ5vA/fKzc1VZmamQkJCvB0KAAAAAAAoR0qckJw1a1aJd3LdddcpODi4xNvBM3JyclxW14kTJ9SgQYMSbZOdnS2p6BZ1ZrNZubm5pYoNrnXixAlt375dt9xyi7dDAQAAAAAA5UiJE5K33357icqbTCYdOHBATZs2Lemu4CGWhKArbNmypciEZFFJx+zsbMaSLGdc0UI1IyNDQUFBLogGAAAAAACUB06NIXnmzBmZzWaHHnTnrHjcNTbguXPndPDgQbfU7Q7Z2dmMk+iglJQUnTp1SikpKQXWLV682AsRAQAAAAA8yZInAiQnEpL33ntvibpfDxs2TBERESXdDSqpwm5OF7fES01N9fokNwsXLtS5c+e8GkN5sWTJEm3fvl1nzpzxdigAAAAAAC/YsmWLdu/e7e0wUEaUuMv2lClTSlR+4sSJJd0FUKx169apbt268vPz3rxMhmFUqBaS2dnZMplMLjunF58bfgkDAAAAgMorMzOTiWlh5VSXbcAZFSl5VxFt2rRJO3fudFv9TEoEAAAAAJCKn49g+/bt2rVrl4eigTe4JCG5bt06V1SDCsaRLtWZmZnFliGR6RmM5wEAAAAAKAvS0tKUnp7u7TDgRi5JSA4cONAV1aCcKW52bsuvGZako71fQBITE53at2EYbmvqnZmZ6dKZxx1x+vRpJSQkeHSfhcnOztbSpUu9HQYAAAAAAKigHB4sbtCgQXaXG4ah+Ph4lwWE8mPBggW65ZZbii1X3mZR3rBhg8LCwnTppZd6bJ/79+9XjRo1VK1aNY/t0x6TyaScnBydP3/eLfXT2hUAAAAAKq+SNCxivMmKzeGE5J9//qnvvvtOYWFhNssNw9Dy5ctdHhjKr7S0NIWEhJS6HmZk9qzCkoWbNm1Sly5dPBwNUHmQqAcAAABQ2TickOzTp4/Cw8PVq1evAus6dOjg0qBQfsybN0833XSTzbK//vpL1157bYGycXFxJar70KFDDpVz9Zd5foWxderUKacSkiRZAAAAAACAPQ4nJH/99ddC15W3LrlwnZLMnLx//361aNHCJfsl2QUAAAAAAFA+OT2pDd1p4W3uGudQykt47tmzR/v373fbPgBAolU2AAAAKoeSNCyiEVLF53RC8vrrr3dlHECR7H1hd3dSPDk5WcnJyW7dR1nkzI3fMpN6STEhFgAAAAAAlY/TCUmy1ShKRbg+KsIxlJSzLbUWLVrkULnExESb/1etWuXU/oCKpDLeawAAAABUbk4nJOliVrl48wuzvX07G090dLTS0tKKLMO17T4M9QAAAAAAAJxOSKKcSUtTk9mzFVxGEkJr1qzxyn537typhIQEm2UHDhzQ5s2bbZZZEp4lTU6W55ZOnop99+7dTnfxBgAAAAAA5R8Jycriv/9Vuy+/VO+nn3Zqc1e3GoyNjXVpfcU5fPiwMjIy7K5LT09XamqqS/azcuVKHTt2zCV1VVSHDh0q9LkAAAAAAFR89EyEn7Mb+vr6ujIOuNuyZZIk/2K6KxfG2y3/zp07Z/N/SePZtWuXQkND7a5z5bGlpqYqKyvLZfWVZ0WdV+4fAAAAAICikLSs2JxuIbllyxZXxgF3q1LFo7tzdQLz5MmTpa7fE0nVktwwl11IEldUS5YsKXSdjw+NswEAAAAAqKzclhUgYVnGeDghWZ7lTyq6M4mZnJzstrqdxS9QAAAAAAB34TsnLFyakIyLi9NHH32kjh07qmvXrq6sGqWVLyHpUwEmFHEmUViSG19pEpEl2bYijKX4559/lngbbw8BAAAAAAAAvKfUCUmz2azZs2frzjvvVP369TVp0iTdcsst2rhxoyvig6sEB1v/DExMdHn1GRkZWrt2rcvrrejK0mzTliRhSZOF6enpTu+TX8cAAAAAABejEUvF5/CkNrGxsXrvvfdUvXp1Pf3009q/f7+mTJmi77//XoZhaNCgQcrNzdXMmTPVpk0bd8YMZ+R7MQcmJiq9Th2XVp+ZmamYmBiX1ukod96oSJi5h+U5M5lMRT5/mZmZCgwM9FRYgFfwYQsAAABAZeNwC8mhQ4cqIyNDJpNJDRo0UI8ePXTy5ElNnjxZp06d0ieffOLOOFFKTy+7Q5dqi+bpRre0kCyJkib57H1ZtyxLSEhQdna2zGazS2KTSEJ6iiPP2aJFizwQCQAAAADA3fghHvk5nJDcu3ev7rrrLt1///2Ki4vTww8/rDfffFM333yzfH193RkjXOBIcnVt06U6poZeT0i60tmzZx0uy82vbJk7d663QwDKBH4EAQAAAFDZOJyQfPXVV3X77berd+/eGjdunI4cOaJ27dqpR48emjBhgmJjY90ZJ0qpVvB5SVKMaikwIcHt+3N38s+Z+hNLkIh1dfze6s5eVpEcBgAAAACg8nI4IfnII49o37592rJli55//nn9+uuvOnHihIYMGaIvv/xSdevWldls1uLFi3X+/Hl3xgwn1ApKkXQhIVmGW0i6s6XQgQMHSrxNfHx8icoXFn9hE/648ngNw1BWVpZT22ZmZspsNrvt/Kem+mn16rrKyir1PFoAAAAAAKCcK1F2ICwsTP7+/tb/a9WqpWeeeUbbtm3T2rVr9dhjj+nNN99U7dq1deutt7o8WDivVlC+FpJlOCHpaMs5T7Wwy8jI8Mh+XOHs2bNauHChU9suWrRIycnJpdp/Uc/J++930rhxXfX++52KLQtUNrweAAAAAFQ2Lmuu1KVLF02YMEGnT5/W1KlTlZOT46qq4QI1y0lC0tXS09MdKpe/O3d5Hc/NlRP7OGPdunU6c+ZMgeUpKX7asCFSkrR6dT0lJQV4OjQAAAAAQBlQXr9vw/VckpBct26d9e+AgAANGjRI8+bNc0XVcJFagXkJyVjVVGBSkpejKZqPj48iIyNdUteff/7p1Ha0WHJM/vMUExOjDRs2FChz4kS4zf/791e1bsebEQAAAAAAlY9LEpIDBw50RTVwI5su22V8Upvw8HAFBQV5bH+uVpZicYar4z92LMzm/yNHIty2LwAAAABAxUADlorNz9GCgwYNsrvcMIwST/wBz8ufkPRLS5NvZqZyAwNdUndFTCqdO3dONWrU8HYYFcLx47YtJI8dCy/RNWMYBm9EAAAAAFCJVMQ8A2w5nJD8888/9d133ykszLa1k2EYWr58ucsDg2vVvNBlO1sBSlaEAhISlO6ibtFS+frlwhJrbm6uli1bZjfx6O3xGL3F1c+jj4+PNSHZrl2sdu6sqbi4krV+BQAAAACUD2azWT4+LpuuBBWYwwnJPn36KDw8XL169SqwrkOHDi4NCq4X4pupEKUqTaGKVU0FJSa6NCHpKp5MbObm5io1NbVAQtKTMZT1RO7Ro0cLXefIL1Ymk0lnzoRIktq3j8uXkGTSKwAAAACoaFasWKGmTZsqKirK26GgjHM4Ifnrr78Wum7x4sUuCQZuZBiqpRgdVajHxpF0Rnlulp2WllbmE4wltX37dknOd5s2m6Vz54IlSW3a5A3tEB8fJLM5r8WuI3XSZRsAAAAAyo6ivrenpaUpKyur2O34jgen29GeOXPGlXHA3S4kJCXPTGxTXGKxJDcfdyUpXXkDzMjI0F9//eWy+iqK+PhA5eT4ysfHrBYt8q65zEw/JSfz5gMAAAAAQGXldELy+uuvd2UccLeLE5KJid6Nx0mW5KQrkpTluTWmPWXxF6azZ/O6a9eqla6QkFyFh2dLkk6dKnuxAgAAAACKVxa/e6L8cTohWdGSORVevoRkrGoqyEtdtp1pObl161br33PmzHGq3pIo7c2V18Y/zp7N665du3a6JKlmzUxJ0unTees5VwAAAABQvvA9Dq7gdEKSjHg5YxiqqVhJF1pIxsd7OSD77N3Yzp4965Z9ufIaTiyixWlZvlmvWbPG5n+TyeTSeC0T2tSpkyZJqlYtr4XkunVHbMqV5XMEAAAAAABci7nYK4uLumwHx8R4JYyymMguSTJs7ty5dpdv2LDBqX17+3zExsY6va0jsVu6bFsSktWrZ13Yr5/DdZCsBAAAQFmXmJiovXv3ejsMwCO8/T0WFQMJycriooRkSCkSkhcniFJTU7Vs2TKntr2Yq1voFaWwmb+KYjabbf53NhFZHmRmZha53pHnyTLD9j8JybwWkklJQaWMDgAAACg7EhMTdejQIW+HAXhEUd8FXZmsJPFZsTmdkPT19XVlHHC3ixKS/qmp8ktJcUnVxSWuSsLZZGRRXaYL8/fffztU7uTJkwUSkUXJzMxUbm6u9X97x5TgpTE87SnsnG/evLnUdZ85809C0j85WbV9867BtLQIu+X37NlT6n0CAAAAAICyzemE5JYtW1wZB9zMyJ+QNNWWpFK1knRkf0Up6pcOZ34FWbNmjcxms86dO1fibYvb/+bNm5Wdne3w9kePHtXhw4eLLBMdHV3oOnvnLjU11eH9u4qzv0adPHlSkpSTY1JsbF5CMirotK56/HF1nfGhJOn8+VCbbXJychQfH6+DBw86HzAAAADgJQwzhMqkNC0XafUIC7psVxb5JrWJVU1JUohlquMSKklrQWc4+2aekZGhdevWFVvOmRugo9tYyhV3DJaknT0XzySem5vrcGvO0irsOEvynBw5ckSSFBsbLLPZJH//XLXfNE+Bycmqq9MX1tm2sD569KhWrVpV6n0DAAAAANzL2e9ofLdDfqVKSKanpystLc36/9GjR/Xhhx9q0aJFpQ4MLpavhWSKEaYMBSr82DGnqrp4vEhX3lSSk5OVnJxcZJmcnBy33MiKa9Vokb87dmEMw3AoRmeSo64+dne9KVgmtKldO121du+UJNVR3ozpFyckK8Ibk9lsLlFLWsCirF//27dvL/MxAgAAAChfSpWQvO222/Ttt99KyhvDr0ePHnrvvfd02223aeLEiS4JEC5iGKqiJPn55EjKG0cy/Phxl1S9Zs2aEpVPS0srtJXl2bNni91+/vz5Jdqfo3bt2uVQuQMHDhS6zpKsPHDggFsmvDl8+LBDrUDLgrNnLeNHpqrahbEhI3VGkpSQ4CsH8rrlyuHDh7VixQpvhwG43NGjR0lIAgAAwIpu13CFUiUkN2/erCuvvFKS9Msvv6hOnTo6evSovv32W3388ccuCRAuYjbLJKlaUN5ENrGqqfCjRz0eRkX4UlvUMVhm7jYMQ+np6cWWL6nMzEybVsnu4Kp4z53LayHZIDRGAampyvXzUw3FyUe5MptNSk4OtJbdu3ev2+NxN7PZ7FDrWQAAAAAozzzxHa28fA+E80qVkExLS1N4eLgkadGiRbrzzjvl4+Ojyy67TEe9kOxC4UwXXsyWhGSMains1CmZcnK8GVaZZPm1J6eSnBt3d9mOCjglSUqJilJGvTrWoQMSEwPtbpeRkeGWeABPOXfunJKSkrwdBgAAAACUWaVKSDZv3ly///67jh8/roULF+r666+XlPdlLCIiwiUBwkUuJJ2qBuclJM/415dPTo5CT51y0+68+2tGTExMoS0J09PTHZqYJyEhwdVhFcrb58sdLAnJxj55P06k1amjtDp1rONIJiTYT0jSyhDl3Z49e3TMyTF6AQAAgPKuIn6/heuVKiH5+uuv6/nnn1fjxo3Vo0cPXX755ZLyWkt26tTJJQHCRS5qIXmiagtJKtHENq64qXjqxrRly5ZCZ7LetWuXTpw44ZE4JPcec2ZmZrHJ1dmzZxfZ2tNd8Vm6bDfL3i9JSq9dW2mRkdZxJAtrIekJ7kh68qYLAAAAAIBjSpWQHDBggI4dO6aNGzdqwYIF1uXXXHONPvjgg1IHBxeyJCQvtJA8Gd407/99+xyuYvny5SXYnWeSM84OplvWkkfOHseff/7pUHLV0eN1JI7c3FwdL2ZCpKwsH8XHB0mSWqTtliSl1a6t1MjIYltIusuZM5ZEaKLmzZvn0X0DAAAAAEqGyXMqthIlJNPT0wu0OouMjFRAQIB8fP6pqnv37mrVqpVrIoRrXEhI1Q7NG9fsSFBeC8ma27Y5XMX58+cdLrtz584SBOc8d9ygPH3Ty8jIKFGCNH9rR0e6nhenpMnZtLQ0bd26tcgy587lzbAdHJyjevF5s5KnOdlC0lXJY8us55VlbFAAAAAAKGtIMsLC4YTkL7/8ohYtWujmm29Whw4dtG7dOuu6e+65xy3BwYUuJHXqV4mVJB3JjpIkVTlyRAGJiS7fXWZmpsvrdNahQ4cKLCssyVXS5Y4obtvFixeXqL7MzMwy18LzYpbxI+vUSVdozDlJUnqdOkqrXdvaQtKbXbYBR2zatMnbIQAAAABAheRwQvKtt97Spk2btHXrVk2ZMkUjRozQ9OnTJZW97q+w48Jz1KBKnCTpdGyEkhs1kiTV3LHDa2GVVv5fV/766y+7ZXbv3u1wfWWxK68rX1/Z2dkuq6swJpPJOn5kZK0UBV6YbTitVi2l165tbSGZEBfgUH1r1651T6BAMU45OemXyWTifREAAAC4SEk+I/N5uuJzOCGZnZ2tOnXqSJK6dOmi5cuX6/PPP9ebb75Jk9vy4MKLOepCC8mEhCAda9tdUsm6bZc+DNfeVFw9hqQjXaBPnTqlxHytSksytqY3ZWZm2oz1apH/XLiqZaulhWT9KnkzlecEBionNFTZYWGqGZAoSUqO83OorqQLCU0AAAAAAFAxOJyQrF27trZv3279v3r16lq8eLH27Nljsxxl1IWkU3hQusLCsiRJ2xr0kiTVdMPzV54mtbk41uLqTEtLs2k5VVjCzJ3nwJm6Lz4uy5iK+eXm5tp9PZdkf3ktJPPGkKwXeFqSlFmtmmQySSaTqlbLS3omJAU5XCcAAAAAoPKg4VvF53BC8rvvvlPt2rVtlgUEBGjGjBlatmyZywODi1kSSiaTIiPTJEn7IjrK7OOj0DNnFHz2rBeDs8+RJJg7blKJDoypaW9cysJYjmPPnj3OhlTA3r17S7zNxecqOTlZku15zs3NVUJCgt3yjjKbzdYWkg0D8mYAz6he3bo+LK+htZLSQpST4/k3mc2bN3t8nwAAAKj4SKAArkOX7YrP4YRkgwYNFBkZaXddz549XRYQ3OSuu7RvyBAlN22qunVTJUnHYmoosWVLSZ7ttu1KrmgheXEd9rotr1ixwqn95Hfw4MFS12GRlZVV6LrDhw87XW+tWrWc3jY/S0KysY5KutBC8oLgugHyVd5M14mJjo0j6UrumnApJSXFLfUCAACgfCCBAgCOczghebEzZ864Mg642113af9ddympWTM1anReknTkSIRiO3aUJEXa6b7rDmVlDMn8HOmynZ6eXur9OKuk52zXrl1O78vPz7FxHYty/ry/kpPzZtBubt4vybaFZGadWqqtvJm34+P9C2yfnZ2tv//+u9RxOKM0ydz83fjT0tJcEQ7KKSa1AQAAAICiOZ2QvP76610ZBzyoSZO8MQ+PHInQySuvlCTV3rhRAUVMHlLSL9cZGRnOB+iB/XgyWeDovqKjo13SEtMRlm7ZUsnPhaX8jkJmZz95MkySVLNmumok5yXp8ick02rV+mem7YTAAtvv2LFDqampJYrJVZxJ5ubk5BRY9tdff3k1iQ0AAADPo8s2UDrHjx93W482lD1OJyRp/VF+NW6cN3bg8eNhio9srMTmzeWTm6v6ZWy26LI2KYwnODJ+pSusXLnSbR+YTpzIS0jWr5+ioAuJz/xdttNr11Yd5Y1ZmphYMCHpznPg6uc9NjZWCxYssJuU5AMpAAAAADhu69atHvtODO9zOiHJl+3yq2bNDIWFZcls9tHx4+E6fvXVkqSoP//8Z/KbciwhIaFUv6oUdm2XNJl1/vx5nT9/3uk4XM1TkwSdPBkqKS8hGXghIdk+X4vq9Nq1/2khaafLdnmSm5srwzA0f/58b4fiMjExMd4OAQAAoNwpqw0egLLGlbmk3Nxcl9UFz3M6IYnyy2SSmjXL6569b19VnerVS7l+fqoSHa1Lpk+3m5R01U3DE2/Ua9eudUscziQXMzMzy/wvPIWdC2dv7idOhEuSGjRIUVB8vCTJLyrKuj6jWjXVNuUlvc6fdmoXZUZRr4vy+qPN2rVry90H6mXLlhU50RNcx1PDcQAAAADFfaeaN2+e3d5qKB9ISFZS7drFSZJ27KiprIgI7b3nHklSyx9/VMNFiwqUN5vN5SZJUdYSQevXr/d2CE6Ji4tzajtLl+2GkYkKsCRx69b9p4CPj2qE5i0/H+PZW1B5uYZRMsnJyXwQ8YDU1FQtXrzY22EAAFAmlbXvIIC3eLoxE9/xyi+nswG+vr6ujAMe1r59XrJp584aMgzp8B13aO+wYZKkNlOmKPzoUW+GV2G44ubo7husI/U7GkNOjklnzoRIkpqEnZQk5fr5SfkmtZGkatXyutQnlqDLdnZ2tg4cOFBgudls9tokOEUpyx9KzWZzketdec0tWLDAZXWVFxc/92Vp6AYAAACgIinL37tQNKcTklu2bHFlHPCwFi0SFRCQq6SkQB0/ntei7WD//kpo0UL+aWnq/uabRc667SxHEx1Hjhxx+b4d5ckxLZxN/Njbrri4PfHL0alTocrN9VFwcI7qm49LkjKrV88bJyCfKjXzWrPFJoU6XHd6err27t1bYHlMTIz+/vvvUkTtmJiYmAoz49vff/+t06c9018+OzvbI/spy5YuXVrken7VBQCg/OP9HHAtEo0VX6n7S2ZkZGj9+vWaM2eOZs2aZfNA2eXvb1br1nnj++3cWUOSZPj6av2//62UunUVEhOjDp995s0QS/2mnpaW5qJInFdcS7SyIP953rp1a6nqio6OkCQ1bpyikKS8CW0y8s2wbVGjYV6i9lRKTZV2HGJPffhbu3atzp4965F9uVt6ejqJQjfjSwkAAABgK/9n5OI+L/N5uuLzK83GCxYs0PDhwxUbG1tgnclkYsajMq59+zht21ZLGzfW0U035XXRzoqI0KaXXtKVzz6rumvWKHL1ap254gqvxJfkZAtNyy8px44dc2U4TikrrwFP3cyPHMlLSDZtet46w3amnYRkaKswBfyRqSwjULGxwapTJ90j8eEfRSXLefPHxbgmAACAu8TFxSkiIkL+/o4P5wRY0JKy/CpVC8knn3xSAwcO1OnTp2U2m20eZSURg8Jddllel82tW2spJeWfm39ykyY6dMcdkqRW06ZJ5aCVX1nlrjEkT5w4Uep6i6rfWfkTkpYZtjMuGj9SktKaNFRTHZYknT4Z7LL9F8fdSZXy9Ga4Y8eOQteRfAIAAICnrF692m4jJ3ieq3r48X0CjihVQvLs2bN69tlnVadOHVfFAw9q2DBFjRolKyfHR2vXRtqsO9i/v7JDQhR+/Lgiy+ks0WVBWboRFxbLxo0bXbYPS5ftJk3st5Ds0qWLJCm1Th01M+UlJOP3Of/jRUZGhtPbAu5SnhLTxTl58qS3QwAAAF5QFieNhPvNnTvXY/uqSJ+Z4ZxSJSQHDBhQ7GD9KNv+9a9TkqQVK+rZLM8JDdWRm26SJDWbOVNyUWLNEwm60t7YCts+JyenVPW6gitu2rt27bL5v6RjbcbFxRWyPFDx8cHy8THUtGnKPy0k7XTZlq+voiJiJEmxh0q0exuLFy/2+AzG9mb6rmhc9TotSwl5OMebE4yhaLy+AADu5IlJIwFUbqUaQ3LChAkaOHCgVqxYofbt2xcY82HUqFGlCg7ud+WVpzRtWitt21ZTyckBiojIsq6LvuUWNf39d1Xft0/Vd+9WfNu2XozUfRzt/rxq1aoS152SklJgmbe/RB4+fNjm/5LGs3PnTrvLDxzISzxGRZ1XSIjZmpDMrFHDbvm6dc5LSdKZU8GSih4vNDY2VgEBAXbXefp87t27Vy1atJBUdILY03HFxcXJx8dH1ewlgFFipX3+vP06L62dO3eqXbt2jOVURiUnJ2vZsmW65ZZbvB0KAAAuUd4/O6HkeM5RqoTkjBkztGjRIgUFBWnp0qU2X85NJhMJyXKgXr1UNW2apMOHq2j16kjdcMM/E8FkVqumE1dfrUaLFqn5L79ofQVNSLrTxcm/sqQk3TAsbxZFjQ27f39VSdIllyQoIyNDQRdaUqbbGUNSkuo0yZH2S8fjakg6U+T+16xZo969ezscb2Eq8pve/v37FRgY6LaEZG5urtauXauePXu6pX4ULzMzU4GBgQWWz5492+WJqejoaLVr104+PqXqSAE3YZxuAABQXpWk1x/duiu2Un3TeOWVV/Sf//xHSUlJOnLkiKKjo62PspyIga0rr8wbI2zp0gYF1h3s31+Gj4/qbNqkKgcPlnpfFTkh5C6Wc1aac+eq8z5v3rxC11kSki1aJMonK0uBycmSpIyaNa1l8r+h1GrrK0k6lB6l7OyCbzTnzp1zRcguVVavX8Mw7LbGLU19F8vKylL8hVav+Z0+fVqZmZnF1ulMC+OScPVzUxaf60WLFpGIAgAAAFAhlCohmZWVpcGDB5eJFhRjx45Vt27dFB4ertq1a+v222/Xvn37vB1WudC790n5+Ji1e3cNHT4cYbMurW5dnezVS5LU4qefvBFeiblrDElXKWmiY/HixU7vy5FWkK5IvJjN0oEDVSVJLVsmWLtrG0FBumHo0ALlW7VqpeDONRWhJOXIX2f3FTzn69atK3R/hY1jWVklJye7dIIfe9dEYYmwjRs3FjorYv567CUzSyo1NdWlkzCVR2UxUQoAqJiio6O9HQIAFIvPx+VXqTKJ9957r3788UdXxVIqy5Yt0xNPPKG1a9dq8eLFys7O1vXXX8/sYA6oWTNDPXueliTNnNm8wPoDAwfKMJlUd+1ahTPBgUutXbvWrfXnH4zanTfqo0fDlZ7ur6CgHDVsmKKgCwkqo359yU6CNzw8XDkR4WobsFeSdG5D8cm0DRs2WP9evXq1U3GW9BwYhqFTp045ta+Kxmw2ezsEpaWl6fTp03bXlaXuHGUpFgAAnFXYuOGAO5BUAiqfUo0hmZubq3feeUcLFy5Uhw4dCgx+//7775cquJJYsGCBzf/ffPONateurU2bNqnXhRZ+KNyddx7UypX1tGJFfd1222G1bJloXZcSFaXTV1yheqtWqc2UKVr3xht2k0zlSWne8ALj4tRk7lwlN2miU//6V6nORXp6utPbWjiS/IiNjdXx48ftrnPFm/+2bbUkSW3bxsnX17COH6l69YrYSmpR67TWnJRO7PZT52L2UdLZwEvr0KFDio2N1blz51SvmOPIryRdzXNycrRz505deumlTkRYkKsSYWXpA6FhGDp69KgaN27skf3l5ubK19e3TJ0DbyK5CsAdDMNQYmIiE7EBQCVTks/YfB6v+ErVQnLHjh3q1KmTfHx8tHPnTm3ZssX62Lp1q4tCdE5SUt6svdULmVAjMzNTycnJNo/KrFmzZF11Vd5s05Mnt9XFr/29d9+tXH9/1d6yRQ3ytborqfJ+U6m6b5+uHD1aLX75RV3efVfNfv3V2yE55Pz584qJiSlVHX8X8bxv21ZbknTppXktI4MvJCSN+vWLrLNhi7yWkYdO2J+J25syMzOtLawdvW7zj+XoyDbZ2dk6fvy49u3bp82bNxdbPi0tTTk5OQ7F4qjk5GRt27bNpXW6Uk5Ojnbs2FFsOU+Mk+oIwzCsDwCAfZmZmVq5cqW3wwAAAF5UqoTkkiVLCn0UlbxwN7PZrKefflo9e/ZUu3bt7JYZO3asqlSpYn1ERUV5OMqy55579iogIFd79lTX6tV1bdalNmigfXfdJUlq+9VXCnRyPDif8+dlcvOkDI606Dl//nzJtjcMNVy4UFe8/LKC842Xd8n06SU+F95IVLhin4UNf5Cd7aOdO/NaOHTsmJf0DHIwIRl5ZbAkaVtqa/klF/6clNaxY8eKL3QRe9dBcefRMAynWpTt379fJ0+eLLbcsmXLdPTo0RLHVZiEhATFxcU5dX4c4cqJdjzN2XN6+PBhl4yXWRgSnQAqAlpfo6Li2gYAx3l/Nho3eOKJJ7Rz50798MMPhZYZM2aMkpKSrI/CurNWJjVqZOjOO/Nm0p427ZICrSQP3367Eps3V0BqqjpMnKgCBYpQ5dAhXfnss7q0Tx9d8+CDqu7lMWlKmjBo9uuv6vjpp/LNztaZ7t01/4cfFN+qlXyzs9W4lC2qpKITpBalSUQcdMEM6YXZu7eaMjP9VLVqhho1yjuOEEu35Qa2M7eHh4erSZMm1v/rXuqrAGUqXjWUsexEqWM5dOiQ3eWOtAC0d34tSVhXt0p0lqs/5K5Zs8ZuItRVSa9ly5YVuu7EiRM6fPiwS/bjTrGxsSUaLqC4GccTEhJKG1KR0tLStGbNGpfUVZLrYPbs2S7Zp7OKmgQLAAAArkPiHa5SqoTk2LFj9fXXXxdY/vXXX2v8+PGlqdppI0eO1Jw5c7RkyRI1uCgZkl9gYKAiIiJsHpBuv/2wgoOzdeJEuLZurWmzzvD11dZRo2T281PkunVqO3myfLKyiq2z9qZNumLMGFW9kBQLjovTZW+8oUg3T+hSlJJ80Q47cUKtpk2TJO296y5tePll5YSE6PCtt0qSGi5eLJODCauKOMnStm1510nHjrHW4TTDLrS4M1q1sikbFhZm02rZ399Q62pHJEnHV5cs6WcvkbZ79+4it3E20XbxGLXe5IkWcs5M/lNS586d05kzZ9y+H2dZ9rVx40aXTmzk7i6KGRkZhc567oziEqxlRUnGbgUAAIDzGAcSrlKqhOTnn3+uVhclHCSpbdu2mjRpUmmqLjHDMDRy5Ej99ttv+vvvv21aYcFxISE5uvbavNaic+YUPIfnGzfW7vvukyQ1nTVLVz73nMJO2G/ZZsrJUZPZs9Xtv/+VX0aGYjp21M45c3Sme3f5ZmWp67hxqr5rl8uPwZFfbEpyY2z75ZfyycnRmW7ddGDwYMkn72VzpkcPZVStqqCEBIeTq3///bfHbsonCnleXG3r1rwJbS69NK+7tm9mpkIvJJqMtm2L3d4ygdL+g9VL1Or24jEXS9vt+OLnxd51dPFYsxeXubgOs9mspUuXOrxPT8st5fAJ0dHRLoqkcGXhHPn5lXz+t6SkJJ04ccLh1s+LFy8uMy1xLQzDUJxl+AU71zYAAADKvy1btng7BFRSpUpInjlzRnXr1i2wvFatWjp9+nRpqi6xJ554Qt9//72mT5+u8PBwnTlzRmfOnHHJLMaVzU03HZEkbdxYR6dPhxRYH33rrdrw8svKrFJFEUePqtdTT6n7m2+q5fTpqrp/v2pt2qSu//ufrrvvPrX78kv5mM06ftVVWvf664o2m7XxxRd16oorZDKb1fm99+TvhXHmikpy5E8yhZ04odpbtsjw8dGuBx+0mVHb8PfXsb59JeUlZ70pJyenQDLDE28sKSn+OniwqqR/JrQJO3FCJsNQVni4VLt2sXU0uizvnK7L7KLwI0eKLb969Wq7y13d/dfeNZKYmFjiOopKSP31118lqq+wZHtpknbZ2dlO17ezFEMvONPVw942pU2q5peRkVFgmdlslq+vb7HbXhxHSkqK9uzZ4/A5ysjIKFdJvrlz53o7BAAAALhASRuyeLLLtiv2lZqaqj///NMF0cDVSpWQjIqK0qpVqwosX7VqlerVq1eaqkts4sSJSkpKUp8+fVS3bl3r48cff/RoHBVB/fqp6tLlrAzDpLlz7bc0PXPZZVr20UeKbd9evtnZqrNxoy754Qdd+fzzuuw//1HdtWsVmJysjKpVtfPBB7X16adl+PtLykvkbX3qKaXUravg2Fi1L+F4lMVxZQvJjhfGJTvbtavS7CTfj9x0k3L9/FR9715V3bvXoTrd0eLLMsu9p23fXkNms0kNG6aoRo28ZE74hZaKyY0ayeRT/C2m7aVJkqRN6qKwv4s/BkuLLXezN+5mccmvstidujiOTjzj7ZaK9qSlpZV6VmyL5ORkLV682Pp//uP1KeY6Pnv2rM227uSq5+H8+fMuS4A6Mn5keUq2AgAAzyuLnzVhX3HPVVkbYzI7O5uGamVUqRKSDz30kJ5++mlNmTJFR48e1dGjR/X111/rmWee0UMPPeSqGB1iGIbdx30XuhejZPr1OyJJ+vvvBsrOtn+ZZFavrjVvvaXl772nvXfdpaQL3eSzQ0N1/KqrtP7ll/Xn5MmKvvVWm5aFkpQbHKwtzz0ns4+P6q9YoQZFdGuVJP+UFLX46Sd1+OQTt3Tzzs9yAw1ISlK1336TJB290BLyYpnVqulk796SHG8lWZI32/zjtxWVDCvsy76r3gwKi3nLlrwWkJ06/ZMktIwfeb5hQ4fqrlEjQ42qn5MhHx36O1dyY+KiqHPvyPNSklmjLfcgFH5uSztWpSuTXEXFUtw4ijk5OdaWpqV5zXnyelm6dKlLxpp0JOaYmBgtWrSo0PW0tiy5svZBHygprmEAqLxc/R7Ad67yq+QDY+UzevRoxcXF6fHHH1fWhclNgoKC9OKLL2rMmDEuCRDeceml51S9erri44O1cWNtXX55IZNPmExKatFCSS1a6MCQIVJurkxms7U1ZFESW7bU/rvuUqvvv1e7SZN0PipKSc2bFygXkJCgf734onVcwoZ//aXd996rw7ffXiDR6ShHblrNfv1VpuRkJTVtqnNduhRaLvrWW9Xwr79Ub/Vq7T92TCnFJOJKcsPM/yV+wYIFatGihcPbulturrRuXR1JUo8e/yQ2Io4eleR4QlKS2nU7r6MLa2vl+W4aumOH4jp2LHE8jozV56jSTJCR/w3W1W+OnvoCV9bf1M1ms+Lj4xUYGOi2feQ/B7t27VLTpk0LLZv/eck/dEJGRoZCQ0NLFYM7n/Pi6s6fiM3MzNTaC2Pl7tmzx275tLQ0hYQUHOYjf8LWnosTyxkZGQoKCioyNgAAAHiHu7+TFFf/mTNndP78+TL13RjOKVULSZPJpPHjxysmJkZr167Vtm3bFB8fr9dff91V8cFLfH2l3r3zZjFesqTw2crtbehIMtLiQP/+imvTRv7p6er54otq8scfNi3kqu7bpyteeUWhZ84ovWZNneneXSazWW2nTFGnDz5waJZve4pKuOTm5sovJUWNLsys/N0Vr+n+Edfr8cf76JtvWuvNN7vrrbe66dChvJnZk5s00enLLsuLy86s8yXZd0kcvZD4K4o73yz27auuxMQghYZmqUOHeOvy8BK2kJSkDp3ztp+rm9VwYeEtqRyRv/toSVo0WpjNZq270FW/MDExMXaXF/bcXtyl9cyZMy6dCdmitM+3I9dUWZCUlKQ1a9Z4bf9Ftcw84sA4qI6aM2dOgWWeTBYnJSVZ/87MzFRaWpok+8MZSK6JzTLBD1DWuLJFNrPCAwBQuOI+U8bGxurkyZMeigbuVKqEpEVYWJi6deumdu3aubXFCjzrqqvyBrfduLGO4uLc1FrF11frX301b+bt7Gy1mzxZfe+5R93eekvd/vtf/euFFxR+4oQyqlXTmv/+VxteeUU7Hn5YZh8fNVi6VFe8/LKCC0kOFaWom1xaWpoaLVwo//R0pbTppv/MH6y4uGCdOBGuX39tro0b62j9+ki98cZlSkwMkCTtvu8+mf38VHvzZtUpZsZtR760O1Jm+/btkvImWvHGDXn58rxxYrt1Oyd//7x4g2JiFHLunAwfHyU3buxwXZ06xSjQP1vRaqpzq1IVUoJJsYqaXXvJkiU2/xd1XhdcSEA7Yq2Ds6pf3MrO4tChQzp+/LjD+yuszqKWOSM1NdUl9VzMVfG5MsFe3IRCRcVcWBdje9skJCQ4HJOnW6YWdj6zSvBDjyMxb9q0qdgyu9w8FAdQWq4cWmDdunVlviU6AEhlv9cMyh9X/YDN0B8Vg0sSkqiYGjc+rzZt4pST46NZs+xPbuMKOWFh2vDKK9r+6KPKCQ5WwPnzily/XpEbNshkGDp+1VVa+sknSq1fXzKZdKRfP639z3+UFR6uavv3q8/IkYpavNg6MU5pb04+2dnW8SD/r8Xnio0LVkREpoYN26M+fU5oyJB9qlcvRUlJgVq0qJEkKa1ePR267TZJUsdPP1VAvpZFF3P1G3tycnKh69x1o87M9NHy5fUlSX36/DMrW+0LE+sktGypnLAwh+sLCspV5655LQZ/Ne5QswtjdzrCFQMU//XXX9bWLyWdSTu/op7bmJiYUs8IXZLns6gusq6ov7zYu3ev3VaLltZ+rlDUeXP1ZC6uvH/k5ORor53JuCwTR7lqX47Uc/jwYZfuEwDcKTs7W7t37/Z2GECFwmcAXKyocegr4veWyoiEJIrUv39e17yFCxspNdX5IUdnzWqioUP76uGHr7aOO2jDZNLRm27Swu+/18p33tGu++/X/kGDtPKdd7T1mWeUHRFhUzyuY0etGjtWic2ayS89XZd+8om6jh1bZCLQUfWXLlVQQoLOVG+iD5ZcKkl69NEdGjTooJ59dovuumu/Bg8+IElatKihtYf5/qFDldywoQKTktT53XcL7U5eEd5sV66sp5SUANWunaaOHf9poVpr82ZJ0rnOnUtc5xVX5LWKnKn+ivrrLwXGxxezRckV1iouf3IqOjq62HocfQPM/1yfP3/e4ZaVhw8f1tmzZ4utsyiWFp9Hjhwp9czkubm5NmMjOhtTfs58iDCc+NEhLi7OoSRz/mM4d+6cQ4nEM2fOlCrhaDmnF/+oEB8f73SX9JI8F2lpaTpw4IBT+yntvlHQjh07imzxDaDsSE9P16FDh7wdBuB2vLejtNxxDRmGIR8fUlkVQakmtXn22WftLjeZTAoKClLz5s112223qXr16qXZDbyoS5dzioo6r+PHw7VgQSP171/yD1/bttXUV1+1kySlpgbo3Xe7aMKEJYqMLNiyzezvr4RWrZTQqlWx9aY0bKgV//d/avb772o1bZrqrl2ranv3av/zzyulQ4cSx5kXgNnaOu/Tlv9R8lqToqJSrMkyiyuuOKVJk9rp3LkQHThQVZdckihzQIC2PPecer70kmpt364u77yjTS++KPNFY2p68o3dXb8czZ/fWJLUt+9R+fpe2Fdurmpt2yZJiunUqcR1dut2Vn5+udqb01q7slup9bffauvTT7so4jyOJI8cacVoOa8Xn9/8z62959nRmZiPHTumgIAAZWdnq0GDEozhasfhw4dVt25d1ahRo9iylriWLFmiK664wrrNjh073DLmpauGLyisXGxsrHJyckr8mlu3bp169uxZbLkNGzbo2muvLTIGe3Jzc2UYhubPny8pbxKX/NLT0ws930VN+FLS5Ghx16Ernx8ULy4ujl/7KxFadwAVD++JgGs48hm1JO+hvDbLrlKllbds2aLJkyfriy++0LJly7Rs2TJ9+eWXmjx5sv766y89++yzat68OV0ayjEfH+nOO/NaSc6c2VzJyY5PWCNJaWl++vjjvBmTe/c+oVat4pWV5avp04tPODrE11eH+vfXivfeU3LDhgpKTFSHV19VjzfeUIQDLd0u1njePIWfOKGskFBNP9NPknTTTcd18Q8wgYFmde2aNyj92rWR1uXJTZpo/auvKtffX5Hr1+uKMWMUeFHrtPKekIyODtf+/dXk52fWtdf+05qn6r598k9NVVZ4uBLtzJZenJCQHHXvntcq8DM9rqi//1aNHTtcFrejimoJaFHUec2/bt++fYWWK+w6iI+PV25uruLi4godV2/FihUu7XJsT/5xBHNychw6L4Xx1oeANWvWFDmkgSv8+eefJX6d7d271+7ESY6cp8JmuJZKPsadKxKSZUF5ibM4JKeA8qOi3HcAoCwq7h5rNpvd9rnJbDYr3g099WBfqRKSt912m679f/a+O0xu4zz/xWJ7v94r78gjeazHTooiRVFUY1wUq7jEsmM5SmLFcdxiJ7Id27/Ylovci2Q5LoltuSU2qUaxiEXsvZPXeP1ur9/2AuD3BxYgFgtgse3uSO37PPvsLspgMJgZzLzzft93993o7+/HqVOncOrUKfT29mLr1q147LHH0NfXh40bN+JjH/tYpvKbwwxg06Y+1NRMwePR41e/mp/UuT/72QIMD5tRUuLFP/zDefzd310EABw4UIH+fnPG8jhVV4eD3/oW2t7xDtAkieLTp3HnRz+Ktf/2b6jbsQPOa9dAKCjfiHAYFfv2YcF//RcA4E/bPouOG3kwGBhs2dIvec7ataxq8vDhMgj7zNFFi3D8c59DyGpF3vXr2PjxjyNfQMpPh+oomwPlPXvY6NmrVg0iLy/EX6/80CEAgGvZMnCySbkXhdz2Bx64AQD4Ffl+TMKOpd/5DvRZJpTEUKMyk8u/sNxHRkZSilr95ptv8mSjOLgIQRDo7OzExMQEgsFgwnzt3r076esL8dprr6V1fqaR6sCDYRhMTk7KRoeWO0ct1KQr9HVKUZSiElfpPjPZtnt7exMfpIBsmeDkkEMOOeSQw62I23FhKfdezmGmIdWuklVIJnOsx+PBm2++qfr4HNJDWoTk17/+dXzpS1+CXeDfz+Fw4Atf+AKeeeYZmM1mfO5zn1MVYTOH2QuSZHgi8bXXarBrV5Wq8w4dKsOuXTUgCAYf/ehZmEwU5syZxIoVQ6BpAn/8Y/IqOiXQej2ufOAD2PeDH6BvwwbQGg0KL1xA8/PP445PfhJb/vZvseI//xOLf/ADNP3iF6h5+WVUv/oqWr76VWz94Aex/NlnQYbDGFy1Cs+Nvw8A8M53AjabdHCQ5ctd0OkoDAxY0d1ti9k3smTJTdXm2BjWfvazaPrFL0CKTDOzjUwNjLjBSCikwRtvsMFstmy5GSWaCAZRuX8/AKB38+aUr9PcPIqqKjd8lAnP2Z6C2eVCy1e/CiJJdd7g4GDKeVADNWrBc1HzdSGEzyPVAZ5UsBqxr0rOf2SyAX/E9SWZaMvJIh0fksnuA1jlqZJiNdn0hOAiaR84cED2mN27d8Pj8aSUfjLHJ1rR3bFjB/9bLgI4d61ELgg8Hk/WJirZVrbOVuQmfjm8VZCr6289ZDrI22xErl6nh1z55cAhZ7L91kFahOTk5CRcLlfc9uHhYX4y4XQ6szqpzWF60Nw8ine9iw1+8MMfLsbu3cqk5I0bNnzve0sBsCbfzc03J8kPP8yms3dvFYaHTRnPq6+8HKc/9Snsff55XHnvezG4ciVCFgtMY2MoO3oUNa+9hsY//hGLf/xjLPnhD1F++DAMk5MI5OWh9a//Gr9/6Mt4Yz/rt++jH5XvvMxmCkuXsgFdDh8ui89HWRkOPfMMejduhIam0fjHP2LTRz4Czc9/DiKFCMjJIF3lkxwOHSrH1JQBhYV+LF9+M5hNyaFD0Lvd8BcWYnjpUn47yTmYVAmCAO6//wYA4Fv6T8FjdKDw4kU0P/dcUukMDAyoHviK1W3JvLAOHz6c9LlutxsA0N8vrbzlYBcFchJD7lpvvPFGHGmZjDIwG5jpQUCi60cikbj6IqVATZQW92zlIHwuUoSbXNAehmGwc+dOyeuLlZZSUbNTxUw+t4GBgcQHRTHT9WsmcDuqcHLI4VaCXOC5HOSRrFsRIaTcnOSQQw5vXeT8MN8+SCuozdve9jZ88IMfxDe/+U2sXLkSAOvk/xOf+ATe/va3AwCOHz+OuXPnpp3RHGYe73nPVYyNGbBnTzW++92lOHmyGI89dh01NbGT8DffLMN3v7sUfr8WixaN4L3vjVUlNTWNY/HiYZw/X4Q//nEOnnzyYlby6y8qQtvDDwMAyEAABRcvwtLfD53HA53HA/PwMMhAAOPz5mFk8WKMLVwIWkPi+X9fBoYhsHFjL1auLMeuXfLX2LChHydOlGLPnio8/PB1iPk3ymzGmY9/HP0bN2LRj38Ms8sFfPSj2FJYiLaHHkL33XeDNhji0u3t7ZWcZKudeHNkRyY7aoYBduyoAwDcd98NkOTNvFRHyZKubdsgLIRUrn/33T34/e8bMThqx9P3/Abfev0B1L76KtzV1bjx4IOq0ujt7cVkNOK6XJlxwUHSjUCdLN544w0UFhZmLL329vaM+ZOc7hf7+Pg4XC4XiouL0dnZibq6urhjuOeXrg9LpXvr6+uLIyDPnDmT8vXkoCZgks/ni8urUMkors8vv/yy5PZbFdx9aLVpDU/i0swNWnOYbbhd2uxbFWLF/aVLl7Bw4cIZys3tDykBTA7Tg9nUV+3YsQMPPvhg7p1+G+Ct9AyDwSAuXryIlpaWmc7KrERaI/6f/OQn+NjHPoZHH32UnyxqtVq8//3vx7PPPgsAaGpqwk9/+tP0c5rDjEOjAZ566hwKCgL4wx8acPhwOQ4fLseqVYNYtGgELpcZly4VoKPDAQBobh7Bpz99Koa44vDww604f74Ir79ejYcfbkV+vrQaKVOgjEa4VqxIeNzxYyW4cKEQOh2Fv/mbqwDKFY9ft24Azz8fgstlxtmzxWhpkRgwEQSGVq3CyOLFqHn1Vcz53/+FaWQEi37yEzS++CJ6tm5F38aNcFdVgYueI2XumwwSKbVSwenTxWhvd8JgiGDbtpvBbArPnUPelSugtVp033NP2tcxGCi8+93X8P3vL8ELR7bgkUefxJrf/AjNzz8PWqdD97ZtqtLhzJXlzJYPHDiAeyTyO5sGXmrQ19enSHRx95+IlJFTBGYCXJmGw2FotdqYfExOTqK4uBgXL16UJCQ5nD17FtXVrP9Sqfu4cOEC1q1bF7ddeCxN0wiFQtDr9XH5EyskperBa6+9hq1btwJgAwulCrk6xjAM9u7dyy/wJXNuNpDoWgzDJDTrFmJwcBClpaWKx3BIVl2thJ07d2L79u0ZSy+Htx5utfdCDtmF0PUFh46OjhwhmYMiaJoGRVHQ6ZILEJrD7EDu+U0v1Lx3bxVSMxgMor+/P0dIyiAtk22r1Yrnn38eo6OjOHPmDM6cOYPR0VE899xzsFgsAIClS5diqcCEM4dbGxoN8N73XsM3vnEIK1eyfvqOHy/FCy80Y8eOenR0OKDR0HjooVZ86UtHYbdLm+svWjSKpqYxhMMk/vSnxL4k+/os+N//rceJE8XI1rxgdNSAH/xgMQDgr/6qA8XFif3vGQw0Nm9mzaP//Od6xWMpoxEdb3879jz/PM4/+SR8RUUwTkyg8fe/x6annsK2970Py595BsWnTgEqlFRKGB5mzakz2VH//vfsc7r33q6bz5Vh0PSrXwEAbtx7L4J5eRm51pYtPaiqcsPt1uM/PR9H5wMPgGAYLPnBD9D0y1+mXT4Aq7gLh8Nx5C2nrEwEOXOtTJW52nQSEY3cC72trQ3hcFiWvNy3b59kOqkE5pHDrl27UvbvOTAwAK/XK7tfTulKEETMoEbq/hmGQWtrq+L1GYZBKBTin/vExISKXMenoQaZbLdKZZYNKF3v+vXrCc9PhvjJKWZyyCGHHHK4VdDR0XFLBsrI9oJMd3f3tFsrpYL29va0FqNzSA1q699sXji8VYjTmULKhGQ4HMaWLVvQ2toKq9WKxYsXY/HixbBarZnMXw6zFA0Nk3j66RP4znfewEMPteKOO/qwcWMvnnzyPH760z14//uvSiojORAE8Oij7OR0585atLc7ZI89eLAcTz11J/7rvxbiS19ajeeea844Ken1avGVr6zExIQRNTVTeOQRZXJCiO3bO6DR0Dh7tghXriQm5Gi9Hl3334+9P/kJTn3ykxhasQKUXg+9242KQ4ew+j/+A9ve9z4s+8Y3UP3qqyg6dQr2jg6YhofRef58OreZMnbs0ODy5QJotRTe/vZ2fnvJsWPIu34dEYMBbe96V8auR5IMPvQh1pT/pZfq8Yc7P43WaPqNf/gD1j79NKxp+smkKArd3d1JB37hkE7gnJGRkZTP5ZDsCzoUCuHEiRO4cuWK5HFSwXIA4Pz58wn9+anNC03T0GhiXzvJ+Dy8eJGtE0rBY8RQMwhQk3/OX6hawloJ3d3divuVyNFkB1x79+5N6vh0rsVdT868PpX0pJRIAFuXsulTTO66bxXI9QdvVeQiymceb/X7z+GtB4qi0nI/c7uio6Mj68EoMwFOIZmDeqTTzwvH79NN6GX6/SSe++QQi5RNtnU6Hc7PEDmSw+xBXZ0bdXWpBVFYvnwYGzb04dChCnz720vxla+8Cav15ouaYYA//WkOfvGLBQCA/PwAxsaMeOmlOmi1ND74wcvIRP/kcpnw1a+uQFubExZLCJ/5zAkYjepfOKWlftx1Vy9272Z9az777AFV5zNaLfrvuAP9d9wBIhyGo70dFQcPovKNN6B3u1F54AAqJYgXT1kZpurrMVlfj6n6emiWLWMZXonCyEQH7vFo8clPsl3F297WgYIC1rRX6/NhUTTYzI23vS2hOjJZk8lly0Zw55292L+/Et/4Rgsqv/0BuKuqsOT730fhxYvY+E//hPZ3vhOdf/VXCCkEgMkE+ZcppPs8pF6QU1NTsNlsEkfHnxsMBhXzMB0DrWR9A6YyKOjr60NFBRsNnqKoGNPiVJ9BoujVmQDn+1Uc/ToT0dmTgVSU7WTwyiuv4N57782qWZNSmYTDYbz++uu4//77s3b9bECs5p0p+Hw+7NmzZ0bN3IeHh0FRlGoT/xxyyCGHHG5NJPvuy/mFvvWR7PO+1ZGrr8pIy4fke9/7Xrzwwgv46le/mqn85PAWw9/93UVcuFCIri47PvaxjXj88SuYP38MHR0OvPRSLU6dKgHAmlB/4AOXsG9fFb773aX485/nQKul8Z73XINWm1xHxTCA261HX58Fe/ZUYe/eKkQiGthsIXzxi0dRXp58gJDHH7+C06eL0NdnxXPPNeOf/ik5H5CMToeJpiZMNDXh8uOPw9nWhtKjR2Hr6YFxZATGsTFofT6QkQisAwOwDgygXGD2QWm1CObnY6quDmGzGZpIBGQoBIPfD/j9CDqdcFdXY2jVKozPn59U3p5/vhl9fQTKyz149NGocothsPD552EaGYG3tJQPHpQs7Ha7ZLRhDk8+eQFXruTD5TLjhz9cjE9+MoKxpiYseu45lJw8ibm/+x3m/N//YXD1avRu2oSxBQsQibqL4NDR0ZFS3hJB6gWZyWA1Qrz++uu870Kl6ydS3lEUpeibT60yT0j4qYFUXhO9nIeHh9HV1ZW0Ty6apnH69OmY/KnxhTgbkAx57na7YTQa+f/ZVnDJmUfLXVdtlHsh3G63pFm3lO9JpfulKErWNN/n8/EuZXKQxmxoD93d3QiFQjlCMoccVMDr9eb6tVkENW50biXcCguh04EcqTS7MJvrihi5uqOMtAjJSCSCn/3sZ9i9ezdaWlriXobf+ta30spcDrc/HI4QvvCFo/jqV1dgaMiCr30tNvCMVkvhgx+8jAcfvAGAjcDs8ejws58txB//2IgTJ0rwnvdcw5o1g5JqyWBQg/PnC3H2bBEGBiwYHjahr8+KSCRWOr1o0Qg+8pFzKCuLJSPVdiB2ewgf//gZ/Pu/r8Xu3dVYunQYGzf2qy8IARidDu5FiySJQ/3kJOwdHXB0dsLe0QFnezssAwMgIxGYXS42ircMSk+cQOMf/4i+O+7AjQcewFhTEx9ERw779lVg374qaDQMPvrRszAY2En+nD/9CdV79oAhCJz7p38CZTQCKRAQK1euxJ49e2T3WywRfPKTp/Cv/7oehw5VoLbWjYcfBo4//TRKjxxB4x/+AGdbGyoOHkRF1K+Lt6QE7upquKurMVVbi8iyZXDbbJIK0kQw9/ej5MQJlJw8CYYk0fnAA3DJBBwpLCxUpVRMBYFAIG7bkSNHklYw0TSd0Fei8Fg5SBF+w8PDGB4exoIFCxTTVTuA8Hg8GBoaSpqQnM3+fVIhRr1eLw4dOsT/n5qawrVr19DW1pawrFPNhxTa2tokt9+4cUN1GkqLDwBLSPb3x/ebQkJybGwM+fn5qq8pxMTEBA4dOjTrAtyMjIxItnEO4XAYJEnmTH5mELfSxCeHtx727t076/q1HG5vDAwMwOVyYcmSJRlLczaQNsPDwygqKprpbNx24N6hiYQRcpgNdSMd3Or5zzbSIiQvXryI5cuXA4h3Vp8r+BzUYs6cKXz72wfw4otz8fLLtQiFSJSVebBw4Rje+c42VFbGBkl4+9s7kJcXxHPPNaO7246vfGUl6uomcdddPSgsDICiCAwOWnDxYgGuXMlDMChdzfPzA2hqGsP27Z1YuDB9c8xFi0bx8MOtePHFufjud5fCbg9h6dLUzIUrKirgcrni/BuGHA6MLFuGkWXL+G0FNht87e0wu1ywd3RAE4mA1ulA63Qg8vPhB2AaHkbelSs8cVdx8CAC+fkYaW5Gz5YtGFmyJI6cvHgxHz/4ATvQePjh65g/nzUjLT16FPN/+Uv2mCeewGhzM4gsTtbmzZvA449fxgsvNOO//7sJNA08+mgrBtetw+DatXC0taHyjTdQevQozMPDsAwNwTI0hNITJ/g0KK0WgYICBPPyELZaEbZYELZY4KirQ73Ph7DFgojVCq3XC9PwMCwDA8i/fBnmaHAgDsWnT+P4Zz+LoTVrsna/ycDnYwn0bPS3Z8+ejfmv5PfI5/PxLjwWLFiAgYEB5CUR4IgbqPT29mJoaAgtLS0pm+RwpJfQB54SmXD58uW4qNuZwNiYAcEgGbPIkQoheerUqbhtHo8nrWd+8uRJVcepIWGuXbsmub2npwf19fUZJ9HefPPNuIm3mnxK1SeapkEQxIyPV/r7+xWDJO3fvx9z5sxRjEKfScx0eXCYLfnIFnIkZw455HCrYmpqKmOB5WaLuxIAOHr0aI7cF6Cvrw96vT5jJO3LL7+cdPnOlrqRQ/aQFiG5b9++TOUjh7c4LJYIPvjBy/jABy4jFCJ5JZ4c7ryzDy0tLvzv/87BX/5Sh85OB154QTowTmGhHytXDqG+fhKFhX6UlPhQVOSHwZC8oi8RHn30Ojo67DhxohRf+tIqfPzjZ7BunXJAEDmoncgzOh38xcXwFxdjtLk5Zp/ZbOZJqxsPPICOt78ddTt2oPToURjHxng/lb7iYvRs2YLue+5BoKAAJ08W45lnWhAKkVixYgiPPMIuOBSdOYPlzzwDgmHQtW0bbjz4IJuHFF8W3IRzy5YtikrJt72tE6EQiV/9aj5+/esm0DSBxx67DoIgMNnYiMnGRlx64gno3G7YOzth6+mBrbsbjvZ22Ds6QEYiPFEphpLWiiZJjC1YgKFVq+Bob0flG29g2Xe+gwO1tUBVVcr3mykolZkYyT6jRCa3QoJSfF9iwkt47a6uLphMJsk0z5w5A4PBEJNuqsE1Xn31VVXHtbe3o6mpSXKf1CBZzTM8erQUX/taCyhKgyeeuIjt2zsBpEZIKp0j3CcOPDQ0NISSEtblxc6dO/FgtK0CN4nsTEOYnytXrqCysjLGrHwmIUVIvvHGG5g3b16c+4FUI5MPDQ2BIAgUFxcDYNWjtbW1qs5VmpBFIpGUTOBvR0QiEYTDYZhMJskgWbcycn7Rcsjh9sat2r7l3k2BQABtbW1oaGiYFfm53a89E+jo6IDdbk+JkMxkfZdL61ZtUznEIi1CEmDN437yk5+go6MDv//971FRUYFf/epXqKurw4YNGzKRxxzeQiAIJCQjOVitYbzvfVfx9re3Y9euapw/X4hgkARBsCRkY+MEFi8eQU2NOyPBb9SAJBn867+ewte/vhxHj5bhq19dge3bO/C+911NKlBOV1eXan9AyXTGkw0NOPuxj0ETDCLv+nWUvfkmKvfvh9nlwrzf/Aa1L/4Jn6v6Lr7e9QAYaLBs8SA+93d7UHDpBioOHED166+DYBj0r1uHC08+qfq6iWA2mxMe8653tUGjYfCLXyzAb387D62tTjz55AWUlNxUkYZtNowuXozRxYv5bUQkAuPoKEyjo9BPTEDn9ULn8UDn9aLEYIC7u5vfFjGZ4CspQaCwEOPz5mF83jxQRiM8Hi08LSQeGhxE/tWraHnmGdz41a9i8kcQBHw+H+wKAXZmEjRNZzRy7iuvvJLSef39/YoDG2FUcEDZBDuVgWEy7SUV35derxY/+MFiUBRLlPz85/OxZs0AiooCaROSer2eLxdxPsT+J8+dO4d77rknJo3XX39d1T0o5SeZ/XIYGhrCyMhInDm+UqCaVMkazoes1Pk+n0+yTahVkIrR2dkJrVbLE5IXLlxQRUimG3DpdoTw+XMRz7dv347Ozk50dHRg27ZteOmll3DPPffELGJMR36ygVAohNdeey2nzHmL4+DBg7jjjjtm5NoURYEgiKRJ/r6+PthstrTHPrfbAsPtDOGiptvtTju92aSQzGH6kKmx6K2A2+Eesom0CMk//vGPeN/73of3vOc9OH36NIJBNvru5OQk/vM//xMvv/xyRjKZQw4c8vLy4iLQ2mxhPPRQOx56qH2GchULnY7Gpz99Cj/72QLs2FGPHTvqcfJkMf7hHzqweHFXxsnRVCaxtMGA0UWLMLpoES5/4ANwHDyNU3/Q4nv9f4P2Lnal8+/wY3zn/EdheCIUc+7QihU4/fGPg0nBB0gi5OfnK0YzfuihdhgMFH72swU4daoEH/lIAd71rjY8+GAHzGZpwpfRauEvKYE/qhYTglywAJcvX5a9HkUR2PnnOvz61/Pg92tx4K9+jRf67oSzrQ1Njz0G6qGHMLRqFaio4m9oaGjWBmFIFPAmHSSqg8m+iK9cuYK2tjbodDpFZdjhw4eTSleM0dHRlPKnhD/8oQGTkwZUVHhgtYZw7Vo+/vKXevzt315Om5DkylmN83epfUp+CtWmkS6uXLkCjUaD/v7+OEJS6Xo7d+6MIWuExyqdd+nSJQA3zbPVIFVikGGYtCfUMzVo9Xg8sFqtSZ0j9AVF0zQuXbqERYsWZSN7MRA+n9tFOXq73EcyUKrr586dy6hvuplCKBRCKBRS3baUXDdkG2fOnIFOp0u63C9duoS6urq0CMlAIIDXX39dlpDv7e2V3N7W1oa8vDwUFBSkfO1UQdM0GIZJyR/erQZxW92zZw8aGxszlr7SYuRswltx0TAUCqG7u1uyX5jNzyqHWwtpjZy//OUv48c//jGef/556HQ6fvv69etx+vTptDOXQw5iTIcSIhMgSQZPPHEJn//8UTidAQwMWPH004vx2c+uw9GjpYhEEr/UkiUPpCD38mQYwOUyYc+eSnzmi5uw+Ydfxj/3fxHtaEC+fhI/sv8zfoS/hwEsGRmy2dC9ZQuOfe5zOP5v/wZG0N4zmb+ampqE5zz44A1897sHsHDhKIJBLf77v5vwd3+3BT/5STMuXsyHRHDdlNDebse//MsdeOGFhfD72bWb/9mxFP/9vm8j6HDAeOMGWr75Tdz32GO48yMfQeNnP4vF3/senF/6Eub+5jeo//OfUfX663BevcoWONKbbNzKL35Omcfh3LlzCnWTiQmgojTYF6vbEgVNEYMjo5MpWyV/k+Pjeuzcyfr5e/zxy3jkETaA0K5d1fD5yJQISY/HI3lsIkVBOvUlm3Wtra0tbdPUsbExDEm4X+AgJm7Fv7MFOdIzEAjE1E2xb2A1kHMdMDIyErdIlwr27dvHk2Jqno3X641ZdKYoKqkAR4kw28yXsx3FPodYZHMBLRHGx8dlg3gli46ODhw9ejQjaWUbkUhE0Ve0WjAMgzNnziRFslMJBm5nzpyR3N7R0cEvLE43rl27huPHj8/ItW9HJNMf3g59Z7oL6tOFbLn4SQZy4wEpS5qZwGwOpnmrIC2F5LVr17Bx48a47Q6HY0ZX+XLIYbagpWUYP/rRPvzhDw3YsaMely4V4NKlAjgcQWza1Iu77+5BTY20uUOiAVoi0DRw+HAh/vSnZrS1OaHRMHA4gjCbI+jpscLrjSVWSkq8uO++Ltx33w2YTFuwa2olGI0GlF4PWqtNGJF7OlFZ6cH/+3+HsW9fJV58cS4GBy146aU6vPRSHazWEBoaJtHQMIGGhgk0NrK+Q9XMbWkauHChEK++WoMjR0pB0xpYrSG8//1XcOFCAQ4cqMS3D/4VSn9kxtJ9e+HYsQOWwUHYu7uB7m5wa/RincBYUxMuffCDmJDxVagGt8MATAghKSO8NzHJqNFoVLeF/fv3JzwmEonwCxuplKmc/0sA+M1v5iEY1GLu3HGsWjUEhgEqKjzo67Ni794qVFR0Jn09IYQDsmRVqcLo6mqJnlSIs3Qgzpfcc+/p6VE1xhgcHOR/TwfBJTQ55MyMAdaUe2BgAHfddRcAYPfu3XFKoFRN1lpbW2EwGJIKIiWH4eFh3u9oIojJBqWyjUQiIEkyK+WfyTQpioJGo5lVRGgO04/R0dGk/OIJlcKDg4M4efIkli9fjvLy8llHrA8PDyMSiaCsrCxr19i5cycAYNGiRWkrxnfs2IHt27fL9o8zWb7hcDijbnDeyphNbWS6MFNEeg6ZR47zSh9pEZKlpaVoa2uL85F06NAh1NfXp5N0DjncNrBYInj/+6/ir/96GL/7XTH27avExIQRf/7zHPz5z3NQUzOFFSuGsHjxCObNG5c1PVaLcJjA6dPF+O1v56K93Rmzb3LypsJUo6FRXz+FlSuHsGlTL0pLfTGkXSiLvhAzMfjQaIAtW3qxcWMfzp4twuHDZTh6tBQejx5nzxbh7NmbfgodjiCqq90oLvbBbg/Bag1Dp6Nx4oQD3d1zEAqRuHHDjrY2B4aHb/qzXLeuH08+eQFOZwjLlg3j8OEyXLhQiP1nG1D0xByc2r4dhtFRODo6UOLzwT80BL3fD9Lrhdbvh97tRsGFC8i/ehUb/vVf0f72t+Pau98NOoWozkpqg1txMCecXMjdWzb8Cu3duxdbtmyRzUuquHw5D6+9xip8P/KRHpScPoXikyfx2CIC3+h7EC+9VIf779+nyOurzYeUybb4XC74B4erV6+qvRUemVS8CaF2EskFJhoWRbsnCIKvM0plJqxXDMOoLt9U2lMwGJT1gaZWzSqnrkx20sswDILBYEYCCk1MTMBkMvEkvs/nU+XzV4jdu3djyZIlaZMg2V6U2bdvH+bPnx8X5ChdhMPhGCuiHG4viAlJhmEwNTU1KwnJ3t5e+Hy+jBOS2W6bWq02R/7NIKZjQXy2tRU53G7igFsFt0LdyCF1pEVIPvHEE/joRz+Kn/3sZyAIAv39/Thy5Ag+8YlP4Omnn85UHnPIgcet3CGVlATxgQ9cwfvedxWnTxdj9+4qnDxZjK4uO7q67PjjH1l/LPX1k1i2zIWqKg9sthBCIRI6HQ2TKQKTKQKjkf0OhzUIBLTo6bHjyhUT+vqs6O214vLlfF79aLFEcO+9ndiwYQAkSWN83AivV4uKCg8qK73Q6TLjt0qn06U9WFy/fr2sImrevHm4du2azLUZrFzpwsqVLvzjP55HV5cdra0OtLU50dbmRFeXDZOTBly4IGfuXxjzz2wOY9OmXmzb1o26uptmlsXFfrzzne343e/m4nvfWwqC6MGaNUMIFhTAVVAApqgIw8PDCARIdHfboNEwsNtDqNT2Y+HP/wuVb7yBhj/9CSUnTuDChz+M0QR+miYnJ2P+K/nWvNVx/fp1ye3pRNlWAhcYJhVIDUa7u6145pkVYBgCW7Z04/7On2POs88CAD6H/fix3oW+PivOnClCS8tw3PlKacuBC6KkhIsXL0pul2pnR44cwYoVK2aUOBE/F45Q5NxXcJHEUyGqxce7XK6MTix27doFu92e8XeUnGm6Ehntcrlw/PjxlAOkCNM7duwY5syZw6vF9uzZk3S64XA4bcX/dCAQCMiarKZaV3LBat7auFVIlmwgk/2rHCH5Vi7ftzJypODswXS0v9zzvv2RFiH5r//6r6BpGlu2bIHP58PGjRthMBjwiU98Ak899VSm8phDFlBeXo7+/v6ZzsZbElotg1WrhrBq1RA8Hh1OnCjB6dNFuHSpACMjJnR0ONDR4UjrGnl5AWzc2Ie/+Zt+6HQT/Pba2vSj4UnB6XTC7Xan5fcyPz8/LlIwB7VmP1otgzlzJjFnziQA1gdVKKTBjRt29PZaMTpqwdQUCY9Hh0hEA6vVgUBgHCTJoKLCg9raKcyfPy4bEf3RR6/j6tU8nD9fhK99rQ5mcyXmzJlEUZEfbrcBIyPz0d1t4yMsA6wp/Mc/Xo87172CxT/8IWw9PVj39NMYXLUKlx9/HN7KSsV74iL+Ck1uZxJdXV1x24SDBTnn82IIBzFyJAAXKC0TEE5mxL4jkxnscFGb2fOAQ4fK8f3vL4Hfr0V19RT+X+lXMefZHwEAfMXFsLlc+CD1PL6Lf8LOnXVpEZLCMguHwwn9rMkpT6WiYo6MjMDn88HhUN/3pGrSLXefiXwhcv2LRqOJUz8CrAq0ScYtglghKXyOYmRjgK3m2WYqanwy6UxNTSn6/JbLl1IZ+f1+dHZ2YsGCBarzAbDPX2h67nK5kjp/NkCshlTr55X7/dJLL2HTpk2wWCwYHByctUHSclCG0I/tbIscHQgE4PV6YbFYVJ+jRPxlm5BgGAZarfR09VYgJFtbW+F0OlFUVHRbRZPO5H3cTuWSgzTS9fc429t5IuTqtzLSIiQJgsC//du/4ZOf/CTa2trg8XiwYMGCpCM15pDDbEUmO0CpzshqDWPz5l5s3sySOGNjBpw5U4SrV/PR329BIMCqI0MhEoEACb9fi0BAC59PC72egtFIwWajkZ/vQU2NG8XFfsyfP4Y5cyZBkgwsFgu83ozdQsYxHS8YvZ7G3LkTmDt3AlqtNob8WpAgyrYYWi2Dz3/+GF59tRYvvjgXU1N6XLhQGHec0xkASTKYmDBgaMiCz352LT7/eRJjP1iIub/5DWpffhmlx4+j+NQpdG/diq777sNUXZ3kNTlV2GxRGJ0/f15xv5zzeSVIkZyZhlBhK/bdk8xAgTt3fFyPH/5wCY4dYwmDRQtdeKH8Y1j5P78GAFx/+GFce/e7sfbpp/FPF76D7+EjOHWqBJ2d9hjlbTL54AhAr9cbRzZKnZvsotOBAwd4P4dqcOLEiaTS5yDMqzDgUU9Pj+J5nOJTPHnhnklXV1cMITndA0C5683mgXQ4HJYkqDkIy1qNmTzABmJqb29PmpA8dOgQryRMFHF+uslK7tojIyMoLIzv8wHWvP3gwYNpqSFpmub7+hMnTswqZeXRo0exZs2ajKU30xM0mqZx4cKFrEbzlgt0NZPw+Xw4c+YMNmzYkNXrZPL5ypG6M0lIqr3ujRs3UF1djaKiosQHz1Jku62Ko2wPDg7ixo0bGe1vcsg8pqsPn853xUy/l96qSIuQ5KDX65MeeOaQQw7xyM8PYsuWXmzZoqwyYxjw/h4LCgreks6RWbJVPdtaUlKiGJlXLXQ6Btu3d+K++26gp8eG9nYHxscNKCoCzGY3amunUFTEBtHxeLR49tllOHGiFP/5nyvwH/8RQfjDH0bX/fdj/s9/jtLjx1H76quoffVVjDc2Av39MJEk/MXFNx9wFLOFkMwUpnMSkchEO9kByMCAGf/2b+swMmICqaHwj7W/xVdu/CPMl1gze9e//AuubdoEADj71FPY9NGP4mH/7/AiHsVvfzsXn/nMybTyoUQgpYtkfC1KnasW3PNPRVUtVEgyDMOriFOJYq6Ut1RAUZRktHelawvbttvtxtDQUFxwmWxFVJeKYi+nZHjppZdUpSn1PspEew8Gg3xb5vr+c+fOYfXq1WmnrVTvOzs7+XLq6elBYWEhjh49ipaWloQuDlK5b7fbDXvUh7OcX9KZgNiX660OmqbR3d2dNUJyx44dqK6uVl0HpnMinGy9zDbxxy22dXd3Iy8vDzabLebatxJutfyqwXT5kOTg9/szOq8Jh8M4e/YsVq5cmbE03+qgaTotq7hMIdP90okTJ5CXl3dLLyDcilA9yvnLX/4y7RE3c8hBDZxO50xnYdoxyxbcJZGNQb5dEGhnU5TwUYtMv7S0WgZ1dVO4++4evOtdbfirv3Jh1aohFBffjOhttUbw6U+fwqJFI/D7dXj66bU4daoYnspKnPj3f8fh//xP9K9bB5okkdfaCjz5JO5+4glsffxxrHn6aSz60Y9Q/+c/o+TYMVjPnYO1sxPWnh5Y+vpg7e6GvbMTjtZW2C5eRP6lSyg4dw5FZ87A0doKw/g4GzZ8GjDbB+Bif5zpwO3W4T/+YzVGRkxoJNtwhl6K73S8F2bvJLylpTj+2c9i7Ikn+OP9paW49MEP4nP4IgjQOHKkDB0d2QsYlQqme1CZbn0hCCJpP6A0Tcu6BsgkBgYG4qK9S/U9NE3jwIEDAGKVrOPj47hw4QIAdnKeSDUKsH4mk1EMhsNhPgp4IrIrFZPtRO4laJpWDNIlh2PHjvGm9lyepO5bygT94MGD6OvrA8MwOHfuXNx+pXLu7u7mF7O4+x4eHo6rg6m+YxiGiXFXIsy/nH/dmYaSe4WBgYGUnu90Y7YpF2f7e1QJiRTNicC1yXPnzqkmvkdGRkBR1Iw9x1v5eSWLvXv3xm3j7j8Tfr5TIciTQSgUwuDgYFLnSCFnWn4T3Lt3utrfdF3H7/dn1F1UDuqgWiH56KOPwmq1YsuWLXjkkUdw//33Q59CpNgcckgHUh1SQUEBJiYmpj8ztwCE5VVbW5u1qLlSUBMcQ+4FYzabYwJ2EAQBnU6HJUuW4ODBgynlR+pamRigKKUPsCbjTz99HF/96gqcPl2ML395JT7ykXPYsqUXo83NGG1uhn5iAlV792LBlSugT56EcXwcxvFxFElMnJMBTZIIFBTAX1QEb2kp/EVF8BcXI5CfD0qvh87rhXF0FIaJCfYzOYmwxYKxBQvQv24dqCSj6d6qUDPAZAPsAM98bTn6+62owQ0coDYg3+JB17qt6Nu4EaPNzQBJQkw3dt9zD1YfOYJHTr+I3+Ix/ObXc/Fv/x6vkkxnoJvOuUIlwnQrIeSQyIw4mbQAoK2tDX19faqOTQdq1Wyc2pALViXVfwwMDCT0q8lFHO/q6kJxcbGqawvJIqX8Hjt2THIhev/+/XFKk2T8sV65cgVerxerVq1Sld9k0dfXh2XLlvFl+sorryASiSAUCoFhGElVnBJZrXYilKySkSsrv9+Ps2fPSh4zGyMLMwwTY14vxsmTJ3H33XfDZDIBYBXAGo1GdTlKkR/TCS6fnZ2dqJNxpZJKerMB3OJTunlSo5hMR2nv9Xol26TwutyCgNBf52z02Xm7Y2hoCJFIBOfPn8fy5ctTTudW8Aeaw01k4lmpnbvL9SWziRyeTdYMtyJUE5Lz5s3DoUOH8Je//AW/+MUv8OSTT+Kee+7BI488gm3btsk6HM4hh9mA+vp6xSAGbwUsWrRoWgnJdLBlyxacPXtWUbWS7MtQ6kWRycjVSi8io5HCv//7cXznO0uxf38lvvOdZbh4sQAf/vBFmEwUQk4n2t/5TizYvh2v/uEPsHd2wtrbC0t/Pyz9/TC7XND7fCB9PhAUBYKmwWg0oEkSjFYb+63RQD81BePEBDQUBbPLBbPLhYJLl1TfS/Xu3Wh+7jn0r1+PnrvvxtiCBYqy3Nk0KMgWCILAz56bi3Pni2GFGzuwHe53bcSphx8GbYiN4B5XHgSBc089hX/9h2/gd/6Hcex4Gc6dK8SSJSPK593iSOd+lPyKyhGSDMOgs7NT0tdhOBzOumpLbjKspKrgzM1TuZbS/1TTEW7jiGpxsDEhWRwKhWLGf8L0+vr6JNVOHDmoBKn9yfT5DMPg9OnTaGlpUaWMFea7u7sboVCIjyzOkb4cuGcmzo9U/sTPl6bppKyNZmOfIM7T1atXMW/evJj7F7aDo0ePoqSkhC/PRBC6Yjl27BhaWlpmZI5x8eLFjBCSYrjdbjAME2PxAWT+WZ87dy6OeOfacjqKNL/fj927dyf0b5rO/bS1tfGuL4TpnD9/Pu6euHtpb2/H0NAQ1q9fn/J1c1AP4XMJhULo6+tLmZDMEZEzj2TdQqkl35T6gdnqBiSV+jgb39W3ElS/4QmCgMViwWOPPYbHHnsMbrcbf/7zn/GTn/wEH/rQh/jACznkkE2k2uDVqPVmGxwOhypT09u1E5R6IaQzaMnUyhVJkpIv7kQTJq2Wwcc+dgZlZV68+OJc7NlTjUuXWFKypcUFgmAHBJTBgPGmJoyLogUbjUYA6s1rCYqCYXwcxpERWAYHYXa5YHK5YBoehmFiAmQohIjJhEBBAQJ5eQjm5SFkt8MwPo7yQ4dg7e9H9Z49qN6zB/78fAwvXw5XSwuGly5FRBSd81atg1y+E0WrBoDdLzqw89VGEKDxS/JxhP7lPty44w7V1woUFID6h834x2/+AN/DP+H5bzfi2efGoNPFR4ueScwWhaQShG1ZTDJ2dXXFTfTF16QoSnbwnY5KI1mySQi/3w9DlNjO5mCYUwkmAymVJhfcau/evViwYAHKysri8uHxePgJRygUwtjYGB/0UCkPoVCIv6awv0vWTL+/vx8tLS2y+3fs2CEZRGd0dBQ+ny+GkOT2EwQhO97lnptQKSH2gzY6OoqjR4/GbLvV/QO3trZi7ty5MfVW+HtiYkLSH5e4HEZGRvj3HAeXy4VIJJIVQnKm+tvr168jFAph7dq1Wc1PtvxjiutrJvKtNg2pe/J4PABifcxOB24XEo1hGFy9ehXz58+f8Xxw37dL2d5KkFu4MxqNkvMO7h3HLdilM8dSa6WUiXTUItO+2mfD+H42Q/UbXlyQNpsN733ve/He975X0oF7DjncbigsLORXl4uKimbtyo4SampqshLRONUBhPicRLL8dAYpmRrgWCwWyT5PKjiEGBoN8O53X8fixaP41reWYXDQgi9+cTWWLh3GI49cB8O8nDH/oAxJIlBYiEBhISZE5GYiXHvPe5B/5QqqXn8d5W++CdPYGKp370b17t2gNRq4a2sxWVeHqbo6TNbXg8jLy0ympxlcvVIkBCgKh78VwncOPgAA+ILhyyj64mr0pzB479u4ER8+9QJ+98bD6B4txa9/UIn3//NNMnQ2DFguXLiA0tLSrF4j3QmHkkLS7/dLmi4Ljzt9+nSMOpphGPT398f5HgwGgzxJyGHHjh0wGAxYt24dAOD48eN8ZHKlxYJEz9bn8/FuKpIpG6G5otQ1hWkNDQ3h+PHj2Lp1q2KaauohRwJEIpG4ZyAFLkJ6c3NzwmsKfwujsCfj61RtAJ5XXnkFa9euTSkgUjLtdXJyEpFIRJLcfeONN5K67q0A4UKBMNI0TdMYHR1FUVFRXFC68+fP88Q2oP7eBwYGkJeXF0dmitHa2orGxkbZ/R6PhyfMs42ZJlySvX4wGITJZAJBEDHntra2yvpbS7XucsGGOP/wcgGnuHx0dHTwgc5yJpMsGIZBT08PqqurEx5L0zTa2trSIiTTdS2RbR+SiSD1rs+BfeeWlpbGvLcOHTqE+vp63iUHALz22mtYvXo18vPzs5KP6XwPctfiFl2TPS+H1KCakHzxxRdl90mpEXLIIRvQaDSw2Wxwu908KThdAzvhQCcvLy9tQlKn0ym+xLMxsCosLMwKISmFdFWpUhMD8bOuqKhQ7RcuU+UpNylWQ0hyaG4exXe/+wZ+//tG7NhRj7Nni3D2bBGKinxoaXFh+fJhzJkziYICP7Ixvtbr9QiFQqAoAm1tDpw7V4S+PgvCYQ3Kyny4885eYMECjC1YgAt///couHQJxadOofjUKVj7+uDo6IBD5AKh0WKBr7gYIYcDYbMZlNGIiMmEiNGIiMWCybo6jM+bh4gKhVS2YBweRl5rK7ReL0AQ0FkssEVVqYHCQgTtdlAmE4yjo7D29cHS3YNf/N9yPOP5ZwDA3+b/Gmu/VoHxEnW++uJAEOh66v34VvsX8Z6eH+KPe5egrtGDjQ+w5NhM+ZAUYmxsLGOBwrL1jJV8SFIUhfb2dsXrC/vd3t5eVFRUSAZCGR8fjyFnOeJaKtpzovxmO6COGkLy+PHjSaWh9Pzk9gl9IQaDQck0Z5qMESISieDgwYNoii7aSN3X+Pg4CgoKEqalVH6dnZ3wer0xRHgm6kRPTw+qqqoUj/H7/ejr61NtMp0Iatr166+/jqVLl/J549qOx+PB0aNHJc19xelypKbH41EkG0+ePInly5ejoqJCMU9Xr15VJCT37duX0AxZDsn0dbeCPzQx9uzZgzVr1qCoqCgmn21tbbLnpFom3G85/3KTk5MYGxuLUR+3tbWhuro6R0hGEYlEcO7cOVWEZLJ4+eWXM54mkPn6H4lE4HK5UF5envDYXbt24YEHHpCsP0KF9mx6d00H2tvb456L2+1GIBCAWeBjPhKJZH2MczuVPUVROHfuXFo+V283qCYk586dK7vv2LFjWL16dUYylEMOSiAIAna7HW63Gw0NDapJwUx0ZFwat3JU7+ka8N55550pLVQI8zdnzhxcvnw5Y3nK1EBVri4lm77VGsEHPnAF993XhT/8oQEHDlRgeNiMV1+txauv1gIA9HoKZWVeFBb6YTAAej0QDNIIhzUIhTQIhUiEQiT/PxLRQK+nYDRSMJkiMJkiMBgoGAwU7PYQrNYwAgESwaAVvb1aXL/uhM8XTxz//veNaGiYwDve0Y61awcwvGwZhpctw6UPfQim4WE42trYCN9RYtI0MgKd1wtHZ2fC+/ZUVMBdVQVq4UJoCgoQdDoRtlgQzMtDxGQCrddnLIw86fOh4NIlFJ09i6IzZ2Dr7VV97gU046P4FnaDVZN9ZPn/Yeu/mxHQ2tLKE63ToeD/rcXHnvwenvU9hWd/shoO4nUsuT8yY8G5pMi4VKC2f+FIqVQjGQoDXgkXCOSUNEp5Uwoaw5lfc6a9lxL4YVW6/1T8V0qlNzY2Jqnk4I4VlqmcYog7tqurC3kS6map66qdbAjfyUqLX+JrCKNlq3lfSz0LmqZ55aba60ptl7q+kkJL7tidO3cq5mXfvn0JA/skqlNnz55NSEhOTk7iypUrGSMk1UJoPutwOFJO58iRI0kThaOjowiFQjGKSzHSVb0qQU3grbGxMZw+fRp333133D6OzE+k+kwEiqIkF0tTGRP39/dLmt4DmS3La9euKaZz4MAByfNuFYXkbCae1YBbXMjkfWQjevXY2BhOnTqF8vLypMYmYrzyyispL1TcqhC7PuCeD0EQvBpZjFSsDNQi3brh9Xqh1WpnTdsLh8Np+Vy9HZERpyzvete7VPngyiEHKeTn56sOLpLNziRRPrgB3MKFCzNirp1oQJgJElU8Oct0+RUXF8dMJDmkOihUyh9BEDGqyWTLJ9ura6mmX1rqw0c+ch5PPHEJ584V4vTpIly4UIj+fgtCIRJdXXZ0dWVPhW6xhLB48SgaGiag11O4eLEQJ08Wo63Nia9/vQUORxCrVw9i4cIxNDaOo7wc8BcVYVDg/4oMBmEaGoJ5aAh6jwdanw9kIACt3w+t3w/91BSc16/DOjAAa18frH19wNGjqJTID0MQiJjNrLLSbEbQ6YS3vBye8nJ4KyrgKS+Hr6QEjEiBq/V4YOvthbW7G47OTuRfuQL7jRsgogOnfpThT8T7ccm5AhO6AlDQgKQp5BHjKKJdKPH1wBDw4jSzDEc1a3GQ3gAaJHSaMJ780Dncsz29wYxWq+VJnZDTifuf8cD18d/if4KP4ss/3oyvD/83at9fknL6mUSq93nw4MGkjt+9e3dK1xH2L4cPH5Y9TkjOKd3Tq6++KrldHNQiESknd41kyUgp5TyX9tmzZ1FWVsYTLUKT7VAohF27dvERsBORb+fPn8edd96pKk+JgsIl41ZD6hihejPZ+ufz+aDT6TA+Po5jx46pOqdTtHiSSB0qdX+jo6PQaDSqSSOp+8p2oKV0EQwGcfr06Th/h8lCzZhAuNAAJFcPxHWqt7cXU1NTsoTk0NCQqgWRYDCIiYkJlJTc7JvV5EtMqkkhEAjE+JwVpnv+/HnQNJ222OPSpUtYvHhx3PZUxitS/htTUVGne2wi+Hw+mM1mvm3NNEkp51s10xgbG+NNZrMxV5IKkpRJJKOeV3N/6ZqRp3PtZDEbyHThfXELtdwir9frxc6dO7F9+3ZZQlIOclYkiRYBxZA7Rs25x48fR0lJSVruiI4ePYo1a9bI7p8tZOetCtWE5MMPPyy5nWGYjEaqzeGth2RMXXOIRzLtTziozgSWLFkS4+MrXWTTh2S2FZLpwmCgsGrVEFatGgIAUBSBoSETBgasGB01gCB0YBgDIhEf9HoaOh0FvZ6GXk/x/7VaBqGQBoGAFn6/FoEAiUCA/Z6a0sPj0cFkomC3R2C3+9HYOIna2kkIm+Db3taJyUk9XnqpFq++WoOJCSN27arBrl01AACLJYyGhgk0NEygqsoDozECiyUCmq7E8LgRg4MWdHfb0Ndnhc0WQkmJD/PmjeOOD/WjiHHB0dkJa08PSvr6QHZ2Qu92Q+d2wxD1y0kwDHReL3ReLzA6CltPDwovXIgrL4YgwESjijMkCa1EMJF21OMFy9/jT8RDuOapAxgA8oK4m4iOtdav78f7338ZpaV+pDvWsNvtMW3VX12J9/xwHOP/vAcvu7fg43/8G3z76ldR/9kGhG3JqzBn42BofHwc+/fvj9vO5TVVMka40KLkv1COQJxuEkjoo/Tq1asJj+fUCXILX0Il6ODgYNw2rnzk6sSePXskt584cQLbt29XNZETp61W7Xrp0qU4xYrY7UaydfnQoUOoq6tLSoWnxtQ+UZ7Onj2LBQsWYM6cOTHHKKkpxa5aEr1PMkX4qIGUqjAYDMZEWe/u7uZNIPv6+hL6kOfMarm8cnVarr4I2+z169cT5pk7XqocpRTnnNq5u7tbMg8Mw6BXoKR3uVw4e/as6ojSap4JR7yI+6Fs9OHZSPPIkSOy6SstXOzYsYP/ffLkSbS0tGR8PDU2NoY9e/bg3nvvxeXLl8EwDJYuXZrRa8xWvPnmm1lV8g0ODsYQkkoLcK+//jq2bdumKt29e/eCIIgYE+BMINn3/EyOoV566aVZqcLkykQ4hhH3XUp+rNUqAdUuCMqBy8/BgwcT+sgWIhmSPZNxI24n8/NMQTUhuXv3bvzqV7+K8+vGMIysfD6HHLKJ6W7Q9fX1/OQv0xCqpzhk4/5mW7RxtUFtMoGZXn1MFiTJoLzch/JyVjWi1Wqh1WqTCuyQKhyOEN797ut4+OFWXLhQgFOnSnD9uhMdHQ54vTqcO1eEc+ekTbfEuHo1H/v3V+K55xahqsqN+fPH0NQ0jvptZoyNjSMYZM3OgwFAE6FAhkNg/BGY4Ee5aRhzNJ2od1+GfZBVVlr6+6ENBEAwDAhRm+nLm4ODefdiD7EFb3pW4spQJRDlHQiCQWPjBOrrJ2G1hqHRMKBpAh6PDlNTerjdeoRCGtTWutHYOI4FC8ZQWZkcaaEESd9ERXl44mceMP9yGK/0rMM/XvocPvPBZ/DI33Sg9957QM9Qe81UO5QzBe/t7YXVak16pZ2DsB9We77U6n86cLvdsESjzSuVVyQS4Y+jKAqtra1pX1sKwjxwUaBTeY6XL1/mfXAKIaf4YhgGly5dSipStNgcLNlolmIiSaPR4MaNG5Km7EIyDZAnjrj/Fy5ckDSBVipLsXKCU6tKoaamJsbvXqqE5BtvvIENGzZI7uvr6wNBECgvL0coFMKJEycUr8Ght7cXbrebJySHhoZiAhcA7ASOM9sdGxvjF1m4fMqVNwfODYscKX7jxg3+dyLS+NKlS7IEmJq6L1X2brcbU1NTkmOlQCCAvr4+1NfXJ0xbDKmJb6K+K5tjXJ/Ph1AoBL1en/S5SmMQoSsFhmFiItkLMTAwgFAoxLfZTBDv4j4oFApNO8k0PDyMK1euzPhYOxvq1GTUi8lEO/d6vdDr9Xxfk4xSMlE+soXZoGjMJpRIRo1Go+geJ9t5EoLLAzeGSHZ+JKX6Btj32Gy3XrjdoJqQ3LRpE2w2GzZu3Bi3T8ocIIccpgvpSL2TQU7JmX1k8wWnJigBh6VLl8YEZ5gNmA6n0WJotQyWLRvBsmUj0TwQ6O62obXVidZWJ1wuMwIBEl6vDhoNg4KCAEpKfKiqcqOqygOPR4e+PguOHi1DW5sTPT029PTYeLWlWphMEcyfP4a6ZZMo2uqHjfSAoCgEfKzys707H619xRh0WWMUkBoNg8WLR7B5cy9aWlyw29UPkjMNucEradDgw98dhfWbJ/H7QyvwleCncOz5PfjG758G+egS9N51F6g0/YjNRng8Huh0uowO+sT9hxo/bonAkXuRSCRGyXf+/Hk+EIpQMSSG2+3mHeKn035bW1sVfXlLKUXVlK24XIRkpNL5wvOERIBahVgmlX8ajQZer1dyMuKXUE4nuqaw3nB+MJXyJKWcUGsuKDc2uXLliuJ5brdb1m9fb28vSJJEeXk5XnvtNVX5CAQC6O7ujvEpevz4cb6OC03c+/v7AUhPyoVt4fLly7I+MoV1prOzU/LZKSmwNBpNTFCTTEXp5QhR7vkJ052cnMTly5clfVsnGi+IJ76cyiidPsrr9fKLHdz5kUgEJEkmJEvcbjc6Ojr458uhv78fTU1NMekqgctzd3d3XFqJ7icSiagiJKempuLM+aXA9dVArPl/JBIBwzBZIQnF+U6kGJ4uzEaLCSVkSx2spl/g2rqa47kAdbNV0ZhpyKn9aZpGT0/PDORIGulYGkghlXZ8q7W52QbVhOSf/vQn2X2ZNNnM4a0HtY24sLAwyzlRRqZXqxP5lZG7ntFonBaV3ExgthCSSs9auK+0tDRrqtlMYMWKFTh58mTG0tNqGdTXT6G+fgrbtqn3G/zww22YmtLjypU8XLmSj9ZWJ0IhEyKRMB90R6+/SX6QJA2/XwuXy4yhIRP8fi1Ony7G6dOJo1uXlnqxaNEIFi0axZIlI8jLSy1wSjpQMtnksG3bNp4sIEngfZ8aQMXSk/jRjxZjL7UFqyY24p9//G185r/+Eb41C9C/fj1Gm5v5KOVqrpkqhCqlbOJWUBhw7UeJTFRScqVKOIgDwiQiF+XIqVSunQ6Suc7p06clTbkSBQ8SQ6m/Fubn4sWLvPoxUT65/ZwCj/svfi5SzzeZMpBTEnEqSqW0hIQch507d6K4OHE/yYFLnyPZxOphzsWA8JlweaNpOmEgLk7NqnQfk5OTksGI5Op8KmSAlCJWbfAiDkpBjMRuB4RQKiOCIGRVhImwd+9e3HPPPTHK4MOHD8NsNvN+ZJUgd68jIyNJE5Jy5u9S4Mhttf3TmTNnkl7MOXDgAO8v7tKlS/D7/Yr+37KFoaEh1YsiYoRCIQSDQdhScOGSKSg9o0y+U5L195iMawSp7Z2dnbzSWSlS/FsVSgpJbh/3LlRzbLLIRl3LtlUlRVG8/9qZzsutiJSD2gwODqblHDSHHG4VTMdELpnOqb6+Xjb6tNg/FYdEUTgzgTVr1mDfvn1JnZOMyfZ0duC5l0XmYbeHsHr1EFavZn1kygVE4sDVZYoCurvtuHQpH/39FoyMmODzaUEQrHLSYgmjutqN+vpJzJkzBas1O47MU0VeXp6kibBUHbvrngEsWDyJF56fj2MnyvENfBI/Cv49Ht3/W7xv/6+wlXgGnjm1GF24EONNTRhvakIgCaJ9tkHOj5xcmaWDbPTjnDIuG2mfP39ecrvX60V7e3tcsA4p1eGxY8dgMBiwfPnyhIq76QSXVznfUkKlkxooEdtyfvrUTniUJlvJoLu7G06nM27ymypZAUC1KTaH4eFheDyemEBNFy5cAEVRqsyHlcrs6tWrWLBggez5PT09ihGvpaBU5jRNx5BUSmOJXbt2xfU1cmSFuByEx6j1k5oIXN6EZZqqCaT4nGAwiKmpKVULpWqul05gELn0ORJeWNbyaljg7FkT/H4bamunUlpgpGk6KZcSYvT19aGioiKlczk1sRyUVHnt7e3o7+/Hli1bYrZfvXoV9fX1iub26Zps79q1C3fffTdeeuklVWmk048J85HJsbdcGVAUhUuXLsW5XpgJM+TZjlQWbrIFtUIROQwMDKTkokIIJe6ru7sb7e3tuP/++yX3c2U2E9ZutwJSJiTvuece2QFzDjnc7lCavGSqo56OF3Mm0xf7l1WCktIgme3ZIg7TffFlCna7PS0ToNlMrKqtkyQJ1NVNoa5udphCJYtkVYClpT7829OncPJkD/7rv+ajp8eOF/AhvIAPwcmMY2PbAdzVthdb/rwTd+NrCBQWYnzePERWrkSwvByTc+bMmO/JTKG0tDQjhGQmFYJSfhWlFGpiZPKdIFTTHTp0KGaf2+2OMx32eDzweDyKViypDozliIra2lrJslKCsHzEPgjVQKmPVFv2ahWT6aQltT1RkCPxOeFwGPv37wdJkjzJwjAMKIrij3W5XJLk3/DwMIaGhlBdXc27oOFULsJJltqyEBJKHR0dmDdvXtyx3d2skn5oaEg2Pbn3lBJJ2tfXF6NMVnrXiYlEr9cre49KpsFyZtmZmFyKyZBU+wyuzMRktdQitvAae/fujbt3r9eLvXv3Jn1ttfB4PLDb7bL7u7ut+MY3luPGDQcA1g90S8sU3vWuC5g/PzMLVhcvXoRWq40zNxfi9OnTsoRkokX1RMr1AwcOoLGxkQ8UJUQ4HObdmvT09MDtdqO5uRmtra0oLS1Nm5AcHByUVV8Gg8Gk6mCyiyNS4K43OTmZ8P3vdrsxPj6O8vJy/p0htqJjGIavk8J3ZzrktBIyTagCiC7KUzBm0W1POBzGuXPn0NzcHLdPTvWYqF6L4Xa7Vd2DnFqcYRiMjIygpoZ19zQ1NcX3HQRBqCp3r9cbE7AsFXCB/6Sgtr2cPXs2R0hKIGV7qdwqQg7pYjb7ZBQOTriOTk2HJ+VjlYNasz4OYmfy6UDK2X+ySIZYSfWlrNPpYuTunPN8Oajth5JVZqjN/2wm/IDZnb9EK+qZqLPTBfGkSo0LhkTPZsUKF77//f346lffxJYt3bDZIphAHv6Ct+Gf8R0swkWUYAgfGPkedr65AKFv78D6T30K9z72GNZ95jNo+uUvUXboEBytrdBNTQG30Ds7U0okIdIdsyhFj1VCJttgokmalNlrIhw+fDjV7EgiFQJQqBpMNsBNsvnh7leJOEjlmQknvJmcmIoncRRFwe/3x72PX3nlFbz66qv8f7nrezwevPzyy3HbxWq1nTt3xuyXMk0XE1BS7VZYZ5VcQUjVbSWCKxGpoFQPx8bGZJ+RXBtTel8pBfaUm3gSBIGpqSlVZv4Mw8DlcsWkxdU3MYkpFdjl8OHD8Hg8smPQo0ePxpC0XDrJkJFAvKo7UV9w6tQpHDlyRFKZ1t7uwKc+tQE3bjhgNEZQWekGwxA4edKBz352HV55pUZ1vpTaosfjQW9vL44dO6a4kHL06FHJBahk3yvivHg8HsX3HUEQCAQCOH/+fIwf10SQy5ff7+f7idOnT+Ps2bP8c+7r61NcIFGrKk/3XTsyMpLQZ2h/fz/vRqKzs5N/PweDQf5cYT7OnDnD/5ZzCZJuvnfu3JnUM1KDq1ev4tixYxlNU4xgMIiBgQH+/gOBQMLxebLK6TfeeCOp46WeBac2pigK+/fvj9mXTMClbEHte5+iqBwhKYGUFZKzeaKbw62Bu+66a9b6H81EMAQxnE5njC8hJR+SDodDlR8KtZg/f37aaZjN5pQmvMmgtLQ0xv/VmjVrsGPHjqTS2L59e9w5K1asSCoNu92OpqYmycGZXN+XjT5RKs1kIhPP5n46UV3iAoHMVggVSjabLUal1djYqOgDTik4iRAEASxYMIYFC8ZQWjqKgwfdOH++EOfPF+LSpQIMh4rxIh7Fi3gUAFBJ9GBLaA9aLp1C46VW1ON/sRA9MCGAsNkMX3ExQk4ngnY7QjKfoMOBkMMBcIQHw7B2c9O4gJRMhE4lTNfCqVoCVex/MFkkmiTMhoViNX3T2NgYH2BCnOeLFy9mND/Xr1+P+c+1U7VlxfWhiSI+nz17VlIhKAR3zWRcEogtD7j8GAyGmGAMctdSCzXms+L94mediMC6cOGC5HZORamUJ7k8cEjG6sLv9yf9/Hfv3i17jNLkUspk1+v1wmQyxRC0p0+fln0ncuTw2rVreRWY1NhZqAjjQFEURkdHUVxcHEdic2UgFZQpFbJJzj2CUhpcNFvhtp4eKz7/+dXw+XSYP38Mn/nMCTidIbhcJrz44nK8/no+fvSjxfB6dfjrv07s/48LaiMHv98Pv98Pl8sFgiAko6gPDw+DYRhUVVWhsrISp06dwsjIiKLqq729PWWl/65du1BaWpqydZDceZFIJCZgk5DAHhsbw9jYmKJaNFPg6oqwTiarQud86Q8ODqKkpAQAS+BNTU3hjjvukFQcC8+TS5f7FpYxZ6qbaCGkp6cnxiVGpjEyMoKhoSEsXLgwa9e4du0a3ydLkWzJWrhlGlILamqvnc3I2WoJydkwTpuNmN0zvhyyhtlMVGQDs+F+k1F8KXVsqdzLbLh/KcgRbqmeL+WPLBWYTCY0NjYmNKeTg9FoRGFhYdrmAVLIFCG5fPlynD59OlPZyjhmGyGp1WpjJp6rV6+WVZdxeV+8eDH8fj/GxsZi9peUlCTdJrVaoLFxEo2Nk3jooXaEwxpcv+7kCcpr1/LQG6nCL/A4foHHY84twAgKfSMovDECKzywwAsrPLDBzX/sGIAN16FHCKSGBmwG6BxaVHZfgA1uDDz6AKi5paBqixAqyGfZ0iyBU89TFDA2ZsLUlB6hkCYq8iRgNEbgdAZht4eg1Sori6R+TyeEz1lMjiWLRP7IOIXP5ORkWtdJB2r7JiUyLZOQU3KIrytUtnR1dSVtoSB8b124cEHSnJIjQ5Np+8J8ColvoYWJ3D2KVb1SZBUHoTJV6hmmG7wnFUilzyltxIsWw8PDkhYVUuTDtWvXkJ+fr+o5JKt4SqR8CQQC8Hg8cfVLjc9H4fPinlGiPk5twCe1+8TKWaVzhAsoSmS1UCE5NGTC5z63BlNTBjQ0TODznz8Gs5kt0+JiP771rQF85Ssu/PrXTfjlL+ejoMCAzZulFW+Dg4Mx5L9UVHgxpHwLchgZGYFWq0VlZSWGh4cRDodhNBoxNTWFQCAQs5hOEARaW1sVlWRcfy31jILBYEJ3H/39/TCZTMjLy+O3nT9/HosXL5Y9T9iHiNMXzzuy2b4vX76MUCiEZcuWxe3LFKkjdYxS/Q2FQjzBvHv3bmzdupXfd+LECdxzzz2Sln3Hjx/HqlWrVOUn3bnY5OQkuru70yIkPR6PpIstrg8S5pGm6Vk7f0wF2VZI5pA6ZteML4ccVEDcORYVFaG1tTXtdOUGdul0xnV1dbID2kTXmO6XwKpVq3D8+PGYbcmQX9mGmvJI1c/K3LlzY8gCqTompSKQy1NhYaEqQrKsrEwxgEOiiWEiKB0rHphn0tddJjDbXDq0tLTEmM6oeQ4VFRXo6emJ255K2xY/G52OxsKFY1i4cAyPPXYdgQCJK1fyceFCAXp7rRgYsMDlMsPv12IUhRhFIa6pvRgNYDL64fBb9ksDCg5Mwql1w2H0wmYOwmILw2RjYMuLwJrPwFJEwFhIwmSmYTRGoNdT0Q8NmiYQCmkQDJIIhUgEg+xnfNyIkREjRkeN8Pny0dVVh8FBMyIR5Xpgs4XgdAbhcAThcLC/i4r8KC72weMxIhzWw+nMjOJSDcTEdSAQkFWGJcKSJUtw7tw5/r8an5VCzESbTkeZN5vAKaYS+fDl2vLk5CRvussRIXJIZtFNSLzt2rWLn4gK+5CjR49K5ks89hD+F/sHFBIVas3xMm1eL4ZU3eCuKSb329vbY4LqcPVQTtmolhwQLyYlghpiMRkIy6C3txfj4+MxCjav16toTSOn+OIgp0ZX044TPX9O8dnV1aWoMOZ8c46OGvD002sxOmpCVZUbX/jCTTKSg16vw6OPXkMkosHvfjcXzz5bD5qexJYt0mMt4X10dnairKwsofVRR0cHDAYDKioqZM2UhdtbW1sRCoXiotsnql+XL1+GRqNRVEHSNC278Hn9+nUUFRXF9DV9fX2ShGRHRwfq6+tx5MiRmPSF/VsiQjIVdxxy4CKIp/p+UqMcTTbty5cv8wSp1ELGkSNHJFXwQv+4StfcuXMn7r777qQXu4TPKBPv9H379kn6QZSy9JBb5JDa3tPTg6mpqYxY5CVb16SO7+7uRkVFBUiSlHRxIZWWz+dTPSahKCpunjIbTMdvVaRMSM62yWIOb104nc6spp/pjkMqEvZsICSlcDt0mg888EDCYxobGxUJyZUrV0qaCaSLgoICWUJSr9enFeGypaVFceIrZYZxOzxvIbIZZErJ5UIq6aULo5HCsmXDWLbsJnHOMIDXq4uSfGYUFjbh/Pl2BIMkAgEt/H724/Pd/KbCBOgABTpIg3Z54Qka4YEVbthAQQsaJMaRj/FIPuAB+5EPlp42dAihiBiBCX4QYJ/lFGHHCF0AGiTcbj3cbj16eqSd8wNzoNdTKCjwo7AwgIKCAAoL/cjPD8DpDAr+B0GSma//Ho8n5XY8G94BySJZglF4vNitSaowm80JfZCp6RfUuCjhVKviCaxSOSTj+uT69euYN28e74aEu56wb5erX0oqcyXTQymzeamJfjZ8vQohzCPDMEmZ8yd6vreC8mdoaCiGMBwZGcHk5GQMIXn06FGeXJC6Z+FCqnh/MBiUJQrVtA8xWS8+hxMKJHpuAwMDcLlM+I//WI3BQQtKS7344hePwG6XX0h6z3uuwe/XYseOenzve0thMFDYsEF+cRdgCVQuuM8dd9whO3cYHBzE6OioJCHJgWvfU1NT0Gq1km0t1folVFL7/X7Ztup2u+NUwXLXFCs/29ra4o5Ntk0kKpvu7m6UlZXx7jnUpCe+fn9/v2TAH+7aUn2pnEuJdJGJsaTagDrhcBiTk5NJL4ikAjGpJ1xQ5cpQPN6V62uGh4d5QlLsViKV8nO5XDFEvzCNHTt2oKCgQDbtc+fOoaCgABaLRZVFxvDwsGp/nWNjYzh8+DAefPBBybxJ4XabX2UaKROSQgexOeSQbQgJ8Jky5VTzos7UAHdqampWDJZT7UAznfd0OnIpUs5ms8Ws7nP5lZsQC+/HYDDA6/UiPz8/5TypwR133IGurq6YgA/JgCRJVc+Bu+dUnpnRaFT0xzPTmC6StaCgICnz/Olq2wQBWK1hWK1h6PVBtLSEUFSkPp+6qSls+NSnMLh6NS4//gGEQiT8EwzojnEEBwII9/nhH47AN0HA5yEx4bdgPGDDKJWHSTjghg0eWBGAET6Y4YcZWoRhgh9m+GK+SzCESvSiEr2oQg8q0YtGtKIKPdCInyED0CAwhny4UIwhlMCFYrhQjAGUoRvV6CTqcIOowwBdilCIxMCAFQMD8WZKHDQaGgUFAZSU+FBR4UV5uQcVFV7k5QVgtYZhs4VhNoeRZND0tHwipltPZmIAnOwk8LXXXuN/Z2qhW80EWE3ZqFEyyk0Yk/G1lwjCIAyc+Wk2TSuVImJPJ4TvFoqiFIPiCKGmfIVl1tHRIRvoItNI1txdWAYcYSMVMVvtdYUYGBjgo9YK4fP5VLmXUNtepYhQIVpbHfjSl1ZhYsKIggI/vvjFIygokCa7bwaZBD70oUswm4vw4os2fOMbyxEOn8XmzX2y+RAqzLu7u+F0OiUXLoT3JaUS3L9/f8x2t9stqYhW6r+lIsRPTU3h+vXrMWlrNBpFEkutSwoxrly5EmdRxBGScipftf3Wrl27ALCEkNVqVRwrS1mmCcvt1KlTMYQkV/e5Y10uF/+/u7sbXV1dcDgcSeVX7Rhb6FogXSRyqzI8PIxTp07FbU9lTBsMBjE5ORlD7LW1taGhoQHAzbLk3i19fTfbkPieOTcMwm1yixqBQEB2vp7ITzhHinZ2dsYoLpO9d3EfpVQnkokUL+WXNhlCP9GC6VsROZPtHLKCwsJCjIyMKB6TzGTr7rvv5jvnpqammIHpbCDu5JCO8lE40VFrOp1OWWQyYI3afKSS3/z8/JQmgUrX5f5LvTxXrVoVMzHljl2/fr2iD8bS0tKk8iEmSc1mc1oTdIIgVJVvOtewWq0xE6ZMmvhnol1Pl8uB6urqGNNaKTgcjhgfPdPdb6VyvbDdjn0//jF7PgCDgYKhBECJA4BD/loRN/RTfZj/y1+iKmoWOjZ/Pq4/8ggIigJB0yAoChqKgiYcZqWcBAGGJEGTJErLl6HfVYE+82Z0mc2g9HowJAlGo4EmHIbe44HO44HO7YZhYgI14+NonHLBMH4NxrExWPr7oaEogAFC0KEXlehDBXpQhV5UogdV6NdWoV9fiT6mAgOBIkRoLYaHzRgeNuPixUKZMmRgsbAEr8kUgcHAmqKbzRHk57Pqy6KiMJxOL/LzA8jPD8JiCafsbnM2v9vkkM6ETWySzjAARRFR034NwmGS/+3z6dDRYcfUlAFerxY+nw5aLY2KCg/mzwdMJholJf44k08OSq4yOCRjWi2+b6UJl06nSypwk1SE90R5S+RvNFkI62JNTY1qcjBTSKYff+mll2C32xWPmZqagsViAZA4YFGmcPny5aQX1KXakzgatFqSU6o/kTL393q9qkzPxcS/3PXF228GzAD27q3Ej360GKEQidraSXzuc8dRWCi/yBmr1AL+539scLl6sG9fFZ59djl6emx4z3uuSsZgE/q0VCorYdsSkxQMwyi6ceDSDYVCMaa5169f5/8zDBPjLoE7x+v1YmBggA/QwplsS6XPlUNPTw8qKyt5pRhBEOjp6eGVsTt27JA0zwWkVd0EQfBkmbgPoWk66cWKdMaXQj+p3P1y80opMkg851TTZygFqwIQZ9IuB27f1NQUXnnlFaxfvx7BYFBWwZrKQj5FUapV6X6/HxqNBgaDAcPDwzhz5kxMPbhy5QoaGhpA0zQfsVrKJYy4DN944424vlUqWF+ivujQoUOK+69cucL/Fvu0lEImiOJk3jHC63F1RFgOwWBQMW5EpgI33k5ImZAcGRnBz372Mxw5coR/cZWWlmLdunV4/PHHJZ1L5/DWwdq1a5OOjqwWyUwSbhVIdaaZGiRv2rQpI+lIDWbV+HHJBLRaLd+5r1+/Pmt1Kx1w98wFM1BrpiI+Xy3UkG1Kad5UGhAJj71VoBTJPhVUVlait7cXK1eujNuXTNoajQZz587FtWvXMpKvVDCdJvmMVotgfj4mGhp4QtLV0oJhlUGnLA0NGEpRGdzY2Ii2y5dhGh2FaXgYtq4uGMfGUOn3o6n3Mqy9u2AaHQUiYD8AKGgwhBJ0oQataMQl23JcNixBG1WPsYgD7qAZ/pAeDEPA49HD44kPWCIHrZbiCcxwmEQ4zL6/NBoGgQAJkgR0OgomUwQWSxgWSwRWawhWaxgNDXb4/fVRcjOAvDyW5DQa1Zl9AWyA9Ol8ZXLjQdZdgBYUpYHfr4XXq4PHw35zH49Hh/FxA4aHzbz/0FCIBE0T0GgYMAxA06lmnvUn6HCwPkUdjiCvcjWZIjAa2TK/+aGi2yP8d0/PKMeVJ4S4bSlNOGPNrQmMjJgwOGjB4KAZQ0NmMAxgs4VRVuZFdbUb+fkBmM2RmHyk24ckM74wGAwx96eGzM001PRdly5d4n1szkbfpEIiUW1fLOWDWAypADdiJNP3q50sc74fU8HAgBn/9V8LcPRoGQCgpWUIn/zkKZjN6vs2ACBJ4KMfPYsVK6rw9a8Df/hDI65fd+Lv//4CKipi67iwDLq7u3klnRhcHzYyMhLnO1xOrahGfOB2u2E0GiVNYsX5A6RVWFILn0eOHOFNRwmCwPj4eIzKjYMaNxbCvkmKlBb6mc+EylyskJSqexRF8UQ+R3CKiVGapuPagbBspZ4PTdMxJLU4P0A8iS2lWhSfF4lEEAqFYtwpCHHjxg3er/TRo0d537fhcBiRSAQmk0kyvx0dHWhtbVXV9x87dgxutxvbt29XfAaJFpbGxsZiFKpqFz8SmaYnUpsKiVcpFa0Y6RB8XLtUgvC6FEXF/Be3yXA4jF27dskuBOQgjZQIyRMnTmDbtm0wm824++67MXfuXABsB/Hd734XX/3qV/Haa69hxYoVGc1sDm9dJOoE7XZ73KqlWnXUmjVrJFeJxUhmArBp0yY+GqT4/HT9zSV7vs0m51stfUyX+Xx9fT1qa2un5VqJoEaFMB3ETzZILal2NB15UKOoVgNxuWcqf6WlpZJBjcSorq7m1R9K109FIXkr+p+hBaQ8nYRSItmyMZlM/MSBJEkwOh18paXwlZZidNGiuOPJQACWvj5Y+/pg6e+HYXISxrExLGlvx1rXUcD9K0AUryEEHcaRhzHkYxx5mCDz4DYXwE+YMWwoQ6+uBn2aCgxQZRgMFmI44ITbZ0QkQmJigoSya0QdotZSEoiPpmkysSpNs5klMRmGAEURPMnn82nBMERUYaiBxRKGRsPWH52OQlERqxxkP2H+N6f4LCgIwG4PwevVYWJCj8lJA6am9JiYMMDv18JgoDA8bAJNs9eIRNgI6IGAFuGwBlotjfFxllxMFRQVXwduBkeiYDBQqK72oLjYx5O5wSCJ7m4bRkby0NenhdvN5n1yUl6pkAgazVKepOSITJ2ORiBA8vdNEABJ0tDpaGi1DAiC4UlVjYYBQbDq2lCIhN+vRSikg89Hwu8nVZcRQTB8YCiDgYLFQsNkCkafHQONJgytloFWS0c/7O9wWMMTwIEACYoioNPR0Otp6PXLo7/Ze2LzT8ds02ppFBbaEAp5AIT49NnjWXWw0UjxZaTTZaefUtP/dXR0SAb9kQNHrM4EeZkoQBV3v0LVTSKffUplNDo6KumLTwpq/daJCS41qsrubitefrkWr71WA4rSgCRpvPvd1/DOd7ZJqhrFkHquGg3wzDMARZ3G97+/BOfPF+EjH9mEu+/uwQc/OAS5GCKJgo0JA8BwkKorDMPA7/fjzTffjIu0nehccTrATbJtcHAw7hwxgcaBs65RChSzZ88exetzCslk3QooIVE7VHMNISEpR65JEVyJyvull15KeG3h9ZIh/Lnz/H4/3G53TL0QWkJx6kWAde/S29uL7du3SxKF4ufCPWspMo1bEOOitUvB6/Um3fdxY1clpWx/fz+/+C4sF2GfJ8yTuE57PB7Z8bZUficnJ+MIeOFxUv1Sa2srGhsbAQBvvvkm/1sNXn755Rh+S07FfOHCBRQWFqKsrEx12m9lpMQmPPXUU3jXu96FH//4x3EVnWEYPPnkk3jqqackO/McckgVatRe6cJqtWbUdPl2xvLly3kVIDcJ4JBpk22CIKYtkNaaNWtUH5uKSb44oneqWLhwIc6fP694zHSTWMLrJdOWampq4gjJVNq0zWaL8c2TTSWiVNrNzc0xhGSm86HkriARZkKVSQsWLJgstt9k740yGjE1Zw6m5syJ26efnISjowPO9nZYu7pgHhyEzusFGQzCGQygyNcGTSQCUIgjLcXwwYTuogXod86BlzaBKs8HaSDgKytFxGIHYSOhCQThthRixF4B/5QGbp8BXj9rhmw2V+HatQmMjRkxNmbA2JgRwaAWfr8Ofr96BbbXG3vs2FhyUT7ThdEYgc1GwWQKwmLhlKDsh4uKzgYc8sNopECSDCIRAhoNeJJUp6NjFIKNjY180Awx1q5diwsXLsDlCmBgwILRUSMmJ/XweHR8ICfhJxAgo2UaG+wJAGiagM+ng8+XnOI9Gej1FEpKfCgt9aKkxAeSZDA1xQZq6uuzwO/XgWEIBINaBIOA2w2w3aUla3lKFVotDYuFVaKyRCVLVhqNN4lkIbHKbTMYbipWLZYIHI4gHI4gTCYKBIGkgx0l0yeoDTQxXXjzzTeTOl5t/qd7POD3k+jttaK724bubhvOnCnCjRs3VYnLl7vw/vdfRl2dfEe6du1ajI2NqbIu2LSpD3PnjuOnP23GyZMleO21GuzaVY3m5lGsX9+PFStcKC6WJvTUQq4eBoNBTE1NKb6fpYK2KCGZoFHChWSpMYgaiBWSao5PhP7+fkQiEV4FKIQckSNGJBLhLaSUyk9MPCmpT6UgdYza8hCqXoGb+RwYGMClS5dgtVr548SLEWIRwNWrVxMu0EciEVy8eBH9/f3Yvn07uru74XK5sGLFCgwPD/P5cblcvNWWGO3t7QkjzgNsuXB9DE3TCRdTQqGQ5Nhf7p4GBgZi3BuIzxWad4vrzOjoKO96QwhhEBspP95Xr17lSchEdYOmaXR2dsZsEysmOej1en7f4OAg9Ho9T0jmODFlpERInjt3Dj//+c9lJ+Mf+9jHsGzZsrQzl0MOYmR7Us29fDh/LMmCy5/Yz0tzczPfGadCYqm577lz52bcr5OaaKUA4kxfZrv5r1L+0nU3kUmXAkr5LCsrkyQkhcpgpQj0Un40MzlhSTWtVPw+rl+/Hm+++SZsNhtvZg3MTD0UK5KlyoHLV0VFhaRplRzScVdwKxKSFotl2vy7cQg5HBhetgyjLS3S9ZBhQAYCMExMQOf1gohEYJiYgGl0FMboxzIwgLxr12Bm/GgaPoWm4aiZV3t8chxojQYamkbEYEAgPx+MVgvd8uUYtIbA2DWg5urhzy/AcH4N2spb4Kas8Hp18Hs1gEYDjYbhTb1Z815WmafRMPB6deCqod+vxfi4ET6fNvrR8b+DQRLBIAmXywyfTwuzOQKnkyWG7PYQnM4gdDoabrceVVVu6HQ0NBoGJMkqAfV6GhoNDZomeB+aJEmDJFOPoF1aWqpKeRX/mBiYzRHMmTOJOXOUAwgA8epwmgaCQVJAWnJEJWt2zyklCYIBwxCIRIioYlKPSISCRsOSqmxeCNA0oNfTMJkiKCgwwGymQFGTMJkisFqV/YyyPjPZ58P60CTBMDaMjkb47ZGIRvAhEA6zv3U6mncFYDRGoqpJEqGQBuGwBqEQ+zsUIvlzwmENnyZFkQiHwe/j9kci7DEsmatFOMy270hEk7YqVQiNhoHJxObfbN7Iq4I5VS/n05X7RCKT6OpyoLa2EBMTQZ4UJcnMBRnKNsbGxiQtW+QILW5CnOidm4mo6AwDuN16jI4aogslRoyPG+JcMQwMWOByxZMdWi2N5ctd2L69A0uW3CQ2hO/tdFBe7sPnPnccly/n47e/nYuzZ4tw4UIhLlwojO73YMmSESxdOoxFi0ZgtUr7mM0ExM+qq6tLMogQh2TGTFJioHRB0zS0Wi2/0JOJNNvb20EQBMrLy+PGo2NjY6oVkhzEx3OL+3Km3slCnL7QLYG4nzhy5AjWrl0reS1uHsDljyPZ2tvbYxSSUpBbaBNCTNpRFAWXy4Xu7u44E2IuL6OjozHEH03TMb4apSB2PaWmr1SjKhXW39HR0Zh3vJigTeTHUzznmpiY4O9z9+7dMfcshUgkojg+bm9vx9WrV2O2cfNir9cbk6dQKMRbRxIEgeHhYTQ0NIAkSb7/VWNt9VZESoRkaWkpjh8/jqamJsn9x48f553y5pBDJpGqz8JkJ+NSK0rCNBoaGlBbWwuaphOaQVitVtTV1SVtkup0Onm1l5r8KznQTRUrV67kHR4ng0ySH3L9DAdxMBi1EE+Q1UbN1mq1aG5uBpBe0CIOGo1GdUTsZKA2vcbGxoyYS6cDYV5Jkkx6gihcIRWmtW7duhjn8dkGQRCqfLZyeayqqlJNSKY7OZgRQjJNk+1sBsdKBL1eL+0HkCBAmUzwJRjk6qamoPX7kXf1Khu8JxKB7cYNaAMBVnXp98M0NISwxQLj2BjI6Iq+NhiElfPR19ODWom07wIQstkQdDphHhpCyGZDyG7H0MqV8BcXg6BpGEdHoXO7+QBCgcJCGMbHQWu1iJjNGG1uhm9BKYyjo5icMweUyOxL6/OB0unAJOkLNylQFIzj49C53aANBkQMBlDRj97thtbng1avh87jARXNh87nQ8hmAzk6CtuNG9C73dBPTUHr80FDUYiYTNDpdNCGQjCaTKqDB4jrkEaDqF9JCoB6Iken08lGvuXABQWYmlKn1jIYaBgMsRNuiyUyLWS92A2FHCIRgidtPR5WxRsIsIpT9puMkp8kKEoPn4/hCdZQSBOjTPV4dJiYMPD+RL1ePbxe9X5bgY3R75uqLK2WJSY5kp4zOddqGZjNGjDMHJ7E50zsuWPF20mS4dWcViur8i0v96Ky0h1VuCZXxlKQIlPk3gHcOy6RAkdOvRcOE5icNGB83IDxcSMmJlhCmXXXoMfUlAGTk3q43XpMTOgRiai/QaczgOpqN6qqPGhomMDq1UOwWqXbx8KFC/lo59u3b+cX34T3XVxcrCoi+oIFY/jiF49icNCEI0fKcPRoGa5dc6K/34r+fiteeaUWGg2DhoYJzJ8/hoaGCdTXT6G83KtIXktB7rlILU4rLfCnouIrLi6Gy+XKCHk4NjYWY16aiTQ5pd7Bgwexfv165OfnY//+/TzhrsY/oJoo4+K+kGEYnuTq6OiQNXUXwuVy8ZGmOQiflzh/wnGzXN7F7wKl8V6yhLzYbyVFUXH1S0iojo+Px4yt1Y6z04lsLbyG8F0sfN+KFxwTkYNiiI8/ePAgtm7dyv+Xq2OJyFgOYjJSmM7evXvjVKZCcnx8fByDg4OKqtLz589j8eLFqvJyOyMlQvITn/gEPvzhD+PUqVPYsmULTz4ODQ1hz549eP755/GNb3wjoxnNIQclJJqQCsm6++67D6+88kpa19Nqtar9J6b6Um9oaJCMXjYTxEJdXZ1EBFT5+0qUR6PRqFqFmsi3R7LBYzg4HI4YQtJoNKpyjEwQBOrq6hT33wrg8llYKB1RWA4OhyPGLDqTaGpqgsfjQW9vr+pyVHqRJ1oZzQRSWQyZrkBCasiRdHHvvffi1VdfldzHpKmQnElCcuXKlTh48GDS53FlHrbbEbbb4Y+Oj2w2G7oFCyfr16/H6evXMTw8DK3HA/3UFMJ2O+wdHSBoGtpAAPPNZvRdvAhtIAAyEIB+agqFFy6wJFz0A4AN4DM6CofIrEgRv/sd/5PSauGuqUGgoAARkwnW3l44BQP/qepquFpawGi1MA0Pw9HWhrH586Hz+WDr7sbknDmofOMNTDQ0wF1VBVtPD3zFxQg6nSg5cQJanw8ESbJ+vjQa0DodaK0WxtFRnohNBbJvhm9+ExsBMASBsfnz4Ssthbe8HN7oN0OSCFssCFutiJhMAEFkTNkunIAJfZsKoeRbVu14YbqVw4mg1TK8SjGRkYHRaExIFDMMq1DlVLxcJHX2+6ayl1PksR8970OVJThJPihSJELC41HqgzJj/q7XU6io8KCiwoPSUtYMv6zMh4ICNjCV2oBUSiQM6xuWAE0T/DdNE5iYCIOmDYJ9Gt7368QERzgaMDpqxPi4EW43W2Zilw5q4HAEo4G2gsjLC8BmCwtcMURQVORDdbUbdru69t3c3AydTidJNpIuF6p27YJhagrWyUnU6PXoMhj4aF1KwSNKS/14xzs68I53dGDDhvvxzW8ex9mzRTh3rhC9vTZcv56H69fz+ON1Ovb51dS4UVPjRnm5B2VlXpSX+2AwyD8TtepTqcVzqSAscuCO4VRYVqs1ISGZqiIrkWmuFJTcDfT09CA/Px9TU1M8ISk0dU4UpX3v3r1xptFyEB7HmfurQZtCMD2psRQ3ZxD7I822ewRh+jRNS5JmYtA0HdOvZEsZLvcuFRKPqbpgk7IClDr+2LFj/G+5+xQ+68uXL8teUwqJAiYJ4fV6JefyHFKJuH47IiVC8h//8R9RWFiIZ599Fj/84Q/5Ck6SJFpaWvDzn/8cDz/8cEYzmkMOHFKZfApXMNRMPDL1MlHKq5rgKGrSmQ40NzcnpZRMlF+bzYZ169almy0edXV16OzsVPXc9Ho9amtrYTQaY14SFotFlcp0kUSQjJmA2jqxbds2vPbaawCAkpIS3hm12CcnSZKq/HTm5+fzhKS4vNWsdkuBu5fGxsakI3eKFwYy1W44J+Ryylk16lg5gmG6CMlFixbh3LlzWfWRprQgICQh6SQCYMmVixwZnum+ctu2bSmbN8qRwOJBcX5+PpxOJ+vvyWpFJOpjalRAsNeuWYPr4oBrNA19NAiPs62NJfsYBrROB0dbG/RuNwiKgq+kBBGTCVq/HwRNQz81BcpohGFsDEUiVw9kJMISkBLqAwCwd3fDLlLJ2QRqDls0ErCzrQ3O6CDfqTJKOq3RIGyzQRMKQRsMguACdBAEaL0epMxzYAiCVYY6HAjZbIiYzWBIElqvF4VRn1EEw6Dg8mUUKEw2GI0GYYsFlM2GoNnMEpVRsjJstcb/tlhA6/WgdDpELBZEzGbopqbYbXo9YDBAE4mAoChAxncXEK2nDAOt1wv91BT0U1Mwer3QTk6izuHAoNuNKaMRQacTIacTQYcD1DQssCRCU1OTqsmvEtS0UYIAb26dn59aW7RYrBgf9/Gm5YGAFgzD+gUNhzX8hzNFZ7tq1ryeCwrFmdsLt3NqUI4QHR01oq/Pit5eK0IhEp2dDnR2Skdw5gIwcQpLYX5CIdZMXkw0islHhsn8e4Mk6SjJGOTdNDidnKuGEOz2EOz2IJzOEJzOQMaDF8W9RxgGBRcuwPbTn6Lg5ZdBcATTL3+JxQAaiotx4777gLvuAkQ+5FpaWiSjITscBFavHsLq1ewYaHjYiIsXC3HtmhMdHQ50dtoRDGpx44Yjxtclh/x8P8rLvVGCkiWay8o8KCvzIUGQXh5S5AM3RkjkExyIJ6q5tqRELqlRlHLgAj2pgdTYRsmHprDdc2IANYRkf38/8vPz4fV6Vc/fwuEw7wYgmcWmZMdKnOm0mPRNZTFTCeFwOGZxS07pqDTuFkYizybUlHc6c2M1aQnNvNU802SvqaYc1bzn/H7/rFtcnCmkHCL3kUcewSOPPIJwOMzLlgsLC1NWK+Vw6yMdX0/pHpOJSG5KqK6uTut8YR5SUf3MFCGZ6ktjuvM7f/78OKfDcti2bZvk9kSm4RyEqjupZ5TqvSdznpIfIjGE7geUFIPz5s1DaWkpT15KoaKiAs3Nzejs7IROp1NcrTYajar8j8qhoKAA/f39cdvlVEdA4jLcsGEDenp60NXVhaKiIkXlwOrVq3HmzBnJNFtaWiQHXYmu/+CDD2Lnzp38uXLOxjOJmYzOTQt9CaWgQEumrywoKFCl6JAjNYW+S/V6fcqEpFyepQaw8+bNU/QXJZmWRoNQXh5CeXmSQXnkIIxkf+dTT8EeXYx547vfBRgGppERmF0uaCIRUHo9hlasQMszzyA/qi7p3bQJYbMZhslJTNXVwTQ8jIjRCJ3Hg2qB25LWhx4CM38+Ij090LvdmGhowFRtLZwOBybHx0EwDMhIBEQwiLDVCk9FBXgbV4aBVa9HcHwcxoICWPPzQUUiKC0sxOVTp0BEIghbLNB7PKhZuhStMn3+Pb/6FQy//z0AYHjJEowuWoTC8+dRKJjwUzodyHCYJWvdbsDtRjboPipKXjIkCRAEGIIAodGADAZBRsliKTgltkUMBoQcDgSdToStVlB6PSImEyJCItViQURAnlJGIyitFiBJMACg0bDfURtkhiQRMZnYBQMV7S0TqvPpGh8QBKLRxGnYbPGLBKm6e5EDRREYHDSjv9+C3l4rhobMGBiwYGjIjLExY1zApGyAjexOQ6NhSUabjTUpz8sLRr8DvH9Xuz0EqzUU/Q5zgsOMkM7pwHbjBrB1K9YJ+pWxefPgLS9HVSgE6uRJmF0uLPjFL4Bdu4AvfAH44Af5YwmCiPMJK4WiogA2b+7F5s3s4gpNAy6XGT09Vty4YUd3tw0DAxb091vg8egxNmbC2JgJFy/GW5VwitHCQj8KCgIoLAygpCQMh0OPgoIA8vICsFgikk2MM7cFEvttF98TFyxF6T2vxvInFahVK3IQtnuOhFFDSHZ2dqK+vh6Aeh/j4XCYFxgkQ8IlqjNiJBuAKlW0trbGuM44fPgw/1stIckwTExdUEs+JzuGTJeQTCXytxKysSCfKWL36tWruUC6UaT9VtTpdLmQ5jkAYH3ypUJIpotkB7epOIPmXvpAvCIrFRQXF6fk4D+bmGkV5q2OpqYmdHZ2plSOtbW1CIfDmJiYwLx58xJG4ZaKjFdWVoaBgQF533eIDbgS7zNNo1i3CwsLY9pKeXk5bDabbD1eu3YtXnrpJf6/wWBQTfLk5+ejtrY2zgwGkG5/SiaQQphMJsybN0/RfEItUnnO3DncgE0qcEGmMX/+/KQUEkIIfXqlAqFCMlmT7YKCghilYXFxsezESqPRqJqAAmxfPjk5GeOjDGD9+gnrcqb7w7y8PFV+rITIZB5KS0t5QpISKMFpnQ7eigq4JdxQRAT9zLmnnorxCcrB0tfHE5Jd27bh6vvfLxkN3lhQAE+0vsuaJhMEGL0eYasV+dEACAwAZ1FRTF5CDgcg6geam5v5aJqMgDTruesu9G3eDNf992Pju98NALjyN3+Dtr/+a2iCQRTr9fD09GBtUxPO7d8PnccDndcb8633eKDltvl80ITDMIp8jcmBDIVAJiAEIiYTQjYbwnY7QlYriubNA+XxYKq1FYaJCRgmJkBGFaRalwtml0vVtZMBo9EgYjDwSk9apwOt00FrsaAS4P/bS0qwzOMBrdPFHCf8HUOGGgygjEbWP6jRCMpoBKFWTnaLgSQZVFR4UVHhxcqV8c/I5yMxMWGMKiu1AKwIBgNRn5YUDAYaWm1soCjuW+63cBvr7zL9+6ivr1dNSKYarEqj0cS/m3p7sfj730f17t0ATYPSahF6z3tg+Od/xptRFXbV9u04feAAdH/8IxpffBGWgQHg7/4OePZZlL7jHRhcvRp5eXlYuXJlnH/3RP2pRoOomb0v7vm53Tr091t4gnJg4ObH7dbzgZzklLEA68f0JjHMfnOf8vJu+HxlcDh0CIfZ9wRFEfD5bpLYnHsCv1/LK2adzkK4XCtBknoEAqtBkkz0E1+PuO3CbcKI9wYD6xPVZuOCRIVgs4VhMFCS9cqVZD+k0WjixqbCd7wSycM9S7XvxDNnzvDjzWSJUw7puvbKJJTmqUJz40QKSakxjmGBJwAAdHNJREFUdaaR6riFExtkcxE9U2mrEVuoOSbZMeHtjKws0/X09ODzn/88fvazn2Uj+RxuYaxbty5mZSdTyDaZRhAEfw3OIX0ibN68Gb29vSl3gHq9np+4LVu2DKdPn87aSmeyWL9+vWI5vBXJTSFRJnzmalQYTU1N6O/vx40bN1BSUoKGhoaY/XfeeSf279+PLVu24MCBA5JpcITkpk2bZH361dTUoLe3V5LQBKSf29atW/H666/HkQhFRUUoKyvjSQAxxKukLS0tWWn7yUCv16c8OJWDGjN3MVLxV5eqj7v6+vqUScV0zgViVZFMgoUcsSpn3bp1MXVdqU9ZvXo1NBqNKqfwcuWY6T6roaEhxkdReXl5nOI308HYlCBU40YEhJAUychBjcm9cDulkJbwXjQajaxqgXs+wndu0lYUwvuL3ve6u+++eWz0GrTBgFB+PjwEAWrNGriSUHQXnj2LtZ/7HABgrKkJb37lKyAjEWjCYTAaDRiNBlaCQGhyEppQiA0uxNr8wm61gjGZMBoKIWyz8c+AW7TZvn07IsEgDu3axd0cH9ndMDkJfTTCOxkMQhsIQOvzseSp18sSp9zH4wEZDEITDkPDMGBoGgQAcN8MA4Kz3KBp6Px+QGKCJH5bVKouJXlQWi1ovR60VssTmZxvUcpgYJWf3MdsZlWgZjMinO/PKLkp/I5ECdCMRJXJAsxmCmbzTfM8uz2M8vJyBAIBSd9oM4Vk+p1U+yiLxYL8/HwQFIWi06eBF14Adu5EDdcv/PVfY98992DZO98JU0EBVpaW4sSJEwAAxmhEz913o+/OO/FATw/wpS8BV69i5Ve+gqnqahi/+EXgscck88qNZ+Swdu1ayeBANlsY8+ZNYN68ibh9brcOIyMmjIwYMTpqwuioESMjRoyMmDA2ZsToqBE+nw6RCInhYTOGh6XHX4C8b3JllKZ4njpotTRPTlosYdhsIeTlBVFY6EdhYSDmW8lHajAYjBOtCN8DanzpqVWmVVZWwmg04syZM6qOl0Kmx4rpoKOjQ3ZfT5SsJwhCcbFdKY3phtSiJPc/m/PcTBGSwnqcTprTYUJ/qyArhOTY2Bh+8Ytf5AjJHOKQCXWhFDIxgEokdU8WVqsVVVVVccFbOAJDKWI4wzDQaDSorq5GV1cXCgoKYLFYEAqFUsq/HFatWoXjx48nfZ7T6ZSd2Fut1mknJMXKs5mE+N43bdoUo8QSgiRJ3s2FeMIuhJp2w50vlZ7wGJ1ONyPlpHRNYV5Tqcdqz0nnvuXq9F133ZWxtDJ9jhoITXkzjRhCS6AKlSLo03G7kcj0XWimnYlyXL58OU6fPq14jMWSfpCMZPKajJo15rkoEZLC9iJnii7om5TSUktICklIpftX6hMZASFJReuGVqgOl5gEJGuKHKMyjZpEUyQZsz1sNsMv4ZeYdDqh1WoRFLU7Yf+kEZU9F9ndJ7BISrTYVVVVxU9WpQhxACAoCqTfzyowAwFoQiFowmGQ4TA0oRBKnE6M9fezpGYohHk1Nei4coU/ThMOgxT91nk8bIT0QIA1TY9+C32EkpEIyCxN+Cm9HhGjEbTZjLBeH0tcmkw84akzGkFPTcFXUoJAXh6oqOn66i9+EQBw9qmn4C0rY4lTnQ6UkDjltmm1gEYDgqaTVoGTJAmr1ZrVCbiwDojBLWKmg1T6U/3EBAovXoTxT3/Clv/5H5gEauqR5mZcfe97seHTn4ZfMG4Stk/OMiMIAB/9KPD448DXv47wt77F+rp9/HHg05/GwlWrMLxsGcaamrB00yYArCsZJcj5jFaCzcaqCuvq5BX6waCGj2TOBRjigg1NTBhA0ya43TQiER1CIfZdR5IMzOYwzOZITFR3sznCKx2XLVuES5fOgSRpEAR45eSCBYtx7txFUJQGFEXwHy7YEfc/HNbw0e4DAZIPDMUFPOL8q05MGDExkVjZbLOFkJ8fQEFBAEVF/ihZ6Ud+fgA9PZO4445C0DQfjyjpoHtqzG/dbjfC4TAcDnm1aqYQCmn4oFpCNavfzwbWomkCBkMERiMFh4NVxnIKVJ1OTRAjRJ8BgUhEA4rSxPwXbqcoEqEQQFGaqK9ZNtgYq76moNezKmzut9FIQaulFVXVDMMkreJTMx73+/1x/R5n3ZWsBVMyfVA2zLfTISTfiuIdOaTEDv3lL39R3D+bWPgcYrF582bs27dvprMBILP+0xYuXJhU0BU5ZKpz4Dooi8USNzGVUlTJXZcro2xFm1UTxIWDw+HgTSKFk6UtW7bEHLd58+ak8pBJqI3cnSmoCWyihMrKSpSWsqvb0+WTs6WlBUB8tEc1flqFx6TrKiFbSHSdVPsdubaipg1l4t7TIVOVVJxVVVUYGRlR7ZspGcSYbEcJpMWLF6v2uyQst9raWkQikYREIEEQin641Jr3Kz2ziooK2Xxw55Ekifnz5+PKlSsA1EdhlYKUCbQYiephjL9bYYROJb/fapSJgvMZhcU2tW3AZDLFmN4zDCOZnsFgiAnSFaP6Fpmk5+fnx2zj7quxsRGjo6OoqqpKun0JiUdhPVfjS1uObE3Gb/TmzZvR0dGhSEhWV1fzVhqyC5kkyQZVAiBVQ83V1RgQ+C6bs2kTOqIRfuUg6z6BYeAwGgGvF6HxcRTZbHCPjYH2+3lCUxM1cdf6/ezH52M/fn+c8pMMBPgI9NpAgK/XvJn81FRafkGXfu97SZ/jLS29qeaM+vaMiIIlRcxmREwmmEtKoPV6YfT5YB0YQJRRYknbqH9PWqMBQ5Ks6pYk2W1RchQEAb1er0hoLlmwAL1y/rXD4ZvBYgBoKIpV846OQs/52WUj+7C/CYL1ARsMss8pGITNbgfldrNlHgyyz8zjgd7thn5qCoaJCfZ7chL6yUkYJifjXBgE7XYYnngC+Nu/xREVwbDmz58Pq9V6MwCewwF8+cvY3dyMmldfxYJdu4CBAdTv2IF6jtRsaACWLwcWLcISgkAvwyBQWIhAQQEoAUmZrXGKwUCjuNiP4uJYcod771qtVng8nqT8mtbW1mLRImDHju64fdu3L8GOHTfSyjMX6Z4jJzmi0u3WY2zspgp0ZMTEq0Ddbj3cbj26upQsyap5ks5u14Ak82A0UjCZIiDJ2L6eIG66IWDd3t40N9dqWVJW6hiCIFBaasXQUDMA8O4MhO4NONN1rfamibsUYRsKkXwAK458ZD96hEKpq7F1Ooq/By5PLOFI8MQjTWd33EySNIzGCEwmCkZjJBpILMI/D72e4klNo5GKIce5j9FIgSTpqL9eCoODLEmr11PQ6aQJTyk1bLYES9lGorlTLmiNOqT09N/+9rfL+wCKIsf65pAIydSRRJMFu90OkiRjVj8yWQeF5mPpwG63w2w2g6IoVek1NTUpBj1IF8ms7CxdulTSBF3O/Hc2YuvWrVm/xvz581UH9+IUi+JtqUDtyn6qL32lfCUKEJPo/ET3vH79ep7ESsVEWnwNkiQl6/6DDz6Ia9euSba5VP09arXaGLJo+/btKaUjVUbV1dUxjs7lUFtbK0uSZLKftFgsMYMvsQ/Jmpoa2XqaaKGmpKQEABuJlDOlmjdvHq5Fg64IUVNTg9bWVj6qZDpEuhKE5FOiYATprKLb7XY4HA7FwF3cfXEEheIYTSUhSajIMyXsT1S2caVnQJIkSktLeRJNfA8bNmzAoUOHYtLQ6/Ux9UdIktJ6PVavXh2TN075yRGSqYAULDQKVaIrV66UVcQngnCcw92fnLJR6NdaDgRBwGAwIBAIzI4xOUGAMRgQYBiEtFoEiovhtlr59lxfXx8naFi0aBEuX76cWNnCMGykdgFBaQEQmZgA6fdDGw0iZCUIkIEAwhMTsHi9wNQUS26GQrBotQhOTbER58ESZWGbjSdKeeVoOCzbNiwp+FEvAqA+PFXyeDCFc6RD/2UGDEHAV1MD3YYNOF9RgcFVq/DgO9/J7lRBSMohr7YW7Q89hAXPPQe8/jq6v/1t5F+6xJK9bW3s53e/QzUAYZjKkMXCk5PECy9g5cAAhlasQMRk4v26hm02hGw21pdtFtoSF9gimYURte6jUgVB3Ix0X1SkbE5dVVWFK1cGMDJiwvg4S1YOD98kK9mPCV4v2zcHg1oEg1qwvHc2lYypmsGrB0EwsFjCkmSdRsMgGCTh92sxOWnA2JgBPp8ODEMgHCYRDic3niUIlohlPzdJ2Zvb2O0aDds/RSIagQqWJVdDIRKRCFvPKEoDr1ePzHNm9/K/tFqWmJT+3NxnNmvBMAHo9bHbtdqbx3P7tFqaD1hWWGhCJIK4spcjQzONRK4GlFwJJVpofishpZlpWVkZfvjDH+Jtb3ub5P6zZ8/yKpwccsgEpiMarRKSmUwuWbJE1lxPSN7NBvNiQCHAAKRVQzMZtTddSJnrcApFKdjtdkXlkbh87rvvvqwQfomONxgMCU2Rli5dmlYe0lVIGgwG5OXlYWJiQnUd4nzOCsmGNWvWyPrIVIIaQoQgiLjnl47aC2AH6hUVFaqOnTNnDtqjk2ExCgvjI3suWbIEExMTqiNDZrvtistFGGWbThA0SaPRqCK2hairq5MkJLn0tm7dildeeSVG+Sn37FLpj4X9eaJgaekSkjU1NYqEJJd/p9OJ+fPn49y5c7JBeoQmy5RSf5WkQjKVRYcVK1bg5MmTuOOOO3Dw4EEsWLAAPp8PDMPwpqbCshP2BVyacQoxQZ6oqC9muTwpqQe5PEmBFPS3cqa6SiSa1DXnzJmDc+fOAYj1pSmEUH0oZWYu9JGnps+76667sHfv3pht4sXdTEKcjzvuuIO32ikqKuIJyWXLluHMmTP88QmVYwTB+gQ1GFjFHNhgQWJzQ2c0WJJUIJa5c+eit7cX4aEhaL1e+OXGBgwDIqomJCMRGIeHMef//g+Dq1cjmJ+PKqcTw+3trD9Pnw+lJhMmu7pu+vmMKj4NoRB0DAOSohCKLmYwrMSLvQZNs9ehKICmoeHUkzMAJqqOZAiCjRwfDYCk0WpBRyLsNr0ehM2GsNUKn9HIRoR3OBCy2xF0OhGy2/ko8ZTRiI0bN2JAwie21FjGYrFgyZIl/P+SkhKsW7cu5pg1a9awiwF6PfDAAzgXLSvd1BTuLS4GTp8GrlwB+vrgvnoVptFRaP1+6L1e6L1e2Lu6gNOnUQqgVMaVEa3RICwgKMNWK/8dtlhQ0tiIrvFx1vep0M+pIKhTxGBgFzE0mjjLBM61iBpIten77rtvRoKxaLVaWK0RWK1u1NbKt9NgUINAQItAgIxGnSej/1kzZ4riXHZwr5/4/xRF8CpCiiL47VwxMgy7raqqGt3dPfxrjDNZZxiCN23nPpwaUahYJEkmSoKxakGLJQKrNRQN+BPmf5vNESQzfKBpwOfTwufTiUzpCZ5c1OlY1WYs8UhnzD0uRRFRolRY/iT/bDiT80CAjCpFWZN+sVk6TVswNRVBJKKJITyFys5IhEQkQkq5J84qhOpPg4HiiU0h2HrF5pWiCL5ehsOsQtVgoGCxsM/b6QyioCAAhyPIB4ji1LXsc4vfxv3nriVU6Go0nOIXmDsXmDdvestntiGlmXNLSwtOnTolS0je6qRFDrMXifxKzQZUV1cnPgjSE9SlS5feNEORQabvf+XKlbJ+JAmCSFnRdauAU15J4c4771Q812q18pHhgOyZHGSiP01EWAqvIY5AnIl8GI1GbNiwAcePH+fNLBNBithXqz5NFam2L7lFOIIgVKs6GxoaJAnJxsZGlJeX8/9ra2v5IAiVlZUxURY5zJ8/H2UCf3OJkA3n2lIm20pQYzYt3rZ69WrZ9LRaLR588MEYNyXC841GI7+6nYryVpyXmpoaXnHHmRrrdLqk/WSJ01fT7rhjFyxYEKfmLSgogNFo5E2/CSHZJLpvocpVjUKSVlluwrJqbGzk/V1ydZRr6yaTiSfa+vv744hiVQFuEhGSgv8ajUa2zXPklSSEKkyZui0XFEHODL24uFiQRek8CetpY2MjDAYDT2ICsf28cCyeDBG/evVqxQBkybp3WL16NY4dOyaZD+GCn3BfeXk5zpw5w+dPbsHg7rvvxu7duyX3icu4rKwMkUhEtj0SBIEVK1bgwIED0BQWAnJuFggCjFYLSqsFBSBkt+PMxz/O7177wAM499JLANgFKaKmBhcPHYpLpri4GDU1NSgtLcVralW1USUoGb0HoVsIKdx7772yC3gFBQU3FcIMwwYY0uvx4F/9FXbs3BnTThYvXozzZ89yNrH8duEiUkVFBfx+P2iaVhV5W6oNLFmyRHIMrdVqY7br9XrVLnrCdjuwdSv7ieLASy+BpmlofT4YR0ZgHB2FaXQUS7/73ZhzJ2trofd4oHO7oQ0GoaFpGKamYFBYBHSqyhULWqsFo9GAJkkwEr8NVit80UBZIAhovV5eoauLtoltoRC/eKTV6fCAVguYTNgcDoPW6di6Gv1m9HpQUbP/0upq9I2M8P/5AFPib52OJVU5kjXqP5XW61mXBBaLqsUrAFEfhiE4HJnxYaqEDRuKceiQ9ILlTEKjQZS8nbmgOax/0gjMZjlnHeqwYMGCuPHn6tWr8eabx6PkJKvQ5Ai+cDh2m3A7ax4v3h57zs1tLPkZDmui5CnJk6TBIPs+zoT6MxQi4XZnXxB15gzw299m/TKzGinNnj/5yU8q2sQ3NDTMGj+FOdz+UEsgcER6Nq+hBDGZOmfOnLiO/Fb1oZEOFi9ePNNZSBl1dXWwWq04evRowmPXrFnDH2c0GuOIlEyb32SauE5XIZkobQ4URcWRQ4lIiGQIm3TypgQhYZgq9Hq95CC9qKgo5r/ZbE5IzJpMppRV2JkKdBMTZTsBcZVKYCOCIGJIHCH5IvxdUlLCK6+EZdLS0sK7AtDpdDGRvsUmwWIVnriOaqJqFzGJyF1PeE+pkurJqNmFECuJlFRWd911183FCDXPQfiM+U3x9S4/P5+v11LR26Xyv3DhQjAME6MakrOWEJZLjMm2RBAvJnotgiCwcuXK1PoGCd+ZYjQ1NaG7u5tX9gmDK0kpEMX53L59e0KfqVIuUxobG9Ha2iqpkORM3pUgdqsg9GGabFndd999kqboidIS+mIV/hf76DSZTKr8dgIseXfhwgXFY7h6VFJSgvnz50Ov18cszm3btg2vvfaaYhpcQMLu7m5Fdz8p1buoEpSOErkVzc04LxG0hg9mk5eHsIx5f8RmQ1iKdI2SX5Lb47ITS+4zDIOysjKYzWbe1UBNTU1coIqamhrJPKld0FeL0tJSRQuCiNkMT3U1PNHrLjWZgK99DQBw+l/+BX2bNvHHakIh6NxunqDUezxoyMvDwKVL0Lnd0Hm9KDGbMdnbezOoE+fnlAvuJCLDNdFFC6W3Y6KRobhH5J5SQqcOR46gMtExKsFotZhrMrFm7hYLqxCN+lKlTCYwNhuCWm2MYrRx6VJQN26wKn3OT6rwQxC871QI/0c/EB8fPYZLi4gqi5OSL2YKnKQzxWsvWrQoYV81m8GqOiOYCY9eFIUY1a3fT/LkZTjMWR5A8M1E11mYqLk3ay6u0dAIhUjed+jYGOt6wO3Wxyhrb35zH0QVtxqEwwSv+iWImypdTkHKBR8qLU3sguV2R0rsxx133KG432KxJFQW5XD7YbarYsvLy1MmJIHMEzxShORsh06nSys4gxTkBqZqMNvVskJwypXS0lKYzeY4AjITUXlvBSRSokUikThiPtkIuFJQqivcBF58XHFxccrqtnvvvTclQrCxsRFlZWWw2+14QyJ4xP3338+rI4GbZuZyaqyZREw0Z4nnbhKZVKppz6m8ZxYuXIjJyUmMjo7GKSQ51NXVKT5rzoSUg7hOilVjmTDZFtefBx98EDt27JA0bRcTOErIltknQxCora3FnDlzsGfPHn47SZKSJGQiSN2LsNxLSkowODgYr5QS+ZCMg4CQTJUcFtZnRqad19fXY2xsjCcky8rKMDk5CYZhYLPZoNfrVRFpsVlP3EY4/5JS5F9eXh4AdcQkh7KyspR9XWm1WkU1ZaL7KSsrw9mzZ1FWVoaJiQk+LaEyR+4ZittcomtxPje5c6XIb7VjjiVLlvCEpNL1pJBMYBO59q70zuQWvex2e9oLT+I6xjAMGhoaAIAnJKXeg2rfjemO8UpKSiStF8T9NU9qC8qNEj1/Wq9HsKAAQUF/U9HSgnbBvMK8ejVORNXAQKwKtbS0FIN9fWxQIIoCEYmwZviRCG+aT0Q/SxYswMWzZzG/oQHXL19mtzMMS/Dp9YBGgwWLFqGopIQVABEECI0GmzZtAkIh9hMM4vAbb0ATDsNhNMI7Po4VixbhwqlTKLTZUFZQgKvnzgFR/6jVpaXo7+yEJhKBJhxGaX4+Rvr6WN+pUWJV6/ff9KcaDELn84FgGBCRCBvISGW95SBv35AZcPZdtAyJiSjJSXOkZ/SjNZkQikTYQFIEwbpP4D4UlfCbjI7HGILgFa+qvkkStFYLi9OJlX4//58bS/H1hKZjAk7FWTMIxQPcb8G2sNXKuhHg3C/odDDm5cEdiYCKqmMZkmQXQEgS+SUlGJ6YAKPTxeTXSFGwd3WxRLBGA2bePDA0DZ3Hw6uuAXbMwZc/Qdw8nlNcZ3AuR5KAxcKa2E83hP1KIksC4bj9drdEVIOkCcnz58+jublZ9cvk0qVLmDdv3ltS+ZVDZpFoYDLbCdHphjjARCKoGfiZzeYYRdJM41Z85g6HAw5Hdpx433///VlJF8icQnLJkiUIhUIYGRmRDNhQWVkZ977Q6XQx6iIlyPn8FJvmy91LeXk5T5yo9f0ohVSJjkT1gyTJOAWg8F7kgmDIQeo5ptqu4vwoioLaiLFhwwbe311GricTCAUAmpubsX//fkmSxmKxwOl0xpB84jQqKytjCEkxxINPcTCdVGA0GpGXlxdXp1esWBHnJ4y7F04xp+i/UDRIbm5uxsWLF+OOiyiQGg6HA1NTU7H3yDBYtGgR/3fVqlU4fvy4qr5C6Ri5cqyursbly5fj3knCoymJdihnYs1h5cqVOHHihOIxUGjfW7ZsiSFkOXD3uGbNGpAkia6urqQJSavVGkMOCsvm3nvZQAIcGSWnTASUg3RJuSKQI5OTdUkgVgxy+RerwLljuPbMEW80TaOkpAT19fUJF3TlCEmlumYymZCfny9b5zLp+1suHxaLJYaQFJdxIsWq2WxWNGfm7i1ZNxVSfasUISnMR2NjIyYnJ2EwGPjFbK1WG3Petm3SIXSamprSWqitqamB1WqVfGZ2u12aZBdIumgF/+EAm29xUCzxwmB9fT1/DEmSAEmCMpuRyEMr1dICwmKBZsECjEj0NdXV1ShcvBggCHiibl7uuusuQFReo9F7NFVXY9zlArZuxaL3vpff3/nKK3yeizZswKVDh2Cz2dDY2AifxYJTBw8qu2FjGJCBAOYUFqL/6lVofT7ofD5WIRr9Tfr9rF/Vzs6bitFAAIUmE6aGhlgTdJqGSa9H0OfjiT8ISUDuE/Xfyu3TqFxc00TTSwbKT18dCIZhyckUFoxnW7jQOpntwlHy1ObNMAC4N0krWUaKqBQpZWmtVprIjX643xzJyqlr+d/R/xzZarBYWHcIWi1vNcGDIG6qzAHenQUl+NAGA0veRoldEARbzygqoZqXoGnU1taifWBAMbDgWwlJs4TLli3D4OBg3OBBDmvXrsXZs2dRX1+fdOZyyEGIW5F8kkM696J2EFlbW5u0IkWMW0mBmG2sXbsWR44ciduutNgijOqd6jPX6/WSA2opYiWZCUaiIByJjk8VWq2WL7OlS5dKEpJiaDQarF69Grt27UqYPheYQExALl++XPL4urq6GAIwka/N2QClCUJLS0tShGQ2wBFciQhJtaaMwtXjysrKGIWo2jQ5srC4uBjXr1+P2ceVZUFBATupSwFyCkkpP5DiZycmkYWBRjZs2KDq+uL7llLM8oSMaGIm14ddfvxxFJ47h5F3vCNmO2eaKYZYUZRMn5HMsS0tLTFmxXHtQRhFXEAqeJ54Anj5ZfTcdRceeOABybQbGhp4FaEShPXZKiL3hGbUhYWFcS4YuD5GXIY6nU7RJyrAklHC4B5S4MgoJR+S3H+dToeSkhKsWrVKNjq4+L0iJpN27twZs7+srCzGTFbuXUMQBDQaDXQ6HdasWQOGYfhAZlKw2WygaRomkyllFw8A+05tbm4GgBgiXuiHVe5dmux7MJHJttQ+sapGfExJSQnGxsZkyVFxexYrLsXltXDhwrTHilw+hWlv2bIFACtkMRqNPCHpcDhi1KdybhgaGxuTzoOQ3FRyB8Tls7q6Gi6X6+YOQdsV92dCEAQBvYR/WqXxoN1uR19fn+x+MdavX8//FqriCYKA0WiMu7ZUOXLvEq1WK7lIKtWONkXN1LkFYOFzjVu8IghQJhOo0lJ4RAKI+vp63lVKwZo1uCBybXTvvffioMC/qbjtz5s3TzZonRBLFi/G1UuXEA4E2HdbVE26fs0aHDl0SJ7gZBh2G6dsFPyuLC9Hf3c3nDYbpiYmwGg0KCkvx4DLhaKyMgyNjIAhSeQXFWF4YoInnPJLSjAyNgZKq8WcuXMxPjyMieFhaCgKhQ4Hxl0uVhnLKWSj33WVlehub+f/V5WWQk8Q6G5vZ1WRkQiMZjN8odBNM3aCYBffYu2P2Wcp109pNABNI48g4B8dBRkKsT5pQyHUFBejv6MDZDAYVyZFdjub92heuG8DQSASCEDn9YIMhWBP0V0fQdOYjbNNZ5bTbwIQstmAo0eBBQuyfLXZjaQJSYZh8PTTT0v6rZFCXPTDHG5bqHUwnQgPPPAAXoo6BE8HxcXFqhwmz0aiU0ldJadQFPuorKury8ggU4zZRFIqKR6EgyE1aSSCXP3Oy8uTVSZmitxKJR015mnJgCTJmAmQ3GRIqN5IhEwRFlz5cBM8gkgcSMbhcKCwsBBz584FkF11aTahqF6IItlgYKm2cTH5JoyyLSRwuEmSnPm00v0sWrQIfX19CIfDiqS6OA1ukp+XlxdnHiM0seEUOXJpceT1nDlzYLFY+CBEVVVV0Gq1cLvdsFqtKCsrQ3d3t+x9CCEm5oX1WQrcdmHACvGxCxcuxMmTJ6UvmKC+cASGv7QUr/33f2PlmjWwXL7MK+7NZrPkMxpevhzzFdLdvHlzSv7FpQhcuX0AYoL23C8gU6e+8AWc2r4dWq1Wsv8qKSlRT4KojC5eW1ur2hcYQRBx7/dULUOWLVsWF+BGClqtFqtWrYrbLhdpW47YFIIjRqwi34VSajeSJHllJ0EQioq4TZs24eDBg5KBjqSUmnJqPo1Gg7q6Ol79IoYSIS28ttPpVBW8RQ6JFk+krgmwpPmVK1dwzz338Ns2bNgAq9XKK7M9Hg+/b9OmTWhtbeX94xYUFMQElktmrLh161acOXOGN/Xm6khJSYlq8/Q1a9aAIIikIkqrhRy5Kcby5cuxZ88eLFy4MNYNkUpCUgr19fWKFkR1dXWKAYiUoEaZK1X+XHuqra1NKsidHCorKyXV9FLlLmzLYlc4LpdLlrzlSE+l+mS32/lFj7Lycgy5XHFqc6KgAKEkrJGEft4LGhow6nRCW1KC4WhbKWxqwtjVq7BUVeGOpUuxY8cO1CxejM7z52/ec3Ex/NGxTsTpRJimEYjuoyoq4JawOmhqakJpYyNOCBaE8hYuRH19PQ4Ktt15553Yv3+/6vtRChpkamxEW9RNEYfye+7BGZlF/+3bt+OQxIIVt5ihCYfxwEMP8dspnQ6v/O53rDsCRN2aCElghoklhaP/hceUlZRgqL//JjEqQeRqoh+CoqAJh6GJRHiSlaBpaCgKZCAAMAyqy8vRd+MGb/ZuIElEfD52vCBh4l5UXIxhl4sNJCZIV+qbjHJdvIk/p+Tl7pO7Lwno3W7gz3/OEZLJnrBx40ZVKxYc1q5dmxH/XznMfhQUFCRFRiQLNeY2QixZsiTlCG5SL8pMEHEEQcDhcCia0wFsJy8HJaKFG4BXVFSAIIiEaotkkZ+ff8u0Z4PBkFHyVCmtVCL0ymG6lIpSCkslNDc383m79957VZkkb926NS2TXCES5TFZtyAmkylGuZ/JZ5gpyPmGzMvLw5w5cwDIE5Ji5cOMLCQIFZKC63MTFWGepEgihmGSNpuXKw+j0YjS0lLJc8RBX7hrA+zER+jncuPGjQBuBl/gItJXVVUBAK5fv46ioiK+n5RSSGYKwvIS13+5ibHFYoFJ7BtNRIAYDIabiiqShNPpRFFREcLhMO688060t7fD5XLxZb37pz+FaWQEk1HfcUIsWLCAV6SKCSohUq2fDQ0NyM/Pj138VogiDiCGyBGCI+bUmCBrBe9BnUriIht1QI48EyvN1RCJQtx///2yikkxxP0UwzDQaDTYvHlzzHFOp5OPai+HRPmiaVqynyBJkn9uOp0O+fn5sFgsMYuSBEGgoaGBP1+tlYDc4mayJBFntswFyRKez/Uj3D1K4b777otz1cBBrIATu+sRkkPid7eatseVjZDkXrZsGXw+H4aHhzF//nz09vZKlgn3/qmoqEBfX59koK/phtlsRkVFBTQaDd9W5HxISs1rpOYjSuN2QL6+cP4rNRoN6uvr0dbWpphOS0tLnMuFe++9V3EMZLFYZMn+BQsWoKamRpYgVuOqp6amhidbFy9ejPPnz8ccK7x3vV6P4uJi2bSqq6t5gpxToXKksZiUs9vt0Ol0WLp0aVw0ean6ZbfbUV1dLUmqCl2jJDvflIJaH7biRTCNRiNJHgvHqJxFhpLLjKqqKjAMI+kWRGkhKRlw6dA6HSi9nifmwjYbS86lMa62LFoEb5Llr+SqrOTOO3FJUHfy8vIwPj4um9amTZtwSsKPe8oQkK6IvouMn/oUal99FRC5fngrImlCUsrJfg45cJiNk/pUkAzpJlxVU3p5cS+nVMxQ1IK7Pmeemml/jwtuoRWcGSNhZDDblLhykzHOzEoMYdtWIiPlVG85JA+5+ut0OuF0OlWnwxEE0w2hQhIJ2qKc+WIy7xQlhaTZbMbKlSvjrglIK7fSaa/cudy3cKKj1WpjTPGE+ZD7L4Z4srRx40ZVJANBEHA6ndALnsv69esTmohyMBqNvKmgsHzqN2+OU1iRJMlPkIXppeK8nTufMyUUgnufChVfSLDgl6hOcWbEiscI0jBLjBfE95nKZE8NdCqUmtXV1ZJEx7Jly+KOTWXB8Z577sHLL78su1+ufosDu0kdK4YcISk8r6CgAOXl5XEB+AiCQGFhIf+/rKwMTqeTV+3Ktfna2toYQlLOfYscuLxVV1fHRD+Xutf581mNsZAAU0OOJKOkVdO3qVHeWywWVFZW8iKVuXPn8gFtpK69fPnyGHcDer1+Rhe4uXEyp7g+deqUpA/JZcuWSfqEBdSXu0ajiTl2+fLlOH36NADWZ+2OHTtgMplky5w7V67/TNVnNZeu2gVduXGE8PpS/b7YuiaRWOLBBx9ET08PtFptDNkp7ruVxjVSxP6dd96pymzearWivLw84WKvGFLtrKKiAgMDAzH7OJWoFIQLmhzmzp0bpzhdsWIFioqK8Morr8RYS3AoLCyEw+HA4OAgrFZrjGo6kRuoVBAxGm8SktMcXttoNCIQCMBqtSYVOwFgyfSurq647RmfPxIES9BydVinQ4BzPSN4Nm9VTP8MJYccZhArVqzIeJqZIF0STUiTVbNlCrONRLtVsXbt2rTT0Ov1/GAsE89Frh5x7jjkHM0rQW6iLzZ3T2X1OdGxZrM55UH5bIVaBU6i+kDT9LT2GxzREONDMsE54gmbGsiRbtlSRqcSnI8gCNxzzz18u9LpdJJETLp5SwoCNVt+fj6cTifvuiCZ6xIEgcbGRknl47333hvj51EJ27b9//buPEqK8t7/+LeX6e7ZehZmmH2YjWGZGRhmBkfWYQQcRiQJ5iga9IjbCYlJ3OLCMUqMUTnK9d7oMWqSe9GfWxJzDUlUMF4Fo4aICxC5KkrA5SpKjLIZZJvn94d2pbunt+qururl/TpnjtJdXf1U91PVVZ96lgGx2WxhL7ZHjBghJ554YsSJWAL2gQRnEffvRhyOUXUsWlDpOwZEal0aTX5+fshjY6jxeufMmaP9f/BNj7q6upA9DyKNMRmKL6AfM2bMsOf0BJL+ZfV/3eTJk6WmpibiDKe+cvt/ruGW9607OMBN9HgV6lhVWFg4bHgUIwLJUMtF+t2I5b1C1YNwv8G+Zf3rSn5+fsB3mBL8giDPl62Pw/3O+P+3r68v5OrCjeEa6lypq6srKefckW4C9fX1SUNDg4iErw/xTmboX4eLioq08+BwPcRCTSTX19cXMuQOLo/T6RzWqtC3P/t6k+hRWloq3d3dEbd30qRJEefT8N/+sWPHBvwe+npUBAvXiyO4bCJf3FDx1aOcnJxhN1x9+2NdXd2w1urJcMzvxutRAwJJPXXN9znE87vsG09YDyNupNhsNjnmyw8IJAkks1W2thwzYgyVZJs0aVJM43GOHTs2rvUHvy6V6oKR9A50n0xlZWVx1fOCggKtRcfAwEDILiXxihZy623RU11dHfZkKviEMrilrdPpDHmC7nA4tG2Otr0zZswIe5KXruLdx+12e8iQwFcHTz755KRMNOf7jsrKymTkyJFfjBsUw/LB/x/r+wQzslW0f/jo+9wGBwdjKluofb22tlZ36/hw2+IL7/QG+1rZQkxq49+a3uPxRA3DfdsYamIHEdHVLTPascZmsw2baTyYr753dnaKx4QbEwH7plJRA0y32x3yGBcqqPHn+xx9F/F6f0cqKiqkoKAg4DsaP358XPtJR0dHXKF8sM7OzrDPhSpXc3Oz1jW9o6NDC1J9F4VKqZDlCh7uQk8rwlCCA9xoy8+dO1fGjBkzLEgP1YIslBNOOEG6u7u1VpP+y/uHEQMDA1Fno461hWQsE5b6QsdYw81U660STk1NjYhfPTrmcsn48eMjbpvvuw13kyk45M7JyZHRo0dLRUVFwFi4Iv8a29RMHo9Hq0f5+fkB5wWRgthY+I5dJ598stY6ubKyUtfvlf9+7X9+6buR4P8b6BvepaysTNrb27VlxowZE/dkdZHKWltbK3l5eWEDU/+yNzc3B9SRUPNrVFdXS05OTsDrgvfHBQsWBFzH+pfPvy52dHSIyBe/K6GOt8HbFTwJZDyMDiRDCXdtHOl8xTe8TjDfZ2C320O+PtI6Y22IFGk5m80mn5eUyP66OpE0yCaSjUASWSGWk3izxu6Lpra2NuTdF6OC22R2GU8lVVVVIQfrTydVVVXS3d2dlHUH1+dQ9SuR7pWRBE+KVlJSEjLsycnJCTveW7BwJw9z5swZ1rooHS6ORL44kWpra4vYMizUtpx44okBAVNwC0mbLfqkP/HIyckJaCGj/E6sD3u9ARcUI0aMiGmSpFB8J8+xdp2KR6wT9wVzOBzaRWiiN0US2YaIdTxECxX/VlkTJ06U9vb2iIGo3q5syea7cKurqxPnqaeKiMgRA3/rfK1SfNsYsE9GaBkmItLf3y/Tp0+PK2zwfSeRWmT4tj3U59/Z2TnsRlFzc3Nc31XwMUPPTQ1fgGuz2SLu66HKNXbsWK215siRI4cdz5VSkpubO2xWZd9yvn052jaHuyiPtB9E4vF4JCcnR2w2m3i93oDQPNzr/R/Lz8+X6urqgG7mPj09PdrnGMvNw3At9YL5PsNoLcNiWVfwe6c6XxdunyG3W5qbmyMe66IFE756G9zS3mazhQxK4vndMWpCvtzc3KjjYIYS3BI++EaZ/7ZPmjRJC8v0mjx5ckCLyOB1+76nkSNHSmNjo7hcLqmqqtImq4t3jMQRI0ZEvCHm/52VlJRoN08KCwsDyue7qeR/juCvu7tbOjo6AoY1OP7442Nujee7KTFu3Dit1Ws4/uVasGCBIddK/oFksrps+382/iZMmKB9TqNGjRKR4WOD621hHm75WFqx+oTqheC//g/6+mT9HXeI3HJLzOvMVASSQJoy4uIvXU4Uown1WXg8npju9qcas76TZIQHesvuu1CLpTzxljc3N1d3d5Vo3VeT8dnNnz8/5ONNTU0RT6RDlcV3Eeyjt4VKvHUwPz8/YMZc5XDI5l/8Qp67+WY5WlAQ0AV06tSpIbslxiJaC6t4ui8msow/32DzoV4fLsjT+57x1j8tdAwRSHq9Xu3CNpb39w84fMvPnTs3rnIZRbuB0twsT9x7r+x+4gnD1u27kRfys4kS7hcUFGghRKjX+08YFszpdEpBQUHIiZd8jj/++IjvL5KcY5aemxr+N0Ijvc6/nJH281CvCw46fReD4Sax8Td//vywQwwY8dn19fVJWVmZtLS0BHQv1HsMOvnkk2N6v0g3HEPVNV+rq0itrv1bFOmVLjcB/WfbHfrydzeRmy/BLVfj/W0KFUr7mDV2f7jwNXhMZN+NgFD1xOl0GtLK2idUIOn/ffX09GjL6BmGKFRdj/bbbbfbtd4Gbrd72A2OUBMUBnM4HAl9n3PmzAl73RPrsSMWvvoYELj6B5JRWmzHKng/8P+3f2vJ0tJSrSeAr4t+pKFx3G531JsJ4Y5zeuqvr87oGfM9W2VUIHnHHXdIQ0ODeDwe6e3tlY0bN1pdpJSXLjMmxysdumjrFal7XLaINrnOSSedFNN4gsFjNSWT2eFvtBPfWE96kl3ucGMvWSnU2GbJFm89jOUCx+12W3as/7ytTT6N0PXc6XRKa2urYRMgWR202+123d1rbTabYa1c/NcZTGudEqb1RKwtwWpqaqSjo2PY9kXrVm2mwyUlIgZNJDNt2jQZMWKEtLa2hj5u6th39V4UtrS0yLRp0wyp13pbvDc2NsZ9DhWq7vsey8vLC3sDxn87Yx2Cw3fDJdL+1tHRkbRQLNxM58GKi4u17tci+ieW0HOzRS/f+Oq+9fsC5GhdDmORLl22h4nzN9nXQmvWrFnadocKhPV8JmZ35Q4l1vOiWG8yB4vlc4kUUOlpueYTrQfS+PHjh809EK58DodDlFJh63tZWdmw8DZWsZ5L5ObmxvQ7Huv4zkVFRSFb7YYKfwMCyQTGPI4kVAAdbplI9aivry8guNXTQtL/8VjP2/WsP1sldCXum5kulLvvvjuRVev2q1/9Si699FJZvny5vPLKKzJx4kQZGBgIO4sVvpDIrMnJGIMsGj0XhjabzdDurvF224l32WCRtj3bAslog1THGrbNnTs3I0Nrkeh1zeVyaReosbbciud9q6ur4+7+Gmm9Il+cfMV7tz2e7W1paZHCwkLJzc0Vj8cTd9cjs40fPz5sa6NknxTZ7faI4xMNDg7KmDFjQu6z6diCOz8/P+xYr5E+60S2P9x6g8c11Fqn/L//Jx/29sqhJ5+Maf3BCgoKpLKyUrvwirRdscxYnSxG1e3i4uKAWcOH+XI8sGScEzkcDq2FdLSJu4zel2tra7WhH8JNIONTWlqqK5AOd84SzzZEC7wKCwuloaFBd5e9WMsU7wzqRrbkjsY/7AkVJgRraWmR0aNHa4FkqInRYgkHoj2XcqZPlwMNDfLB1Kna9hUUFEhRUVHAYpG+E9+YgpGGWom2jlQU/D1G64Gk97pE7/KlpaUBx2T/Y2Wsoh2zcnJyAsZJDq4HIrEFYL51lZaWBixnxA35eG6gx1r3gnvb+ITap/0DycMhPicj+JfFN2Zo8PPB5Q3VvT/4fCvU+Vciv1GxzAPhW8+sWbOiLpsNEkox5s2bJ5dffrkcOXJEe+zjjz+WBQsWyFVXXZVw4fS49dZb5YILLpBzzjlHxo8fL3fddZfk5eXJf/3Xf5lajnSTyIlCdXV10rsKxDM7WrqJ9yLG6JOZdDs5MkK4H9tkMPuk3IqQOlR3k+7u7oRmiPWx2WzaiZev683s2bNDhl3t7e0Rx26J17hx42TWrFlSVFQkDocj6jg9Zoi1y58Z9Txc6+1os91Ger2ecnd3d0tZWZmhAXt5ebmuWRjb2tq0oDpSK7FwfBOOzJo1K+aLq3Dfb9jf54YGefHqq0VmzIhp/eHE0vKpoaFBZs6cmdD7pIqw392Xrd70jr9WVVWlq2719/dbdgMtWgvradOmxdRS0OwWzPX19cNaOIUSb6sskS8ueCN1qQ0W60RtsZQtVpWVlTLVL2SL5b3GjBmjjasYal/3/buzszPipDoRw/xU43LJX372M/m/f//3gAYbwcficGPZRRPrDapUE2soFe01wXznhvPmzdMV4oh8Ua8S+QwXLFig+zyhuro6pnJGk8j5SUVFRcAN5mhDDAXTM8GP/+frP4t3qN+tw/6T9gR1lza619GCBQuGHXPCtbANN2GNEfU33DKtra3aWLv+ZRORYeN1xntDK9Mk3ELyt7/9rUyePFlee+01eeyxx6S9vV327dsnmzdvNqiI0R0+fFhefvnlgDu4drtd5syZIxs2bAj5mkOHDsm+ffsC/mCtaLMEJotZQVFdXd2wWfWCpdMJSij++6AZysvL4+qmkQ38LwBGjRoVcf8yqt51dHQMGxjeSL4TL98PeLhyjxw5MmrrhExRWFiYEt25QqmsrJTi4mKtVUGyj2/V1dW6un7HUp7CwsKwszSGW6ee7QzuRuvr7heu/oZqlRvP5+p0OiPetMjNzZURI0ZIQUFB1ElIXC5X2EDGqhaSoSYiyMvLS3g2Uf/Pes/69bJjyRKRiy6Ka10FBQVRzwn8pXpPCKsm3isqKgo7Xli8wVE8Yu2R4/F4ZHBwMKmBZHBLLrfbrQUp/t+T/3nBxIkTA/ZV/2PZ0NDQsPrne66uri5i4DhhwoSAi/NUV/bleaX/xHDB9F6vJNplOxUE79/RQvhYjvv9X47vrfc3ItJnp+c45D8jdbT1K6WkpaUlZMu84Pc2ct8OXsY32VW88vPztXLquWarrKzUbrqFukG1x284ioNBoW1BQUHEm1pGna/7H7N8x6uSkpKwQ6XE2zI+Wh1zu91SW1srSikpKCgIOF4Ej2mcSkPdWCmhs5upU6fK5s2bpb29Xbq6umThwoVyySWXyPr167WTajN8/PHHcuzYsWEnmhUVFfLhhx+GfM1NN90kRUVF2l+sY9UgeXyDtoe7g5huP97BampqQrZusNkizzrpL9IJko9ZA1yHYvY4dTU1NRnXijaebprB+8bJJ58c0E16woQJhnSbDqewsFAKCgoSHpBbD7o5fKGwsFDa29sDxiaLV6iT3FgDvnD1q6WlxZCypSujf8P0tMqN9H6Dg4MRLwJHjhwpU6ZMkf7+fq0lebjfqcLCQpkyZUrM5TLD1KlTh7VkKS4ujms20XCfY3FfnzStWiWSxGNrOgr3ecX62zY2wpizoYwfP15Gjx6dtJvL0fZbX+tBPSFBuEmOjDrPDfc7HOn96uvrw+7jiYwDaeZ5gRE6Ozt13YTSI12vaYLLWlZWFvHmzkknnSRer9fwIDp4mIBEP0OXyxXyN1VPfQ0uQzoNURDumi1SD6NwXeP/PneuyI03yv+ee658PGFCwHNVVVVhexDMmTMn5Pm873P0f05PgGu322XBggVSWVkZ8lgb6XvKy8vTjoWRrmtjrX/+DTX8u/in03Ex2RK+3frmm2/KSy+9JLW1teJ0OmXbtm3yz3/+04iyJdWyZctk79692t97771ndZGyXqLd9ZItWWVpbW2NaZZMkfAX/SL/OrhmWkAXq1SfxczMk5R4x+GKV1tbm+kTwWRLC8hYhRrbKBahWrb414VYZ042okueUcfY6upqmT59etTlkr1PxtNlO57PwIzfybFjx0pvb2/AY01NTXHXO6/Xa8nkUUbw77pmBLOGVIhGbxAYzOoL8XS7wDOzy7Y/vWOxi0RuIYn46P389AwLYIREgjbffpiMoXN83G63oa3LfGUuKiqKq1V/qO9z5MiRw26MpUIoHe27jKcFpnK5RJYtkx1f+5pI0HE43paINpst5nN9Pa1TbTabVFZWhr1B6b+OSL+LvgkM9QgO1fGFhALJFStWyJQpU2Tu3LmydetW2bhxo2zatEkmTJgQtqt0MpSVlYnD4ZCPPvoo4PGPPvoobHdOt9stXq834A/JZ+TOlyknQ06nM6Yf1eC7gf53WRKRKZ/jjATHQ8tm8Z4sIP2FGpg+Vb7zkpKSsL/N4WbpFfmi+1eq3KDw/yzdbndShiYJ930Z+T06nc5hrSLa2triDiSnTZumTf6Q6oI/R6OHCamvr9c1rlc4iX7fsXaVTrQFZLLU1tbK7NmzDV9vLC0k4+FwOGIK+Yzcj0tLS7Ub216vN+aQq7KyMuDCvKuri66GOoTqsq1XqrVCt4L/vjBp0qSEJmYNlp+fH7ZlbKR9MFIPt+bm5pA9RvXeFDD62GrUMcW/XPGuM/i8ItJ6nE6ndm4X7jPJyckZNqFfKB6PJ6DXof/xLdZjW/C4yaFu4IdrlZ6M7zWdJRRI/uQnP5HVq1fL7bffLh6PR9rb22Xjxo1yyimnmNqdzuVySXd3tzz11FPaY0NDQ/LUU09xAI8iVS48RfSfiJWWlsqJJ56oe51GLp+ocONaRJOfnx+yybxR5U+Vi/lMkq4/PB6PJ+ZWcsgMNpst4bFAPR7PsJO6aMen4Am+2tvbw3ZRNmI8PbNbSNbX18u0adMiviZVW0gaLdoYltnEbrfrGvs0VcUyOH8y66rdbo8rJIu2T8Yinu1qaGiQ0tLShN9bj+OOO06qq6ulsbFRamtrQ46f58+3XcXFxQGt3WpqarJ6/9X7fftPQqJ3HcHjDFshlvDkpJNOiuvGykknnRR1mVDnI8kY8iDSZCfhHq+qqhp2jpyqv8m+a86SkpKI5/WRbnKG+xxi3ebgG3r+xxGXy6VNWhmKw+EI2/jEv9FOouNWx5odTZkyRSb4dU+P5Xc8eAxJfCGhPlavvvrqsLtrOTk5csstt8QdtMTr0ksvlbPPPlt6enrkuOOOk//4j/+Qzz77TM455xxTy5FuzL7rYvQOGOnkMx129njLeMIJJ8jBgwe1fxcXF0tubm5C36d/WWbMmCF/+MMf4l4X4hdPl7NEBrj2iVR3MuFiGfqO95EGbo9FtAvdULxer+nj0BohUou5ZI0RF7zOdL3hgczR2dkpnZ2dYYdAStU6mmgoGO92WXmOqmd2dwSaOHFiwO9UcKvcUN+rr9up/7E6Ha5Rwgl188HhcMTVAyCWc17f+UiyP7OampqQvUYi8d1Q8pUtniERzOL/fkac1/uvz7/HQ1FRkezduzfkayorK8PO72Gz2WIOE5M5O3W4my2+md1937Hdbo/YgKe4uHhY/aaFZGgJ3d6K1NS/r68vkVXrtmjRIlm5cqVce+210tnZKZs3b5a1a9cmPKMijBPc+iVY8IG5rq7OlHHiysvLZfr06UkZ28ssU6ZMMSSUCsbBMtCEoIGa9SgpKdEmbgrHNxB4LHz10ePxGNptxQhm35CC9XJycgLGkUyVcfHMEG5Mwby8PN2/YUZ/ZkZ0Bc5m6RLc1NXVWb6/2e32jGw153Q6A3rjlJSUJO0ax+rvEKH5H8fr6+sDQoZYJgyM5Vw6lcc/Da6X8dxwNFKk/SSR65bS0tKEhuSI5b0zKYjy345okxn7f2fRel3FEjYWFxdrs7SHeo9I76/nOOu/jTNnzoz5dSJfBNzBY1ByjA8toRaSP/rRjyI+f+211yayet2+853vyHe+8x1T3zObJXvijAkTJojNZjOkO00w/zs0Dodj2DgQqciIGeWQmGg/uJE4HI5hg1uHWiaaZLS4MrpeUU/16enpSXgdBQUFusfkC76QSuSO83HHHZd2YYTT6Yx407K2tlYKCgriXn88E4zF22U73G9rMsaszCaNjY1WFyEmobqEJksix/d0/W3w741jt9uH3ThM1+2KJlO3S6+2tjbZs2ePfPLJJwmtJ9znOX/+/IDfz1T83P1/Y5L1W9/S0pKSY5pbPfxXugWYHo9Hjh07JgcOHAj7fCi+z21gYEDefvvtZBXPUr59x+FwGDIZZKZI6JP47W9/G/DvI0eOyM6dO8XpdEpzc7PpgSTSW7gxJGPtThPpgB38XEdHR9gm48F8TbTDScUTh3ik2w8ejMX3bx0jjiG5ubkybty4uF8/atQoaWtri/skMB1PrJxOZ9hZFkW+GDQf8Bk1apRUVVVZXYy0EG6G+Uw5X/LHb2d2mDZtWlxDGTU3N4ccisR/X0jlm3kVFRVSVlYWcC2WrB4QiZzDiKTG9VhpaWnM50OxLJcK2+QTanK7UKqqqqSurk73/pLIOVeyjsPJGtquuro6YFKdbJfQFcSmTZuGPbZv3z5ZsmSJLFy4MJFVI02k+6zZsbQemTVrljidzpQ76Uy18sAcdrs9pU5Q0hX7TyDfcAQ1NTVy6NAhi0uTnWKZGTIUm80mDocjpq6DiF9OTk7Cg+VngnjDk0wNJEWMO3/N1M8nm/kPqZOO3XVtNlvUIbfM4ts/9PYGMYtSSioqKiL2vPDfx1P1Rm6441BtbW1Sb8r5X5PH2v090r/95eTkSH19vbz77rvxF1C+GLKhoqJCNm7cmNB69IyXmQ0MvyXj9Xrluuuuk2uuucboVQOGCx5/IhSXy0UIhJQxY8aMgG6EVnfZjrdLq5VdIdmXA9XX11tdBE1nZ2fAbK7ZJJ6T09mzZ2tBWfDkCkAyzJgxI67ZrDM1kKyoqMjYli6Z+H0lItHJ3vyly2drxlj+eoWb/G706NG6J6WJlZHzDCilpLy8PKXHDQ3FZrMZFqLqOd+J1JPFJ9r3k5OTIxMnToz5PcOtt7i4mPlJkiApbcT37t0bdnYlIBz/mafMfs9EmPWDEuug2OlykoP4uN1urc4ZGSTFe9c+llA/lHSZLCKTlJSUaGPNlZWVaaFw8EmalS04ysrKGPdQB1pFwmxutzvuVpKZeH4yatSohMaXRvro6upKeB3p1kIyeFIOK0U7fjQ0NCRlToBYjltOp1PXcfH444+Pedl0qzOxCLUvpcLvQ/CEZb4baV6vN+YQNdR2cMM4soRi7ttuuy3g30op2bVrl9x3330yODiYUMGQHEbt7E6nU5xOZ0ocPMIxq2wej0cWLFgQ19gyeoUbZ9Nn+vTpaXfHDfFLZBISZB+32y11dXUi8kXwV1ZWZnGJAGSacOdemdpC0kip9vmkWnmAVDVt2rSkXH9VVlYOm0TLLEbu/8ludGTU70twC9Dc3FwpKyuLGiBXV1dHfJ6bx5ElFEj++7//e8C/7Xa7lJeXy9lnny3Lli1LqGBIrkR3Wl/gbMTO77vzw4lP4vQGVJl41w36se8BAJKJ8w1ku0w518qU7fAJbhUXj0Raz0WS6EQ/Vpo0aVLI+UbSSbQxQX0ybZ8wW0KB5M6dO40qB9JUMnfA4KbvVu/sNptNGhoawj4/adKksOOaGCH4ZD7Rk/uenh4pLS2Vjz/+OKH1wFpG7Bfjxo1LyXGCAACZgRaS0dlsNqmqquL3OIPRCCN+yfrMYmmBaOQNFW7OpC72S2uk5vROSBtGN+eONtGFUQfxeGYktdls0tHREfb5ZE/EUFFRIUVFRcMej2e8lMHBwZgGJuZHM7XV1tbKiBEjDFlPNvF4PCk7uyEAZKpMuthL1vmRx+MRj8eTlHXrlUnfVyrw/zzz8vLkhBNOiLockKqiHQPtdrvWuCiWOp1IvTfqhlcy973Zs2dzXR2G7iuySy+9NOZlb731Vr2rR5qJtOPabDbdO55ZE12k44ykbW1tIR+fOnWq7nURxmSGwsJCWlLEYfr06XFPygAA0I8WkkAgJnDTx6rjR319vWHn2u3t7RnxvdfV1Wk3TsJ1V6+qqkq7scr1Xhvo6RmZl5cnn332md4iZQXdqUSsYwFw0pEd+J7T3yeffGJ1EQBTMfFTeG63W4aGhmJaVs+4S8xCC2Q3WoZEF+6cevLkySaX5Auc4xuP/SD9tLS0GLauqqoqw9Zlpc7OTm3Ir4GBgZDL2Gy2hCbftOL4o/c9XS5X2oWuqUh3ILlu3TrZsWOHNDQ00MIEnKxkAE6OAPjoGUBdz8yPEyZMiKc4AFJQT0+P7m7FXV1d3AyKU2VlpdVFgAEy6Zopk7YFiUn3ujB16lRxuVzyxhtvGLIt/M7pF1eiOHr06ICJMBYtWiQfffSRYYVC8hkVQunZcUtLS7X/T2aYHeokORNDN6O2KdbWUAAyn/+YPwAQSnFxse5AMj8/P2XGRswGg4ODCa8j3YOGVJQJ1yNW1ovW1lbL3jtbJKOOxtK1OZF6Fc8wcT4FBQVaS07/8994WncuWLAg4ra63e6o82Vko7iuOoK/8Mcff5w+8VlKz8HDv5n6/PnzRSQ5weTo0aMNX2cmI5AEAABG8Hq90tDQYHUx0pKRQQ9jhSMTjRkzxuoiIA7BY3BGO9bFEi4mIxj3X2e4rujBxo8fH3P24HQ6TZsvI53QDCJLGbUT9/b26lo+1ZsxZ+PdYN/M3Zlw1xYAAFinuLhYOjo6rC4GkHISacUFY+Tn5zMEQoxS5Zo4XDmS0aAmnm0uKipigtEExXX7zGazDfvCUqXSwlx6ZworLCzUWkf6OByOpNzJpU7GpqKiwuoiAAAAIIVwHq1fpM+svb097IzEsa4DiSkuLrZskigYW7cdDocWLhsR9o8dO9aIYiEOcaVASilZsmSJuN1uERH5/PPPZenSpcPCqUceeSTxEiLj+HfTttlsUllZmTI/Dul055Jx3gAAADIDQVRm8x9LH0h1tbW1KT30Q25urqH5AUO+WSeuWnb22WcH/PvMM880pDDIPr4AUO8BL9ZxHfSWJZ1OBvPy8uSkk05KeD3ptM0AAABIPs4PEQr1IrP5rs0LCwvpigxTxBVIrlq1yuhyALrEM/NVJkr2mJzp1GIUQPK1trbKm2++aXUxACDjpGLQM3fuXKuLAMBEqXIc0lOOVCkz4kOfT1hK7wEkUkBGeAYAyeXxeKwuAgDAJBzzgeySruEeOUD6IpCEiCQ+HuG4cePiep0ZB4/Ozk5tJmkMF+6HZ/LkybonLQIAAACQvtI1lEL6SqTOUV/TG4EkRERk9uzZCb3e6/UaVBLj1dXV0cU7DpWVlUnvEg4AAAAuqpE+qKuZK12/W1pIpi8CSYhIcrpkxHJAS+b4EOl6QDUbnxMAAAAAZLdErwu5roReBJJImljuVHA3418qKiokLy/P6mIAAAAgggkTJlhdBAAwXKyBYioFjx6Ph96QaSyuWbYBGO+4446z5H1T6QcFQGrjJhIAiBQWFhq+Ts7HIMLvLFJDtONRKtXTSZMmcfxMY7SQRNIY3WUbAGCtESNGSHNzs9XFAICUU1ZWZnURACAh6Xhtbrfb07Lc+AKBJJLGd+dk3rx5UZeBdTiAA4hVYWEhgSQAhDBlyhSriwCYguu3zJUK14XUr+xCIImky8nJMeV9nE5GIEgEB38AkdTW1lpdBADIWKkQBACRjB071uoiIMk4DsFsBJJImkS6bJeXl+t+v9mzZ+t+DfjhAZCY+fPnW10EAACQZKNHj7a6CEii+vp6yc/Pt7oYyDIEkjCE0a3rjj/+eN2vcblcYrfHX6WLioqy+iBMMAkgHokcdwEAAGC9hoaGlOlxyHVp9uAqIktl6k7ucDji3rZJkyZJQ0OD9u+amhqDSpUe6LINAABgjUw9NweAaDj+ZS8CSRgiVQ4i/f39UldXZ8i6urq6DFkPAAAAAERDAwGkq5ycHHE4HFYXA2kmNdrkIu2Z9eMZ7X3cbrcp5QAAAACMkio39wEgHnPmzCGQhG4EkgAAAAAAICpacWa+eG6QpMr4k0gv1BoYih8o4/X29pr2Xg6HQ0488UTT3g8AAAAAABHyhGzDGJJIG9nalWXkyJFJf4+BgQHt/7m7BSCSbD0WA0AycWyFCGEMgOxCIAlDcTKVnlwul9VFAJAmXC6XDA4OWl0MAAAAAGmMQBIJ6+7ulpKSEquLAQAwCS2pAQAAACSCKwokrLq62uoiAAAAAGmLXkYAskGoYQk4/mUvWkjCUIx7kt74MQDMNWnSJFqYAwCQATLlPDovL0+6urrCPs/1HgCj0EISAACL1NbWWl2EmHi9XoJTAACygN1ul5qaGquLARiqsbHR6iIgBAJJAAAQUWtrq1RVVVldDAAAAEC39vZ2q4uAEOiyDUNlSlcFAAAAIJyTTjrJ6iIAQEYiU8geBJIAAAAAoIPD4bC6CACQFASCMAuBJAzFIMcAAACAPgQAEOFaCvDfBzguZj4CySxUXFxsdREAAGmEE0IASJ6cnByOsxmAMBGILtR+wvEvexFIQhev12t1EQAAJuNEEQCSZ968eWK3c1mG9EDwCsAozLINAADCGhgYkJycHKuLAQAAACCDEEjCUMlsRWNGC51sbgXE3U4AobhcLquLAAAAACDD0DcAhkp2qJXs9RcXF8vcuXOT+h4AAAAAAGSLeBr+0GAm8xFIZhkzWwCm6wHE4/FYXQQAAAAAWSZdr58AIB4EkgAAAAAAAEgKPWF7Ng+jlm0IJAEAAAAAQFS04sx8yQwEqT/wRyAJXbhbAQAAAAAAYkWOgFAIJLOU2QeE+fPnm/p+iA8/FAAAAACAcGjlCKM4rS4AMpfT6ZS6ujoREbHbE8++7XY7gRkAAAAAABmCa/zsRQtJxOSEE06I63Vut9uwMrS3t0t3d7dh6wMAAACAVEHLM6QDAkQYhRaSiEkqHHScTqorAAAAAFiF0BTJRP3KLrSQzFKZvqOffPLJVhcBAAAAADJKbm6uVFZWWl0MGCwVGiAh+9DkDDFJtwCTA6p+dXV1UlZWZnUxAAAAgKyTm5srLpfL6mJE5fF4ZPLkyVYXAwbTc72fbtkAUheBZBY77rjjpLi4OGnrd7vd4nA4Ii7T1dUlXq83aWVA7FwuV1qcBAEAAACZZs6cOVYXARCR5DbuIfiEPwLJLGWz2aSioiLm5XNycnS/x4wZM6IGkjT3BwAAAAAAyC6MIYmYuFwu3eGh0+mk6zQAAAAAACmM63ZYgUASunCgAgAAAIBAdC8F4hOcMZA5ZA8CSQAAAAAAAESVzYHhggULrC5CRiGQRMzGjh0r48aNs7oYAAAAAADAArQGhlGY1AZSVFQU03KFhYXMwgwAAAAAAHSLFmYSdmYXWkhCZs6caXURAAAAAAAAkCUIJLMQdx0AAAAAAABgFQJJAAAAAAAAAKYhkAQAAAAAAEBS0VsT/ggks5DNZrO6CAAAAAAAIMWkSl5AeJn5CCQBAAAAAAAAmIZAErqkyt0SAAAAAAAApCcCSQAAAAAAAACmSftA8u2335bzzjtPGhsbJTc3V5qbm2X58uVy+PBhq4sGAAAAAAAAIIjT6gIk6o033pChoSG5++67paWlRbZu3SoXXHCBfPbZZ7Jy5Uqri5eSGBwWAAAAAIzDNRYQXbT9RCnFMHFZJO0DyXnz5sm8efO0fzc1Ncm2bdvkzjvvJJAEAAAAAACwECEjQkn7QDKUvXv3SmlpacRlDh06JIcOHdL+vW/fvmQXCwAAAAAAAMh6aT+GZLDt27fL7bffLt/85jcjLnfTTTdJUVGR9ldXV2dSCTPb+PHjrS4CAAAAAACIQzJbMzK0AfylbCB51VVXic1mi/j3xhtvBLzm/fffl3nz5smpp54qF1xwQcT1L1u2TPbu3av9vffee8ncnKzh9XqtLgIAAAAAAABSWMp22b7ssstkyZIlEZdpamrS/v+DDz6Q/v5+mTp1qvzsZz+Lun632y1utzvRYgIAAAAAAADQIWUDyfLycikvL49p2ffff1/6+/ulu7tbVq1aJXZ7yjb8TAkMKAsAAAAAAACrpGwgGav3339fZs2aJaNGjZKVK1fK3//+d+25yspKC0uWmQgzAQAAAAAAkIi0DySffPJJ2b59u2zfvl1qa2sDnmPA1OFsNlvUz2Xq1Kny5z//2aQSAQAAAEB6czqdkpeXZ3UxgJRGRgN/ad+3ecmSJaKUCvkH/fLz82XEiBFWFwMAAAAA0obL5ZLZs2dbXQwgrRUWFsrIkSOtLgZMkvYtJKFPpC7XHo9nWCtTAAAAAACAZKupqZGamhqriwGTpH0LSQAAAAAAACSOeSNgFgLJLMPBBQAAAAAApDKG4ct8BJIAAAAAAAAATEMgmWVoIQkAAAAAAMxGq0f4I5CELhxAAAAAAAAAkAgCySxjRgvJysrKpL8HAAAAAABIL/TahA+BJAw3efJkq4sAAAAAAABSCD0u4Y9AEgAAAAAAAIBpCCSzDM2jAQAAAACAFcgk4EMgCQAAAAAAAMA0BJJZhrsRAAAAAAAAsBKBJAAAAAAAAJLaiIlJbeCPQDLL6Dm4VFdXJ7EkAAAAAAAAwxFeZj4CSYTV3d1tdREAAAAAAACQYQgkswxjSAIAAAAAALP4cgilFJkENASSAAAAAAAASAq6XyMUAsksE+luBAcJAAAAAAAAJBuBJAAAAAAAAADTEEgCAAAAAAAgKRg3EqEQSAIAAAAAACDp4SHhJHwIJAEAAAAAAJBUzFsBfwSSWWTcuHERn4/lToXdbheXy2VUkQAAAAAAAJBlCCSzSEtLS8TnY7lb4XQ6ZWBgwKgiAQAAAACALEGXbfgQSAIAAAAAACCp3G63FBQUxLQs3bszn9PqAgAAAAAAAMAaZrVarK2tldraWlPeC6mPFpIAAAAAAABZitaIsAKBJAAAAAAAAADTEEgCAAAAAACASWdgGgJJAAAAAACALEUICSswqU0WGj16tLjdbquLAQAAAAAAgCxEIJmFqqqqrC4CAAAAAAAAshRdtgEAAAAAAACYhkASAAAAAAAAgGkIJBGAwWwBAAAAAACQTASSAAAAAAAAAExDIAkAAAAAAADANASSCKCUsroIAAAAAAAAyGAEkgAAAAAAAABMQyCJAExqAwAAAABAdiITgFkIJAEAAAAAAACYhkASAAAAAAAAKYP5LTIfgSQAAAAAAACiIiiEUQgkAQAAAAAAAJiGQBIhDQ4OWl0EAAAAAACQRDabTRwOh67lASM4rS4AUpPTSdUAAAAAACCTnXzyyVYXAVmKFpIAAAAAAAAATEMgCQAAAAAAALpkwzQEkgAAAAAAAIiKWbZhFAJJAAAAAAAAAKYhkAQAAAAAAEBS0A0coRBIAgAAAAAAICno5o1QCCQRVXd3t9VFAAAAAAAAWYIQM/MRSEITboeneTUAAAAAAIgHmQJCIZAEAAAAAAAAYBoCSWi4awEAAAAAAIBkI5AEAAAAAAAAYBoCSQAAAAAAAACmIZCEhlmsAAAAAAAAkGwEkgAAAAAAAABMQyAJAAAAAAAAwDQEkgAAAAAAAABMQyAJAAAAAAAAwDQEkgAAAAAAAEgZTLqb+QgkAQAAAAAAAJiGQBIAAAAAACDLeb1eq4uALEIgCQAAAAAAkOX6+vqsLgKyCIEkAAAAAAAAANMQSAIAAAAAAAAwDYEkAAAAAAAAANMQSAIAAAAAAAAwDYEkAAAAAAAAANMQSAIAAAAAAAAwDYEkAAAAAAAAANMQSAIAAAAAAAAwTUYFkocOHZLOzk6x2WyyefNmq4sDAAAAAAAAIEhGBZJXXHGFVFdXW10MAAAAAAAAAGFkTCC5Zs0a+eMf/ygrV660uigAAAAAAAAQEZvNZnURkIKcVhfACB999JFccMEFsnr1asnLy4vpNYcOHZJDhw5p/963b1+yigcAAAAAAADgS2nfQlIpJUuWLJGlS5dKT09PzK+76aabpKioSPurq6tLYinTQ2trq5SXl1tdDAAAAAAAkCGUUlYXASkoZQPJq666Smw2W8S/N954Q26//XbZv3+/LFu2TNf6ly1bJnv37tX+3nvvvSRtSfpobGyU4uJiq4sBAAAAAACyGCFm5kvZLtuXXXaZLFmyJOIyTU1N8vTTT8uGDRvE7XYHPNfT0yOLFy+We++9N+Rr3W73sNcAAAAAAADAOIwhiVBSNpAsLy+PqfvwbbfdJj/+8Y+1f3/wwQcyMDAgv/rVr6S3tzeZRQQAAAAAAACgU8oGkrGqr68P+HdBQYGIiDQ3N0ttba0VRQIAAAAAAEACaFmZ2VJ2DEkAAAAAAAAAmSftW0gGa2hoYPBTAAAAAAAAIEXRQhIRjRs3ToqKiqwuBgAAAAAAADJExrWQhLFaWlqsLgIAAAAAAAAyCC0kAQAAAAAAAJiGQBIAAAAAAACAaQgkAQAAAAAAAJiGQBIAAAAAAAApQylldRGQZASSAAAAAAAAAExDIAkAAAAAAADANASSAAAAAAAAAExDIAkAAAAAAICUYrPZrC4CkohAEgAAAAAAAIBpCCQBAAAAAAAAmIZAEgAAAAAAAIBpCCQBAAAAAAAQlVLK6iIgQxBIAgAAAAAAADANgSQAAAAAAACSgtmyEQqBJAAAAAAAAKKKJ1yMp5s3XcMzH4EkAAAAAAAAANMQSAIAAAAAAAAwDYEkAAAAAAAAooqnKzVjSCIUAkkAAAAAAAAApiGQBAAAAAAAAGAaAkkAAAAAAAAApiGQBAAAAAAAAGAaAkkAAAAAAABExQQ1MAqBJAAAAAAAAKKKZ5btcPr7+w1bF9IPgSQAAAAAAABMVVBQEPF5WmNmNgJJAAAAAAAApAwjW2IiNRFIAgAAAAAAADANgSQAAAAAAAAA0xBIAgAAAAAAIGW43e6oY0wivTmtLgAAAAAAAADgU1NTIzU1NVYXA0lEC0kAAAAAAAAApiGQBAAAAAAAAGAaAkkAAAAAAAAApiGQBAAAAAAAAGAaAkkAAAAAAAAApiGQBAAAAAAAAGAaAkkAAAAAAAAkhd1O9IThnFYXAAAAAAAAAJlnYGBAXC6X1cVACiKmBgAAAAAAgOEIIxEOgSQAAAAAAAAA0xBIAgAAAAAAADANgSQAAAAAAAAA0xBIAgAAAAAAADANgSQAAAAAAAAA0xBIAgAAAAAAADANgSQAAAAAAAAA0xBIAgAAAAAAADANgSQAAAAAAAAA0xBIAgAAAAAAADANgSQAAAAAAAAA0xBIAgAAAAAAADANgSQAAAAAAAAA0xBIAgAAAAAAADANgSQAAAAAAAAA0xBIAgAAAAAAADANgSQAAAAAAAAA0xBIAgAAAAAAADANgSQAAAAAAAAA0xBIAgAAAAAAADANgSQAAAAAAAAA0xBIAgAAAAAAADANgSQAAAAAAAAA0xBIAgAAAAAAADANgSQAAAAAAACiKioqkra2NquLgQxAIAkAAAAAAICoPB6PNDU1WV0MZAACSQAAAAAAAACmIZAEAAAAAAAAYBoCSQAAAAAAAACmIZAEAAAAAAAAYBoCSQAAAAAAAACmIZAEAAAAAAAAYBoCSQAAAAAAAACmIZAEAAAAAAAAYJqMCSQfe+wx6e3tldzcXCkpKZGvfe1rVhcJAAAAAAAAQBCn1QUwwn//93/LBRdcIDfeeKOccMIJcvToUdm6davVxQIAAAAAAAAQJO0DyaNHj8pFF10kt9xyi5x33nna4+PHj7ewVAAAAAAAAABCSfsu26+88oq8//77YrfbZdKkSVJVVSWDg4NRW0geOnRI9u3bF/AHAAAAAAAAILnSPpDcsWOHiIj88Ic/lB/84Afy6KOPSklJicyaNUs++eSTsK+76aabpKioSPurq6szq8gAAAAAAABA1krZQPKqq64Sm80W8e+NN96QoaEhERG5+uqr5etf/7p0d3fLqlWrxGazycMPPxx2/cuWLZO9e/dqf++9955ZmwYAAAAAAABkrZQdQ/Kyyy6TJUuWRFymqalJdu3aJSKBY0a63W5pamqSd999N+xr3W63uN1uQ8oKAAAAAAAAIDYpG0iWl5dLeXl51OW6u7vF7XbLtm3bZPr06SIicuTIEXn77bdl1KhRyS4mAAAAAAAAAB1SNpCMldfrlaVLl8ry5culrq5ORo0aJbfccouIiJx66qkWlw4AAAAAAACAv7QPJEVEbrnlFnE6nXLWWWfJwYMHpbe3V55++mkpKSmxumgAAAAAAAAA/NiUUsrqQqSCffv2SVFRkezdu1e8Xq/VxQEAAAAAAADSSqz5WsrOsg0AAAAAAAAg8xBIAgAAAAAAADANgSQAAAAAAAAA0xBIAgAAAAAAADANgSQAAAAAAAAA0xBIAgAAAAAAADANgSQAAAAAAAAA0xBIAgAAAAAAADANgSQAAAAAAAAA0xBIAgAAAAAAADCN0+oCpAqllIiI7Nu3z+KSAAAAAAAAAOnHl6v5crZwCCS/tH//fhERqaurs7gkAAAAAAAAQPrav3+/FBUVhX3epqJFllliaGhIPvjgAyksLBSbzWZ1cWCBffv2SV1dnbz33nvi9XqtLg6QMOo0Mg11GpmGOo1MQ51GpqFOI9OYUaeVUrJ//36prq4Wuz38SJG0kPyS3W6X2tpaq4uBFOD1evmxQUahTiPTUKeRaajTyDTUaWQa6jQyTbLrdKSWkT5MagMAAAAAAADANASSAAAAAAAAAExDIAl8ye12y/Lly8XtdltdFMAQ1GlkGuo0Mg11GpmGOo1MQ51GpkmlOs2kNgAAAAAAAABMQwtJAAAAAAAAAKYhkAQAAAAAAABgGgJJAAAAAAAAAKYhkAQAAAAAAABgGgJJZKwVK1aIzWaTiy++WHvs888/lwsvvFBGjBghBQUF8vWvf10++uijgNe9++67Mn/+fMnLy5ORI0fK5ZdfLkePHg1YZv369dLV1SVut1taWlrknnvuMWGLkG1++MMfis1mC/gbO3as9jz1Geno/ffflzPPPFNGjBghubm50tHRIS+99JL2vFJKrr32WqmqqpLc3FyZM2eOvPXWWwHr+OSTT2Tx4sXi9XqluLhYzjvvPDlw4EDAMn/9619lxowZ4vF4pK6uTm6++WZTtg/Zp6GhYdix2mazyYUXXigiHKuRfo4dOybXXHONNDY2Sm5urjQ3N8v1118v/nOhcqxGutm/f79cfPHFMmrUKMnNzZWpU6fKiy++qD1PnUYq+9Of/iQLFiyQ6upqsdlssnr16oDnzay/Dz/8sIwdO1Y8Ho90dHTI448/Hv+GKSADbdy4UTU0NKgJEyaoiy66SHt86dKlqq6uTj311FPqpZdeUscff7yaOnWq9vzRo0dVe3u7mjNnjtq0aZN6/PHHVVlZmVq2bJm2zI4dO1ReXp669NJL1WuvvaZuv/125XA41Nq1a83cRGSB5cuXq7a2NrVr1y7t7+9//7v2PPUZ6eaTTz5Ro0aNUkuWLFEvvPCC2rFjh3riiSfU9u3btWVWrFihioqK1OrVq9WWLVvUV77yFdXY2KgOHjyoLTNv3jw1ceJE9Ze//EU9++yzqqWlRZ1xxhna83v37lUVFRVq8eLFauvWreqhhx5Subm56u677zZ1e5Eddu/eHXCcfvLJJ5WIqHXr1imlOFYj/dxwww1qxIgR6tFHH1U7d+5UDz/8sCooKFA/+clPtGU4ViPdnHbaaWr8+PHqmWeeUW+99ZZavny58nq96v/+7/+UUtRppLbHH39cXX311eqRRx5RIqJ++9vfBjxvVv19/vnnlcPhUDfffLN67bXX1A9+8AOVk5OjXn311bi2i0ASGWf//v1q9OjR6sknn1R9fX1aILlnzx6Vk5OjHn74YW3Z119/XYmI2rBhg1Lqix3dbrerDz/8UFvmzjvvVF6vVx06dEgppdQVV1yh2traAt5z0aJFamBgIMlbhmyzfPlyNXHixJDPUZ+Rjq688ko1ffr0sM8PDQ2pyspKdcstt2iP7dmzR7ndbvXQQw8ppZR67bXXlIioF198UVtmzZo1ymazqffff18ppdRPf/pTVVJSotVz33uPGTPG6E0ChrnoootUc3OzGhoa4liNtDR//nx17rnnBjx2yimnqMWLFyulOFYj/fzzn/9UDodDPfroowGPd3V1qauvvpo6jbQSHEiaWX9PO+00NX/+/IDy9Pb2qm9+85txbQtdtpFxLrzwQpk/f77MmTMn4PGXX35Zjhw5EvD42LFjpb6+XjZs2CAiIhs2bJCOjg6pqKjQlhkYGJB9+/bJ//7v/2rLBK97YGBAWwdgpLfeekuqq6ulqalJFi9eLO+++66IUJ+Rnn7/+99LT0+PnHrqqTJy5EiZNGmS/PznP9ee37lzp3z44YcBdbKoqEh6e3sD6nVxcbH09PRoy8yZM0fsdru88MIL2jIzZ84Ul8ulLTMwMCDbtm2TTz/9NNmbiSx2+PBhuf/+++Xcc88Vm83GsRppaerUqfLUU0/Jm2++KSIiW7Zskeeee04GBwdFhGM10s/Ro0fl2LFj4vF4Ah7Pzc2V5557jjqNtGZm/TX6fIRAEhnll7/8pbzyyity0003DXvuww8/FJfLJcXFxQGPV1RUyIcffqgt439B4Hve91ykZfbt2ycHDx40alMA6e3tlXvuuUfWrl0rd955p+zcuVNmzJgh+/fvpz4jLe3YsUPuvPNOGT16tDzxxBPyrW99S773ve/JvffeKyL/qpeh6qR/nR05cmTA806nU0pLS3XVfSAZVq9eLXv27JElS5aICOceSE9XXXWVnH766TJ27FjJycmRSZMmycUXXyyLFy8WEY7VSD+FhYUyZcoUuf766+WDDz6QY8eOyf333y8bNmyQXbt2UaeR1sysv+GWibd+O+N6FZCC3nvvPbnooovkySefHHb3C0hHvpYIIiITJkyQ3t5eGTVqlPz617+W3NxcC0sGxGdoaEh6enrkxhtvFBGRSZMmydatW+Wuu+6Ss88+2+LSAYn7z//8TxkcHJTq6mqriwLE7de//rU88MAD8uCDD0pbW5ts3rxZLr74YqmuruZYjbR13333ybnnnis1NTXicDikq6tLzjjjDHn55ZetLhqQtWghiYzx8ssvy+7du6Wrq0ucTqc4nU555pln5LbbbhOn0ykVFRVy+PBh2bNnT8DrPvroI6msrBQRkcrKymEzX/r+HW0Zr9dLSISkKi4ultbWVtm+fbtUVlZSn5F2qqqqZPz48QGPjRs3ThuKwFcvQ9VJ/zq7e/fugOePHj0qn3zyia66DxjtnXfekf/5n/+R888/X3uMYzXS0eWXX661kuzo6JCzzjpLLrnkEq0HEsdqpKPm5mZ55pln5MCBA/Lee+/Jxo0b5ciRI9LU1ESdRlozs/6GWybe+k0giYwxe/ZsefXVV2Xz5s3aX09PjyxevFj7/5ycHHnqqae012zbtk3effddmTJlioiITJkyRV599dWAnfXJJ58Ur9erXURPmTIlYB2+ZXzrAJLlwIED8re//U2qqqqku7ub+oy0M23aNNm2bVvAY2+++aaMGjVKREQaGxulsrIyoE7u27dPXnjhhYB6vWfPnoAWDU8//bQMDQ1Jb2+vtsyf/vQnOXLkiLbMk08+KWPGjJGSkpKkbR+y26pVq2TkyJEyf/587TGO1UhH//znP8VuD7xMdDgcMjQ0JCIcq5He8vPzpaqqSj799FN54okn5Ktf/Sp1GmnNzPpr+PlIXFPhAGnCf5ZtpZRaunSpqq+vV08//bR66aWX1JQpU9SUKVO0548ePara29vViSeeqDZv3qzWrl2rysvL1bJly7RlduzYofLy8tTll1+uXn/9dXXHHXcoh8Oh1q5da+amIQtcdtllav369Wrnzp3q+eefV3PmzFFlZWVq9+7dSinqM9LPxo0bldPpVDfccIN666231AMPPKDy8vLU/fffry2zYsUKVVxcrH73u9+pv/71r+qrX/2qamxsVAcPHtSWmTdvnpo0aZJ64YUX1HPPPadGjx6tzjjjDO35PXv2qIqKCnXWWWeprVu3ql/+8pcqLy9P3X333aZuL7LHsWPHVH19vbryyiuHPcexGunm7LPPVjU1NerRRx9VO3fuVI888ogqKytTV1xxhbYMx2qkm7Vr16o1a9aoHTt2qD/+8Y9q4sSJqre3Vx0+fFgpRZ1Gatu/f7/atGmT2rRpkxIRdeutt6pNmzapd955RyllXv19/vnnldPpVCtXrlSvv/66Wr58ucrJyVGvvvpqXNtFIImMFhxIHjx4UH37299WJSUlKi8vTy1cuFDt2rUr4DVvv/22GhwcVLm5uaqsrExddtll6siRIwHLrFu3TnV2diqXy6WamprUqlWrTNgaZJtFixapqqoq5XK5VE1NjVq0aJHavn279jz1GenoD3/4g2pvb1dut1uNHTtW/exnPwt4fmhoSF1zzTWqoqJCud1uNXv2bLVt27aAZf7xj3+oM844QxUUFCiv16vOOecctX///oBltmzZoqZPn67cbreqqalRK1asSPq2IXs98cQTSkSG1VWlOFYj/ezbt09ddNFFqr6+Xnk8HtXU1KSuvvpqdejQIW0ZjtVIN7/61a9UU1OTcrlcqrKyUl144YVqz5492vPUaaSydevWKREZ9nf22Wcrpcytv7/+9a9Va2urcrlcqq2tTT322GNxb5dNKaXia1sJAAAAAAAAAPowhiQAAAAAAAAA0xBIAgAAAAAAADANgSQAAAAAAAAA0xBIAgAAAAAAADANgSQAAAAAAAAA0xBIAgAAAAAAADANgSQAAAAAAAAA0xBIAgAAAAAAADANgSQAAABgoG3btsnkyZOlsbFRfve731ldHAAAgJRjU0opqwsBAAAAZIpFixbJcccdJxMmTJDzzjtP3n33XauLBAAAkFJoIQkAAABT/fCHP5TOzk6ri6Gx2WyyevVqXa9paGgQm80mNptN9uzZE/BcUVGRjBo1SlpaWmTkyJHDXjtr1izttZs3b46/4AAAAGmKQBIAACAD3XXXXVJYWChHjx7VHjtw4IDk5OTIrFmzApZdv3692Gw2+dvf/mZyKc1ldBD6ox/9SHbt2iVFRUXDHl+0aJG0tLTIsmXLhr3ukUcekY0bNxpWDgAAgHRDIAkAAJCB+vv75cCBA/LSSy9pjz377LNSWVkpL7zwgnz++efa4+vWrZP6+nppbm62oqhpq7CwUCorK8VmswU8/sILL0htba2cfvrp8uc//3nY60pLS6W8vNysYgIAAKQcAkkAAIAMNGbMGKmqqpL169drj61fv16++tWvSmNjo/zlL38JeLy/v19ERO677z7p6enRwrZvfOMbsnv3bhERGRoaktraWrnzzjsD3mvTpk1it9vlnXfeERGRPXv2yPnnny/l5eXi9XrlhBNOkC1btkQs7y9+8QsZN26ceDweGTt2rPz0pz/Vnnv77bfFZrPJI488Iv39/ZKXlycTJ06UDRs2BKzj5z//udTV1UleXp4sXLhQbr31VikuLhYRkXvuuUeuu+462bJli9Zd+p577tFe+/HHH8vChQslLy9PRo8eLb///e9j+6BDWLVqlXzjG9+Qs846S+6///6AVqoAAAAgkAQAAMhY/f39sm7dOu3f69atk1mzZklfX5/2+MGDB+WFF17QAskjR47I9ddfL1u2bJHVq1fL22+/LUuWLBEREbvdLmeccYY8+OCDAe/zwAMPyLRp02TUqFEiInLqqafK7t27Zc2aNfLyyy9LV1eXzJ49Wz755JOQ5XzggQfk2muvlRtuuEFef/11ufHGG+Waa66Re++9N2C5q6++Wr7//e/L5s2bpbW1Vc444wwt7Hv++edl6dKlctFFF8nmzZtl7ty5csMNN2ivXbRokVx22WXS1tYmu3btkl27dsmiRYu056+77jo57bTT5K9//aucdNJJsnjx4rDljWT37t3y+OOPy5lnnilz584Vm80mjz32mO71AAAAZDICSQAAgAzV398vzz//vBw9elT2798vmzZtkr6+Ppk5c6bWcnLDhg1y6NAhLZA899xzZXBwUJqamuT444+X2267TdasWSMHDhwQEZHFixfL888/r80cPTQ0JL/85S9l8eLFIiLy3HPPycaNG+Xhhx+Wnp4eGT16tKxcuVKKi4vlN7/5TchyLl++XP7t3/5NTjnlFGlsbJRTTjlFLrnkErn77rsDlvv+978v8+fPl9bWVrnuuuvknXfeke3bt4uIyO233y6Dg4Py/e9/X1pbW+Xb3/62DA4Oaq/Nzc2VgoICcTqdUllZKZWVlZKbm6s9v2TJEjnjjDOkpaVFbrzxRjlw4EBc4zzef//90tbWJm1tbeJwOOT0008PaIkJAAAAAkkAAICMNWvWLPnss8/kxRdflGeffVZaW1ulvLxc+vr6tHEk169fL01NTVJfXy8iIi+//LIsWLBA6uvrpbCwUPr6+kREtACys7NTxo0bp7WSfOaZZ2T37t1y6qmniojIli1b5MCBAzJixAgpKCjQ/nbu3Bly0pzPPvtM/va3v8l5550XsPyPf/zjYctPmDBB+/+qqioREa07+bZt2+S4444LWD7435H4rzs/P1+8Xq+2bj1WrVolZ555pvbvM888Ux577DH5+9//rntdAAAAmcppdQEAAACQHC0tLVJbWyvr1q2TTz/9VAsXq6urpa6uTv785z/LunXr5IQTThCRL8LBgYEBGRgYkAceeEDKy8vl3XfflYGBATl8+LC23sWLF8uDDz4oV111lTz44IMyb948GTFihIh8MZN38NiVPr7xHP35Wl7+/Oc/l97e3oDnHA5HwL9zcnK0//dNJDM0NKTzUwnNf92+9etd90svvSRbt26VK664Qq688krt8WPHjsn9998vl1xyiSFlBQAASHcEkgAAABmsv79f1q9fL59++qlcfvnl2uMzZ86UNWvWyMaNG+Vb3/qWiIi88cYb8o9//ENWrFghdXV1IiIBs3T7fOMb35Af/OAH8vLLL8tvfvMbueuuu7Tnurq65MMPPxSn0ykNDQ1Ry1dRUSHV1dWyY8cOrdt3PMaMGSMvvvhiwGPB/3a5XHLs2LG43yOaVatWycyZM+WOO+4IePy+++6Te+65h0ASAADgSwSSAAAAGay/v18uvPBCOXLkiNZCUkSkr69PvvOd78jhw4e18SPr6+vF5XLJ7bffLkuXLpWtW7fK9ddfP2ydDQ0NMnXqVDnvvPPk2LFj8pWvfEV7bs6cOTJlyhT52te+JjfffLO0trbKBx98II899pgsXLhQenp6hq3vuuuuk+9973tSVFQk8+bNk0OHDslLL70kn376qVx66aUxbed3v/tdmTlzptx6662yYMECefrpp2XNmjVaS0pfuXfu3CmbN2+W2tpaKSwsFLfbHfNnGcmhQ4fkoYcekhtvvFHa29sDnjv//PPl5ptvlldeeUW6uroMeT8AAIB0xhiSAAAAGay/v18OHjwoLS0tUlFRoT3e19cn+/fvlzFjxmjjMZaXl8s999wjDz/8sIwfP15WrFghK1euDLnexYsXy5YtW2ThwoUBk8PYbDZ5/PHHZebMmXLOOedIa2urnH766fLOO+8EvL+/888/X37xi1/IqlWrpKOjQ/r6+uSee+6RxsbGmLdz2rRpctddd8mtt94qEydOlLVr18oll1wiHo9HW+brX/+6zJs3T/r7+6W8vFweeuihmNcfzerVq2Xv3r2ycOHCYc+NHj1aOjo6ZNWqVYa9HwAAQDqzKaWU1YUAAAAAjHbBBRfIG2+8Ic8++6zh625oaJCLL75YLr744rhe//bbb0tjY6Ns2rRJOjs7DS0bAABAqqOFJAAAADLCypUrZcuWLbJ9+3a5/fbb5d5775Wzzz47ae935ZVXSkFBgezdu1fX6wYHB6WtrS1JpQIAAEh9tJAEAABARjjttNNk/fr1sn//fmlqapLvfve7snTp0qS81zvvvCNHjhwREZGmpiax22O/z//+++/LwYMHReRf43YCAABkEwJJAAAAAAAAAKahyzYAAAAAAAAA0xBIAgAAAAAAADANgSQAAAAAAAAA0xBIAgAAAAAAADANgSQAAAAAAAAA0xBIAgAAAAAAADANgSQAAAAAAAAA0xBIAgAAAAAAADDN/wdxy5+zGVgf2gAAAABJRU5ErkJggg==",
-      "text/plain": [
-       "<Figure size 1600x900 with 1 Axes>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "fig = plt.figure(figsize=(16, 9), dpi=100)\n",
     "ax = fig.add_subplot(111)\n",
     "spectrum_index = 12  # Step through spectra here.\n",
-    "pl0 = ax.plot(qso_wavelength, qso_flux[spectrum_index, :], 'k-', alpha=0.3, lw=0.5, label='SPARCL flux')\n",
-    "pl1 = ax.plot(qso_wavelength, qso_model_flux[spectrum_index, :], 'r-', label='SPARCL model')\n",
-    "pl2 = ax.plot(qso_wavelength, tmpl_model_flux[spectrum_index, :], 'b-', label='Redrock model')\n",
+    "pl0 = ax.plot(desi_qso_specutils.spectral_axis, desi_qso_specutils.flux[spectrum_index, :], 'k-', alpha=0.3, lw=0.5, label='SPARCL flux')\n",
+    "pl1 = ax.plot(desi_qso_specutils.spectral_axis, desi_qso_specutils.meta['model'][spectrum_index, :], 'r-', label='SPARCL model')\n",
+    "pl2 = ax.plot(desi_qso_specutils.spectral_axis, tmpl_model_flux[spectrum_index, :], 'b-', label='Redrock model')\n",
     "txt = ax.set_xlabel('Wavelength [Å]')\n",
     "txt = ax.set_ylabel(r'Flux [$10^{-17} \\mathrm{erg} \\, \\mathrm{cm}^{-2} \\mathrm{s}^{-1} \\mathrm{\\AA}^{-1}$]')\n",
     "txt = ax.set_title(f\"TARGETID={desi_qso_ids[spectrum_index]['targetid']:d}; Z={desi_qso_ids[spectrum_index]['z']:.3f}; SPECTYPE={desi_qso_ids[spectrum_index]['spectype']}; SUBTYPE={desi_qso_ids[spectrum_index]['subtype']}\")\n",
@@ -1730,81 +897,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": null,
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2025-12-15T16:59:57.507108Z",
-     "iopub.status.busy": "2025-12-15T16:59:57.506861Z",
-     "iopub.status.idle": "2025-12-15T16:59:57.603896Z",
-     "shell.execute_reply": "2025-12-15T16:59:57.603423Z",
-     "shell.execute_reply.started": "2025-12-15T16:59:57.507095Z"
-    },
     "tags": []
    },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div><i>Table length=50</i>\n",
-       "<table id=\"table140046316543984\" class=\"table-striped table-bordered table-condensed\">\n",
-       "<thead><tr><th>specobjid</th><th>bestobjid</th><th>z</th><th>zerr</th><th>zwarning</th><th>class</th><th>subclass</th><th>rchi2diff</th><th>primtarget</th><th>sectarget</th></tr></thead>\n",
-       "<thead><tr><th>int64</th><th>int64</th><th>float64</th><th>float64</th><th>int64</th><th>str6</th><th>str11</th><th>float64</th><th>int64</th><th>int64</th></tr></thead>\n",
-       "<tr><td>3327035125891360768</td><td>1237655468065620461</td><td>0.26219922</td><td>6.426468e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>0.16153336</td><td>96</td><td>0</td></tr>\n",
-       "<tr><td>3327036500280895488</td><td>1237655468065489538</td><td>0.21097003</td><td>5.7919853e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>0.13921309</td><td>64</td><td>0</td></tr>\n",
-       "<tr><td>3327038424426244096</td><td>1237655468065620456</td><td>0.2605426</td><td>6.229882e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>0.22558784</td><td>32</td><td>0</td></tr>\n",
-       "<tr><td>3327038974182057984</td><td>1237655468065620382</td><td>0.11276812</td><td>1.5994665e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>0.510905</td><td>64</td><td>0</td></tr>\n",
-       "<tr><td>3327040073693685760</td><td>1237651736318574966</td><td>0.06364931</td><td>2.8312488e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>0.42436635</td><td>64</td><td>0</td></tr>\n",
-       "<tr><td>3327040348571592704</td><td>1237651736318640378</td><td>0.20836118</td><td>4.189276e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>1.1794078</td><td>96</td><td>0</td></tr>\n",
-       "<tr><td>3327040898327406592</td><td>1237655468602491146</td><td>0.20784536</td><td>4.1236628e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>0.61972916</td><td>64</td><td>0</td></tr>\n",
-       "<tr><td>3327041722961127424</td><td>1237651736318575080</td><td>0.1408417</td><td>1.9260546e-05</td><td>0</td><td>GALAXY</td><td>STARFORMING</td><td>0.49670327</td><td>64</td><td>0</td></tr>\n",
-       "<tr><td>3327042822472755200</td><td>1237651736318574838</td><td>0.21259658</td><td>7.138862e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>0.14038157</td><td>96</td><td>0</td></tr>\n",
-       "<tr><td>3327044196862289920</td><td>1237655468602556710</td><td>0.12747255</td><td>1.0024814e-05</td><td>0</td><td>GALAXY</td><td>STARFORMING</td><td>0.9118272</td><td>64</td><td>0</td></tr>\n",
-       "<tr><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td></tr>\n",
-       "<tr><td>3327063988071589888</td><td>1237655468602294437</td><td>0.117277816</td><td>1.2225097e-05</td><td>0</td><td>GALAXY</td><td>STARBURST</td><td>2.301178</td><td>64</td><td>0</td></tr>\n",
-       "<tr><td>3327065087583217664</td><td>1237651736318378283</td><td>0.02987722</td><td>6.544521e-06</td><td>0</td><td>GALAXY</td><td>STARBURST</td><td>6.2372937</td><td>64</td><td>0</td></tr>\n",
-       "<tr><td>3327065362461124608</td><td>1237655468602360140</td><td>0.08503898</td><td>2.8198616e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>0.38777363</td><td>64</td><td>0</td></tr>\n",
-       "<tr><td>3327065912216938496</td><td>1237651736318443551</td><td>0.16617252</td><td>3.350158e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>0.5785748</td><td>64</td><td>0</td></tr>\n",
-       "<tr><td>3327066187094845440</td><td>1237655468602294603</td><td>0.084284484</td><td>1.1737382e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>0.53542316</td><td>64</td><td>0</td></tr>\n",
-       "<tr><td>3327066736850659328</td><td>1237651736318378031</td><td>0.050459415</td><td>3.3662614e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>0.066199064</td><td>64</td><td>0</td></tr>\n",
-       "<tr><td>3327067011728566272</td><td>1237651735781377183</td><td>0.44971278</td><td>0.00015747716</td><td>0</td><td>GALAXY</td><td>--</td><td>0.060908318</td><td>32</td><td>0</td></tr>\n",
-       "<tr><td>3327067286606473216</td><td>1237651736318444114</td><td>0.15844806</td><td>2.7416756e-05</td><td>0</td><td>GALAXY</td><td>STARFORMING</td><td>0.13396144</td><td>64</td><td>0</td></tr>\n",
-       "<tr><td>3327067561484380160</td><td>1237655468064965078</td><td>0.0846016</td><td>2.5953486e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>0.16839969</td><td>64</td><td>0</td></tr>\n",
-       "<tr><td>3327068111240194048</td><td>1237655468064964823</td><td>0.08544502</td><td>3.2923934e-05</td><td>0</td><td>GALAXY</td><td>STARFORMING</td><td>0.3577659</td><td>64</td><td>0</td></tr>\n",
-       "</table></div>"
-      ],
-      "text/plain": [
-       "<Table length=50>\n",
-       "     specobjid           bestobjid           z      ... primtarget sectarget\n",
-       "       int64               int64          float64   ...   int64      int64  \n",
-       "------------------- ------------------- ----------- ... ---------- ---------\n",
-       "3327035125891360768 1237655468065620461  0.26219922 ...         96         0\n",
-       "3327036500280895488 1237655468065489538  0.21097003 ...         64         0\n",
-       "3327038424426244096 1237655468065620456   0.2605426 ...         32         0\n",
-       "3327038974182057984 1237655468065620382  0.11276812 ...         64         0\n",
-       "3327040073693685760 1237651736318574966  0.06364931 ...         64         0\n",
-       "3327040348571592704 1237651736318640378  0.20836118 ...         96         0\n",
-       "3327040898327406592 1237655468602491146  0.20784536 ...         64         0\n",
-       "3327041722961127424 1237651736318575080   0.1408417 ...         64         0\n",
-       "3327042822472755200 1237651736318574838  0.21259658 ...         96         0\n",
-       "3327044196862289920 1237655468602556710  0.12747255 ...         64         0\n",
-       "                ...                 ...         ... ...        ...       ...\n",
-       "3327063988071589888 1237655468602294437 0.117277816 ...         64         0\n",
-       "3327065087583217664 1237651736318378283  0.02987722 ...         64         0\n",
-       "3327065362461124608 1237655468602360140  0.08503898 ...         64         0\n",
-       "3327065912216938496 1237651736318443551  0.16617252 ...         64         0\n",
-       "3327066187094845440 1237655468602294603 0.084284484 ...         64         0\n",
-       "3327066736850659328 1237651736318378031 0.050459415 ...         64         0\n",
-       "3327067011728566272 1237651735781377183  0.44971278 ...         32         0\n",
-       "3327067286606473216 1237651736318444114  0.15844806 ...         64         0\n",
-       "3327067561484380160 1237655468064965078   0.0846016 ...         64         0\n",
-       "3327068111240194048 1237655468064964823  0.08544502 ...         64         0"
-      ]
-     },
-     "execution_count": 36,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "q = \"\"\"\n",
     "SELECT z.specobjid, z.bestobjid, z.z, z.zerr, z.zwarning, z.class, z.subclass,\n",
@@ -1832,15 +929,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": null,
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2025-12-15T16:59:57.604656Z",
-     "iopub.status.busy": "2025-12-15T16:59:57.604445Z",
-     "iopub.status.idle": "2025-12-15T16:59:57.607129Z",
-     "shell.execute_reply": "2025-12-15T16:59:57.606714Z",
-     "shell.execute_reply.started": "2025-12-15T16:59:57.604644Z"
-    },
     "tags": []
    },
    "outputs": [],
@@ -1859,31 +949,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": null,
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2025-12-15T16:59:57.608000Z",
-     "iopub.status.busy": "2025-12-15T16:59:57.607681Z",
-     "iopub.status.idle": "2025-12-15T16:59:59.477048Z",
-     "shell.execute_reply": "2025-12-15T16:59:59.476497Z",
-     "shell.execute_reply.started": "2025-12-15T16:59:57.607988Z"
-    },
     "tags": []
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'status': {'success': True,\n",
-       "  'info': [\"Successfully found 50 records in dr_list=['SDSS-DR17']\"],\n",
-       "  'warnings': []}}"
-      ]
-     },
-     "execution_count": 38,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "include = client.get_all_fields(dataset_list=['SDSS-DR17'])\n",
     "sdss_spectra = client.retrieve_by_specid(specid_list=sdss_ids['specobjid'].value.tolist(),\n",
@@ -1903,23 +973,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2025-12-15T16:59:59.477965Z",
-     "iopub.status.busy": "2025-12-15T16:59:59.477764Z",
-     "iopub.status.idle": "2025-12-15T16:59:59.481361Z",
-     "shell.execute_reply": "2025-12-15T16:59:59.480893Z",
-     "shell.execute_reply.started": "2025-12-15T16:59:59.477952Z"
-    },
-    "tags": []
-   },
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": [
-    "sdss_records = sorted(sdss_spectra.records, key=lambda x: x.specid)\n",
-    "assert (np.array([r.specid for r in sdss_records]) == sdss_ids['specobjid']).all()\n",
-    "assert all([r.plate == 2955 for r in sdss_records])\n",
-    "assert all([r.mjd == 54562 for r in sdss_records])"
+    "sdss_spectra = sdss_spectra.reorder(sdss_ids['specobjid'].value.tolist())\n",
+    "assert (np.array([r.specid for r in sdss_spectra.records]) == sdss_ids['specobjid']).all()\n",
+    "assert all([r.plate == 2955 for r in sdss_spectra.records])\n",
+    "assert all([r.mjd == 54562 for r in sdss_spectra.records])"
    ]
   },
   {
@@ -1931,20 +992,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 40,
+   "execution_count": null,
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2025-12-15T16:59:59.482192Z",
-     "iopub.status.busy": "2025-12-15T16:59:59.482006Z",
-     "iopub.status.idle": "2025-12-15T16:59:59.488330Z",
-     "shell.execute_reply": "2025-12-15T16:59:59.487757Z",
-     "shell.execute_reply.started": "2025-12-15T16:59:59.482176Z"
-    },
     "tags": []
    },
    "outputs": [],
    "source": [
-    "assert all([(r.wavelength == sdss_records[0].wavelength).all() for r in sdss_records])"
+    "assert all([(r.wavelength == sdss_spectra.records[0].wavelength).all() for r in sdss_spectra.records])"
    ]
   },
   {
@@ -1956,33 +1010,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 41,
+   "execution_count": null,
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2025-12-15T16:59:59.489187Z",
-     "iopub.status.busy": "2025-12-15T16:59:59.489005Z",
-     "iopub.status.idle": "2025-12-15T16:59:59.494226Z",
-     "shell.execute_reply": "2025-12-15T16:59:59.493620Z",
-     "shell.execute_reply.started": "2025-12-15T16:59:59.489175Z"
-    },
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "WARNING: Spectrum record 0 is fully masked!\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "sdss_fully_masked = np.zeros((len(sdss_records), ), dtype=bool)\n",
+    "sdss_fully_masked = np.zeros((len(sdss_spectra.records), ), dtype=bool)\n",
     "\n",
-    "for k in range(len(sdss_records)):\n",
-    "    assert np.isfinite(sdss_records[k].flux).all()\n",
-    "    assert np.isfinite(sdss_records[k].ivar).all()\n",
-    "    if (sdss_records[k].mask > 0).all():\n",
+    "for k in range(len(sdss_spectra.records)):\n",
+    "    assert np.isfinite(sdss_spectra.records[k].flux).all()\n",
+    "    assert np.isfinite(sdss_spectra.records[k].ivar).all()\n",
+    "    if (sdss_spectra.records[k].mask > 0).all():\n",
     "        print(f\"WARNING: Spectrum record {k:d} is fully masked!\")\n",
     "        sdss_fully_masked[k] = True"
    ]
@@ -2003,251 +1042,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 42,
+   "execution_count": null,
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2025-12-15T16:59:59.495123Z",
-     "iopub.status.busy": "2025-12-15T16:59:59.494931Z",
-     "iopub.status.idle": "2025-12-15T16:59:59.502282Z",
-     "shell.execute_reply": "2025-12-15T16:59:59.501745Z",
-     "shell.execute_reply.started": "2025-12-15T16:59:59.495111Z"
-    },
     "scrolled": true,
     "tags": []
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'redshift_err': 6.426467734854668e-05,\n",
-       " 'specprimary': True,\n",
-       " 'specid': 3327035125891360768,\n",
-       " 'wavemin': 3821.2021484375,\n",
-       " 'targetid': 1237655468065620461,\n",
-       " 'sparcl_id': 'f54e0331-5e22-11f0-95ba-525400f334e1',\n",
-       " 'instrument': 'SDSS',\n",
-       " 'spectype': 'GALAXY',\n",
-       " 'ra': 236.58816,\n",
-       " 'data_release': 'SDSS-DR17',\n",
-       " 'datasetgroup': 'SDSS_BOSS',\n",
-       " 'wavemax': 9191.7880859375,\n",
-       " 'telescope': 'sloan25m',\n",
-       " 'dec': 0.91476191,\n",
-       " 'redshift_warning': 0,\n",
-       " 'exptime': 3002.0,\n",
-       " 'site': 'apo',\n",
-       " 'redshift': 0.2621992230415344,\n",
-       " 'tcolumn': [0, 1, 2, 3, -1, -1, -1, -1, -1, -1],\n",
-       " 'spec2_g': 24.95490074157715,\n",
-       " 'run2d': 26,\n",
-       " 'elodie_feh': 0.0,\n",
-       " 'comments_person': '',\n",
-       " 'fracnsigma': [0.3508818745613098,\n",
-       "  0.0670764297246933,\n",
-       "  0.006413682363927364,\n",
-       "  0.0008017102954909205,\n",
-       "  0.0005344735691323876,\n",
-       "  0.0,\n",
-       "  0.0,\n",
-       "  0.0,\n",
-       "  0.0,\n",
-       "  0.0],\n",
-       " 'deredsn2': 0.0,\n",
-       " 'elodie_z': 0.0,\n",
-       " 'designid': -1,\n",
-       " 'platequality': 'good',\n",
-       " 'spectrosynflux_ivar': [2.1609764099121094,\n",
-       "  4.695135116577148,\n",
-       "  2.821389675140381,\n",
-       "  1.6888610124588013,\n",
-       "  0.8614444136619568],\n",
-       " 'survey': 'sdss',\n",
-       " 'tile': 1929,\n",
-       " 'ancillary_target1': 0,\n",
-       " 'chunk': 'chunk186',\n",
-       " 'cx': -0.5505830676883018,\n",
-       " 'spec2_r': 26.778099060058594,\n",
-       " 'elodie_logg': 0.0,\n",
-       " 'firstrelease': 'dr7',\n",
-       " 'lambda_eff': 5000.0,\n",
-       " 'sn_median': [0.30225488543510437,\n",
-       "  1.2845332622528076,\n",
-       "  8.549945831298828,\n",
-       "  12.833003044128418,\n",
-       "  7.959794521331787],\n",
-       " 'ancillary_target2': 0,\n",
-       " 'eboss_target0': 0,\n",
-       " 'thing_id': 0,\n",
-       " 'mjd': 54562,\n",
-       " 'spectrographid': 1,\n",
-       " 'platesn2': 20.60099983215332,\n",
-       " 'subclass_noqso': '',\n",
-       " 'fiberid': 3,\n",
-       " 'subclass': '',\n",
-       " 'vdispchi2': 2368.89501953125,\n",
-       " 'elodie_rchi2': 0.0,\n",
-       " 'anyandmask': 231800836,\n",
-       " 'targetobjid': '     11268994537292320',\n",
-       " 'spec1_g': 20.60099983215332,\n",
-       " 'spectroskyflux': [5.863976955413818,\n",
-       "  10.033677101135254,\n",
-       "  26.674739837646484,\n",
-       "  46.53768539428711,\n",
-       "  89.36570739746094],\n",
-       " 'rchi2diff_noqso': 0.0,\n",
-       " 'vdispz_err': 0.0,\n",
-       " 'elodie_z_err': 0.0,\n",
-       " 'spectrosynflux': [0.8224945664405823,\n",
-       "  4.342596530914307,\n",
-       "  25.939159393310547,\n",
-       "  47.046897888183594,\n",
-       "  63.13018798828125],\n",
-       " 'cy': -0.8346277053986425,\n",
-       " 'calibflux_ivar': [6.960999965667725,\n",
-       "  32.389869689941406,\n",
-       "  15.000844955444336,\n",
-       "  5.515562057495117,\n",
-       "  0.4543570280075073],\n",
-       " 'specsegue1': 0,\n",
-       " 'eboss_target1': 0,\n",
-       " 'tfile': 'spEigenGal-53724.fits',\n",
-       " 'segue1_target1': 0,\n",
-       " 'rchi2': 1.1840944290161133,\n",
-       " 'spec1_r': 21.144100189208984,\n",
-       " 'specsegue': 0,\n",
-       " 'specsegue2': 0,\n",
-       " 'marvels_target1': 0,\n",
-       " 'chi68p': 1.0683659315109253,\n",
-       " 'xfocal': 254.52798461914062,\n",
-       " 'eboss_target2': 0,\n",
-       " 'sectarget': 0,\n",
-       " 'elodie_teff': 0.0,\n",
-       " 'sourcetype': 'GALAXY',\n",
-       " 'bluefiber': -1,\n",
-       " 'elodie_object': '',\n",
-       " 'segue2_target2': 0,\n",
-       " 'anyormask': 266272772,\n",
-       " 'run1d': 0,\n",
-       " 'elodie_filename': '',\n",
-       " 'specsdss': 1,\n",
-       " 'sn_median_all': 5.26422119140625,\n",
-       " 'special_target1': 0,\n",
-       " 'npoly': 3,\n",
-       " 'plate': 2955,\n",
-       " 'fracnsighi': [0.17691074311733246,\n",
-       "  0.029396044090390205,\n",
-       "  0.0024051310028880835,\n",
-       "  0.0005344735691323876,\n",
-       "  0.0005344735691323876,\n",
-       "  0.0,\n",
-       "  0.0,\n",
-       "  0.0,\n",
-       "  0.0,\n",
-       "  0.0],\n",
-       " 'segue2_target1': 0,\n",
-       " 'vdisp_err': 19.371538162231445,\n",
-       " 'eboss_target_id': 0,\n",
-       " 'class_noqso': '',\n",
-       " 'primtarget': 96,\n",
-       " 'zwarning_noqso': 0,\n",
-       " 'calibflux': [0.9236018657684326,\n",
-       "  6.705709457397461,\n",
-       "  29.254060745239258,\n",
-       "  49.9967041015625,\n",
-       "  72.04325866699219],\n",
-       " 'spectroflux_ivar': [1.5567643642425537,\n",
-       "  4.762773513793945,\n",
-       "  2.497319459915161,\n",
-       "  1.469778060913086,\n",
-       "  0.6877836585044861],\n",
-       " 'rchi2diff': 0.16153335571289062,\n",
-       " 'programname': 'legacy',\n",
-       " 'zoffset': 0.0,\n",
-       " 'speclegacy': 1,\n",
-       " 'z_person': 0.0,\n",
-       " 'boss_specobj_id': 0,\n",
-       " 'targettype': 'SCIENCE',\n",
-       " 'theta': [0.0009990220423787832,\n",
-       "  -0.0020634604152292013,\n",
-       "  0.0063892873004078865,\n",
-       "  0.010271521285176277,\n",
-       "  -9.59719467163086,\n",
-       "  31.447433471679688,\n",
-       "  -23.034820556640625,\n",
-       "  0.0,\n",
-       "  0.0,\n",
-       "  0.0],\n",
-       " 'class_person': 0,\n",
-       " 'elodie_dof': 0,\n",
-       " 'nturnoff': -1,\n",
-       " 'platerun': 'dr2008.02.1',\n",
-       " 'z_conf_person': 0,\n",
-       " 'objid': [2327, 40, 2, 95, 544],\n",
-       " 'boss_target2': 0,\n",
-       " 'elodie_sptype': '',\n",
-       " 'z_err_noqso': 0.0,\n",
-       " 'vdispz': 0.0,\n",
-       " 'segue1_target2': 0,\n",
-       " 'thing_id_targeting': 0,\n",
-       " 'fracnsiglo': [0.17397113144397736,\n",
-       "  0.037680383771657944,\n",
-       "  0.0040085515938699245,\n",
-       "  0.0002672367845661938,\n",
-       "  0.0,\n",
-       "  0.0,\n",
-       "  0.0,\n",
-       "  0.0,\n",
-       "  0.0,\n",
-       "  0.0],\n",
-       " 'elodie_z_modelerr': 0.0,\n",
-       " 'marvels_target2': 0,\n",
-       " 'special_target2': 0,\n",
-       " 'nspecobs': 1,\n",
-       " 'spec1_i': 20.87619972229004,\n",
-       " 'elodie_bv': 0.0,\n",
-       " 'wcoverage': 0.3741999864578247,\n",
-       " 'specboss': 0,\n",
-       " 'legacy_target2': 0,\n",
-       " 'fluxobjid': '1237655468065620461',\n",
-       " 'legacy_target1': 96,\n",
-       " 'z_noqso': 0.0,\n",
-       " 'vdisp': 174.73614501953125,\n",
-       " 'vdispdof': 2117,\n",
-       " 'snturnoff': -9999.0,\n",
-       " 'spectroflux': [1.6958324909210205,\n",
-       "  4.575725555419922,\n",
-       "  25.73033332824707,\n",
-       "  46.75497055053711,\n",
-       "  63.58713912963867],\n",
-       " 'spec2_i': 23.063199996948242,\n",
-       " 'vdispnpix': 2168.0,\n",
-       " 'cz': 0.015964928936132036,\n",
-       " 'boss_target1': 0,\n",
-       " 'dof': 3735,\n",
-       " 'plateid': '3327034301257639936',\n",
-       " 'yfocal': -158.91990661621094,\n",
-       " 'mask': array([16777216, 16777216, 16777216, ..., 16777216, 16777216, 16777216]),\n",
-       " 'wave_sigma': array([0., 0., 0., ..., 0., 0., 0.]),\n",
-       " 'model': array([0.50012714, 0.59808964, 0.66844636, ..., 9.11743164, 9.0471859 ,\n",
-       "        9.00358009]),\n",
-       " 'wavelength': array([3802.76948244, 3803.64520329, 3804.5211258 , ..., 9217.22098659,\n",
-       "        9219.34357452, 9221.46665124]),\n",
-       " 'ivar': array([0., 0., 0., ..., 0., 0., 0.]),\n",
-       " 'flux': array([0.85558206, 0.85530269, 0.85502368, ..., 8.03089142, 8.03085518,\n",
-       "        8.03081989]),\n",
-       " 'sky': array([0., 0., 0., ..., 0., 0., 0.]),\n",
-       " 'dateobs': '[\"2008-04-06 00:00:00+00\",\"2008-04-06 00:00:00+00\"]',\n",
-       " 'dateobs_center': '2008-04-06 00:00:00+00',\n",
-       " '_dr': 'SDSS-DR17'}"
-      ]
-     },
-     "execution_count": 42,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "sdss_records[0]"
+    "sdss_spectra.records[0]"
    ]
   },
   {
@@ -2258,7 +1060,7 @@
     "\n",
     "Prospect needs several inputs:\n",
     "\n",
-    "1. An object containing spectra.  In this case we'll use a [`Spectrum1D`](https://specutils.readthedocs.io/en/stable/api/specutils.Spectrum1D.html#specutils.Spectrum1D) object.\n",
+    "1. An object containing spectra.  In this case we'll use a [`Spectrum`](https://specutils.readthedocs.io/en/stable/api/specutils.Spectrum.html#specutils.Spectrum) object.\n",
     "   * The object contains the usual flux, wavelength, uncertainty.\n",
     "   * In addtion a \"plugmap\" table is needed. This should be an Astropy `Table` with the expected columns.\n",
     "2. A redshift catalog. This should be an Astropy `Table` with the expected columns.\n",
@@ -2266,61 +1068,31 @@
     "\n",
     "#### Spectrum object\n",
     "\n",
-    "First we assemble the components of the spectrum object"
+    "First we assemble the components of the spectrum object. Most of the work is done simply by converting the retrieved results to a `specutils` object."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 43,
+   "execution_count": null,
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2025-12-15T16:59:59.503114Z",
-     "iopub.status.busy": "2025-12-15T16:59:59.502953Z",
-     "iopub.status.idle": "2025-12-15T16:59:59.508685Z",
-     "shell.execute_reply": "2025-12-15T16:59:59.508118Z",
-     "shell.execute_reply.started": "2025-12-15T16:59:59.503100Z"
-    },
     "tags": []
    },
    "outputs": [],
    "source": [
-    "flux = np.zeros((len(sdss_records), sdss_records[0].flux.shape[0]),\n",
-    "                dtype=sdss_records[0].flux.dtype)\n",
-    "uncertainty = np.zeros((len(sdss_records), sdss_records[0].ivar.shape[0]),\n",
-    "                       dtype=sdss_records[0].ivar.dtype)\n",
-    "mask = np.zeros((len(sdss_records), sdss_records[0].mask.shape[0]),\n",
-    "                dtype=sdss_records[0].mask.dtype)\n",
-    "\n",
-    "meta = {'sparcl_id': list(), 'data_release': list()}\n",
-    "sparcl_id = list()\n",
-    "data_release = list()\n",
-    "\n",
-    "for k in range(len(sdss_records)):\n",
-    "    flux[k, :] = sdss_records[k].flux\n",
-    "    uncertainty[k, :] = sdss_records[k].ivar\n",
-    "    mask[k, :] = sdss_records[k].mask\n",
-    "    meta['sparcl_id'].append(sdss_records[k].sparcl_id)\n",
-    "    meta['data_release'].append(sdss_records[k].data_release)"
+    "sdss_specutils = sdss_spectra.to_specutils()"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "And the \"plugmap\" table. We'll start with photometric quantities."
+    "We need a \"plugmap\" table. We'll start with photometric quantities."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 44,
+   "execution_count": null,
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2025-12-15T16:59:59.509564Z",
-     "iopub.status.busy": "2025-12-15T16:59:59.509377Z",
-     "iopub.status.idle": "2025-12-15T17:00:00.748993Z",
-     "shell.execute_reply": "2025-12-15T17:00:00.748276Z",
-     "shell.execute_reply.started": "2025-12-15T16:59:59.509551Z"
-    },
     "tags": []
    },
    "outputs": [],
@@ -2340,15 +1112,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 45,
+   "execution_count": null,
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2025-12-15T17:00:00.750516Z",
-     "iopub.status.busy": "2025-12-15T17:00:00.750296Z",
-     "iopub.status.idle": "2025-12-15T17:00:00.756005Z",
-     "shell.execute_reply": "2025-12-15T17:00:00.755385Z",
-     "shell.execute_reply.started": "2025-12-15T17:00:00.750498Z"
-    },
     "tags": []
    },
    "outputs": [],
@@ -2361,7 +1126,7 @@
     "plugmap.add_column(mag, name='MAG')\n",
     "plugmap.add_column(sdss_ids['primtarget'], name='PRIMTARGET')\n",
     "plugmap.add_column(sdss_ids['sectarget'], name='SECTARGET')\n",
-    "meta['plugmap'] = plugmap[~sdss_fully_masked]"
+    "sdss_specutils.meta['plugmap'] = plugmap[~sdss_fully_masked]"
    ]
   },
   {
@@ -2373,15 +1138,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 46,
+   "execution_count": null,
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2025-12-15T17:00:00.757114Z",
-     "iopub.status.busy": "2025-12-15T17:00:00.756921Z",
-     "iopub.status.idle": "2025-12-15T17:00:00.761828Z",
-     "shell.execute_reply": "2025-12-15T17:00:00.761244Z",
-     "shell.execute_reply.started": "2025-12-15T17:00:00.757099Z"
-    },
     "tags": []
    },
    "outputs": [],
@@ -2398,24 +1156,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 47,
+   "execution_count": null,
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2025-12-15T17:00:00.762917Z",
-     "iopub.status.busy": "2025-12-15T17:00:00.762573Z",
-     "iopub.status.idle": "2025-12-15T17:00:00.769824Z",
-     "shell.execute_reply": "2025-12-15T17:00:00.769272Z",
-     "shell.execute_reply.started": "2025-12-15T17:00:00.762902Z"
-    },
     "tags": []
    },
    "outputs": [],
    "source": [
-    "sdss_prospect = Spectrum1D(flux=flux[~sdss_fully_masked, :] * u.Unit('1e-17 erg / (Angstrom cm2 s)'),\n",
-    "                           spectral_axis=sdss_records[0].wavelength * u.Unit('Angstrom'),\n",
-    "                           uncertainty=InverseVariance(uncertainty[~sdss_fully_masked, :]),\n",
-    "                           mask=mask[~sdss_fully_masked, :] != 0,\n",
-    "                           meta=meta)"
+    "sdss_prospect = Spectrum1D(flux=sdss_specutils.flux[~sdss_fully_masked, :],\n",
+    "                           spectral_axis=sdss_specutils.spectral_axis,\n",
+    "                           uncertainty=InverseVariance(sdss_specutils.uncertainty[~sdss_fully_masked, :]),\n",
+    "                           mask=sdss_specutils.mask[~sdss_fully_masked, :] != 0,\n",
+    "                           meta=sdss_specutils.meta)"
    ]
   },
   {
@@ -2429,81 +1180,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 48,
+   "execution_count": null,
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2025-12-15T17:00:00.770871Z",
-     "iopub.status.busy": "2025-12-15T17:00:00.770554Z",
-     "iopub.status.idle": "2025-12-15T17:00:00.778760Z",
-     "shell.execute_reply": "2025-12-15T17:00:00.778211Z",
-     "shell.execute_reply.started": "2025-12-15T17:00:00.770856Z"
-    },
     "tags": []
    },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div><i>Table length=50</i>\n",
-       "<table id=\"table140046225045584\" class=\"table-striped table-bordered table-condensed\">\n",
-       "<thead><tr><th>SPECOBJID</th><th>BESTOBJID</th><th>Z</th><th>Z_ERR</th><th>ZWARNING</th><th>CLASS</th><th>SUBCLASS</th><th>RCHI2DIFF</th><th>PRIMTARGET</th><th>SECTARGET</th></tr></thead>\n",
-       "<thead><tr><th>int64</th><th>int64</th><th>float64</th><th>float64</th><th>int64</th><th>str6</th><th>str11</th><th>float64</th><th>int64</th><th>int64</th></tr></thead>\n",
-       "<tr><td>3327035125891360768</td><td>1237655468065620461</td><td>0.26219922</td><td>6.426468e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>0.16153336</td><td>96</td><td>0</td></tr>\n",
-       "<tr><td>3327036500280895488</td><td>1237655468065489538</td><td>0.21097003</td><td>5.7919853e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>0.13921309</td><td>64</td><td>0</td></tr>\n",
-       "<tr><td>3327038424426244096</td><td>1237655468065620456</td><td>0.2605426</td><td>6.229882e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>0.22558784</td><td>32</td><td>0</td></tr>\n",
-       "<tr><td>3327038974182057984</td><td>1237655468065620382</td><td>0.11276812</td><td>1.5994665e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>0.510905</td><td>64</td><td>0</td></tr>\n",
-       "<tr><td>3327040073693685760</td><td>1237651736318574966</td><td>0.06364931</td><td>2.8312488e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>0.42436635</td><td>64</td><td>0</td></tr>\n",
-       "<tr><td>3327040348571592704</td><td>1237651736318640378</td><td>0.20836118</td><td>4.189276e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>1.1794078</td><td>96</td><td>0</td></tr>\n",
-       "<tr><td>3327040898327406592</td><td>1237655468602491146</td><td>0.20784536</td><td>4.1236628e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>0.61972916</td><td>64</td><td>0</td></tr>\n",
-       "<tr><td>3327041722961127424</td><td>1237651736318575080</td><td>0.1408417</td><td>1.9260546e-05</td><td>0</td><td>GALAXY</td><td>STARFORMING</td><td>0.49670327</td><td>64</td><td>0</td></tr>\n",
-       "<tr><td>3327042822472755200</td><td>1237651736318574838</td><td>0.21259658</td><td>7.138862e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>0.14038157</td><td>96</td><td>0</td></tr>\n",
-       "<tr><td>3327044196862289920</td><td>1237655468602556710</td><td>0.12747255</td><td>1.0024814e-05</td><td>0</td><td>GALAXY</td><td>STARFORMING</td><td>0.9118272</td><td>64</td><td>0</td></tr>\n",
-       "<tr><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td></tr>\n",
-       "<tr><td>3327063988071589888</td><td>1237655468602294437</td><td>0.117277816</td><td>1.2225097e-05</td><td>0</td><td>GALAXY</td><td>STARBURST</td><td>2.301178</td><td>64</td><td>0</td></tr>\n",
-       "<tr><td>3327065087583217664</td><td>1237651736318378283</td><td>0.02987722</td><td>6.544521e-06</td><td>0</td><td>GALAXY</td><td>STARBURST</td><td>6.2372937</td><td>64</td><td>0</td></tr>\n",
-       "<tr><td>3327065362461124608</td><td>1237655468602360140</td><td>0.08503898</td><td>2.8198616e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>0.38777363</td><td>64</td><td>0</td></tr>\n",
-       "<tr><td>3327065912216938496</td><td>1237651736318443551</td><td>0.16617252</td><td>3.350158e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>0.5785748</td><td>64</td><td>0</td></tr>\n",
-       "<tr><td>3327066187094845440</td><td>1237655468602294603</td><td>0.084284484</td><td>1.1737382e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>0.53542316</td><td>64</td><td>0</td></tr>\n",
-       "<tr><td>3327066736850659328</td><td>1237651736318378031</td><td>0.050459415</td><td>3.3662614e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>0.066199064</td><td>64</td><td>0</td></tr>\n",
-       "<tr><td>3327067011728566272</td><td>1237651735781377183</td><td>0.44971278</td><td>0.00015747716</td><td>0</td><td>GALAXY</td><td>--</td><td>0.060908318</td><td>32</td><td>0</td></tr>\n",
-       "<tr><td>3327067286606473216</td><td>1237651736318444114</td><td>0.15844806</td><td>2.7416756e-05</td><td>0</td><td>GALAXY</td><td>STARFORMING</td><td>0.13396144</td><td>64</td><td>0</td></tr>\n",
-       "<tr><td>3327067561484380160</td><td>1237655468064965078</td><td>0.0846016</td><td>2.5953486e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>0.16839969</td><td>64</td><td>0</td></tr>\n",
-       "<tr><td>3327068111240194048</td><td>1237655468064964823</td><td>0.08544502</td><td>3.2923934e-05</td><td>0</td><td>GALAXY</td><td>STARFORMING</td><td>0.3577659</td><td>64</td><td>0</td></tr>\n",
-       "</table></div>"
-      ],
-      "text/plain": [
-       "<Table length=50>\n",
-       "     SPECOBJID           BESTOBJID           Z      ... PRIMTARGET SECTARGET\n",
-       "       int64               int64          float64   ...   int64      int64  \n",
-       "------------------- ------------------- ----------- ... ---------- ---------\n",
-       "3327035125891360768 1237655468065620461  0.26219922 ...         96         0\n",
-       "3327036500280895488 1237655468065489538  0.21097003 ...         64         0\n",
-       "3327038424426244096 1237655468065620456   0.2605426 ...         32         0\n",
-       "3327038974182057984 1237655468065620382  0.11276812 ...         64         0\n",
-       "3327040073693685760 1237651736318574966  0.06364931 ...         64         0\n",
-       "3327040348571592704 1237651736318640378  0.20836118 ...         96         0\n",
-       "3327040898327406592 1237655468602491146  0.20784536 ...         64         0\n",
-       "3327041722961127424 1237651736318575080   0.1408417 ...         64         0\n",
-       "3327042822472755200 1237651736318574838  0.21259658 ...         96         0\n",
-       "3327044196862289920 1237655468602556710  0.12747255 ...         64         0\n",
-       "                ...                 ...         ... ...        ...       ...\n",
-       "3327063988071589888 1237655468602294437 0.117277816 ...         64         0\n",
-       "3327065087583217664 1237651736318378283  0.02987722 ...         64         0\n",
-       "3327065362461124608 1237655468602360140  0.08503898 ...         64         0\n",
-       "3327065912216938496 1237651736318443551  0.16617252 ...         64         0\n",
-       "3327066187094845440 1237655468602294603 0.084284484 ...         64         0\n",
-       "3327066736850659328 1237651736318378031 0.050459415 ...         64         0\n",
-       "3327067011728566272 1237651735781377183  0.44971278 ...         32         0\n",
-       "3327067286606473216 1237651736318444114  0.15844806 ...         64         0\n",
-       "3327067561484380160 1237655468064965078   0.0846016 ...         64         0\n",
-       "3327068111240194048 1237655468064964823  0.08544502 ...         64         0"
-      ]
-     },
-     "execution_count": 48,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "sdss_zcatalog = sdss_ids.copy()\n",
     "for col in sdss_zcatalog.colnames:\n",
@@ -2525,26 +1206,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 49,
+   "execution_count": null,
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2025-12-15T17:00:00.779793Z",
-     "iopub.status.busy": "2025-12-15T17:00:00.779481Z",
-     "iopub.status.idle": "2025-12-15T17:00:00.790724Z",
-     "shell.execute_reply": "2025-12-15T17:00:00.790170Z",
-     "shell.execute_reply.started": "2025-12-15T17:00:00.779777Z"
-    },
     "tags": []
    },
    "outputs": [],
    "source": [
-    "model_flux = np.zeros((len(sdss_records), sdss_records[0].model.shape[0]),\n",
-    "                      dtype=sdss_records[0].model.dtype)\n",
-    "\n",
-    "for k in range(len(sdss_records)):\n",
-    "        model_flux[k, :] = sdss_records[k].model\n",
-    "\n",
-    "sdss_model = (sdss_records[0].wavelength, model_flux[~sdss_fully_masked, :])"
+    "sdss_model = (sdss_specutils.spectral_axis, sdss_specutils.meta['model'][~sdss_fully_masked, :])"
    ]
   },
   {
@@ -2593,81 +1261,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 51,
+   "execution_count": null,
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2025-12-15T17:00:01.546685Z",
-     "iopub.status.busy": "2025-12-15T17:00:01.546322Z",
-     "iopub.status.idle": "2025-12-15T17:00:01.654811Z",
-     "shell.execute_reply": "2025-12-15T17:00:01.654240Z",
-     "shell.execute_reply.started": "2025-12-15T17:00:01.546665Z"
-    },
     "tags": []
    },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div><i>Table length=50</i>\n",
-       "<table id=\"table140046224292544\" class=\"table-striped table-bordered table-condensed\">\n",
-       "<thead><tr><th>specobjid</th><th>bestobjid</th><th>z</th><th>zerr</th><th>zwarning</th><th>class</th><th>subclass</th><th>rchi2diff</th><th>boss_target1</th><th>eboss_target0</th><th>eboss_target1</th><th>eboss_target2</th></tr></thead>\n",
-       "<thead><tr><th>int64</th><th>int64</th><th>float64</th><th>float64</th><th>int64</th><th>str6</th><th>int64</th><th>float64</th><th>int64</th><th>int64</th><th>int64</th><th>int64</th></tr></thead>\n",
-       "<tr><td>-7639230456632420352</td><td>1237665127987282622</td><td>0.8864001</td><td>7.46243e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>0.06786668</td><td>0</td><td>0</td><td>17592186044416</td><td>562949953421312</td></tr>\n",
-       "<tr><td>-7639227982731257856</td><td>1237665098459972441</td><td>0.9110273</td><td>0.00010862139</td><td>0</td><td>GALAXY</td><td>--</td><td>0.017336488</td><td>0</td><td>0</td><td>17592186044416</td><td>562949953421312</td></tr>\n",
-       "<tr><td>-7639227707853350912</td><td>1237665128524284395</td><td>0.38422197</td><td>3.6719743e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>0.04284048</td><td>0</td><td>0</td><td>17592186044416</td><td>562949953421312</td></tr>\n",
-       "<tr><td>-7639227432975443968</td><td>1237665098459972179</td><td>0.800372</td><td>7.3419695e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>0.026912212</td><td>0</td><td>0</td><td>17592186044416</td><td>562949953421312</td></tr>\n",
-       "<tr><td>-7639226333463816192</td><td>1237665128524350020</td><td>0.7552478</td><td>0.00021523784</td><td>0</td><td>GALAXY</td><td>--</td><td>0.013269424</td><td>0</td><td>0</td><td>17592186044416</td><td>562949953421312</td></tr>\n",
-       "<tr><td>-7639225783708002304</td><td>1237665128524415517</td><td>0.8210997</td><td>8.6923865e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>0.023777902</td><td>0</td><td>0</td><td>17592186044416</td><td>562949953421312</td></tr>\n",
-       "<tr><td>-7639225233952188416</td><td>1237665098460037767</td><td>1.4448175</td><td>0.7513441</td><td>0</td><td>GALAXY</td><td>--</td><td>0.011829615</td><td>0</td><td>0</td><td>17592186044416</td><td>562949953421312</td></tr>\n",
-       "<tr><td>-7639224959074281472</td><td>1237665128524153288</td><td>0.92107</td><td>0.000118537646</td><td>0</td><td>GALAXY</td><td>--</td><td>0.017925024</td><td>0</td><td>0</td><td>17592186044416</td><td>562949953421312</td></tr>\n",
-       "<tr><td>-7639224409318467584</td><td>1237665097923035567</td><td>0.98253536</td><td>0.00013488902</td><td>0</td><td>GALAXY</td><td>--</td><td>0.0124723315</td><td>0</td><td>0</td><td>17592186044416</td><td>562949953421312</td></tr>\n",
-       "<tr><td>-7639224134440560640</td><td>1237665128524153695</td><td>0.7265247</td><td>0.00017648208</td><td>0</td><td>GALAXY</td><td>--</td><td>0.012127399</td><td>0</td><td>0</td><td>17592186044416</td><td>562949953421312</td></tr>\n",
-       "<tr><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td></tr>\n",
-       "<tr><td>-7639198570795214848</td><td>1237665129060959070</td><td>0.880374</td><td>0.00012446102</td><td>0</td><td>GALAXY</td><td>--</td><td>0.011144221</td><td>0</td><td>0</td><td>17592186044416</td><td>562949953421312</td></tr>\n",
-       "<tr><td>-7639198021039400960</td><td>1237664834855306140</td><td>0.8465685</td><td>0.0001428312</td><td>0</td><td>GALAXY</td><td>--</td><td>0.010542035</td><td>0</td><td>0</td><td>17592186044416</td><td>562949953421312</td></tr>\n",
-       "<tr><td>-7639197196405680128</td><td>1237665097385771894</td><td>0.95612645</td><td>0.00012754179</td><td>0</td><td>GALAXY</td><td>--</td><td>0.016105115</td><td>0</td><td>0</td><td>17592186044416</td><td>562949953421312</td></tr>\n",
-       "<tr><td>-7639196371771959296</td><td>1237665097385772080</td><td>0.9289423</td><td>0.00012436773</td><td>0</td><td>GALAXY</td><td>--</td><td>0.020461261</td><td>0</td><td>0</td><td>17592186044416</td><td>562949953421312</td></tr>\n",
-       "<tr><td>-7639191698847541248</td><td>1237665098459644688</td><td>0.8261564</td><td>6.6143366e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>0.044942915</td><td>0</td><td>0</td><td>17592186044416</td><td>562949953421312</td></tr>\n",
-       "<tr><td>-7639191423969634304</td><td>1237665128523891276</td><td>0.8741866</td><td>0.0001341164</td><td>0</td><td>GALAXY</td><td>--</td><td>0.0131188035</td><td>0</td><td>0</td><td>17592186044416</td><td>562949953421312</td></tr>\n",
-       "<tr><td>-7639190874213820416</td><td>1237665098459644459</td><td>0.8458714</td><td>0.00012319988</td><td>0</td><td>GALAXY</td><td>--</td><td>0.019765258</td><td>0</td><td>0</td><td>17592186044416</td><td>562949953421312</td></tr>\n",
-       "<tr><td>-7639190599335913472</td><td>1237665098459644444</td><td>0.8814687</td><td>0.0001139445</td><td>0</td><td>GALAXY</td><td>--</td><td>0.013265789</td><td>0</td><td>0</td><td>17592186044416</td><td>562949953421312</td></tr>\n",
-       "<tr><td>-7639190049580099584</td><td>1237665098459710264</td><td>0.29381013</td><td>5.2243926e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>0.017308354</td><td>0</td><td>0</td><td>17592186044416</td><td>562949953421312</td></tr>\n",
-       "<tr><td>-7639188950068471808</td><td>1237665098459644427</td><td>0.9214909</td><td>0.00020075552</td><td>0</td><td>GALAXY</td><td>--</td><td>0.011227965</td><td>0</td><td>0</td><td>17592186044416</td><td>562949953421312</td></tr>\n",
-       "</table></div>"
-      ],
-      "text/plain": [
-       "<Table length=50>\n",
-       "     specobjid            bestobjid      ... eboss_target1   eboss_target2 \n",
-       "       int64                int64        ...     int64           int64     \n",
-       "-------------------- ------------------- ... -------------- ---------------\n",
-       "-7639230456632420352 1237665127987282622 ... 17592186044416 562949953421312\n",
-       "-7639227982731257856 1237665098459972441 ... 17592186044416 562949953421312\n",
-       "-7639227707853350912 1237665128524284395 ... 17592186044416 562949953421312\n",
-       "-7639227432975443968 1237665098459972179 ... 17592186044416 562949953421312\n",
-       "-7639226333463816192 1237665128524350020 ... 17592186044416 562949953421312\n",
-       "-7639225783708002304 1237665128524415517 ... 17592186044416 562949953421312\n",
-       "-7639225233952188416 1237665098460037767 ... 17592186044416 562949953421312\n",
-       "-7639224959074281472 1237665128524153288 ... 17592186044416 562949953421312\n",
-       "-7639224409318467584 1237665097923035567 ... 17592186044416 562949953421312\n",
-       "-7639224134440560640 1237665128524153695 ... 17592186044416 562949953421312\n",
-       "                 ...                 ... ...            ...             ...\n",
-       "-7639198570795214848 1237665129060959070 ... 17592186044416 562949953421312\n",
-       "-7639198021039400960 1237664834855306140 ... 17592186044416 562949953421312\n",
-       "-7639197196405680128 1237665097385771894 ... 17592186044416 562949953421312\n",
-       "-7639196371771959296 1237665097385772080 ... 17592186044416 562949953421312\n",
-       "-7639191698847541248 1237665098459644688 ... 17592186044416 562949953421312\n",
-       "-7639191423969634304 1237665128523891276 ... 17592186044416 562949953421312\n",
-       "-7639190874213820416 1237665098459644459 ... 17592186044416 562949953421312\n",
-       "-7639190599335913472 1237665098459644444 ... 17592186044416 562949953421312\n",
-       "-7639190049580099584 1237665098459710264 ... 17592186044416 562949953421312\n",
-       "-7639188950068471808 1237665098459644427 ... 17592186044416 562949953421312"
-      ]
-     },
-     "execution_count": 51,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "q = \"\"\"\n",
     "SELECT z.specobjid, z.bestobjid, z.z, z.zerr, z.zwarning, z.class, z.subclass,\n",
@@ -2696,16 +1294,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 52,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2025-12-15T17:00:01.655674Z",
-     "iopub.status.busy": "2025-12-15T17:00:01.655511Z",
-     "iopub.status.idle": "2025-12-15T17:00:01.658525Z",
-     "shell.execute_reply": "2025-12-15T17:00:01.658077Z",
-     "shell.execute_reply.started": "2025-12-15T17:00:01.655660Z"
-    }
-   },
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": [
     "assert (np.unique(boss_ids['specobjid']) == boss_ids['specobjid']).all()"
@@ -2722,31 +1312,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 53,
+   "execution_count": null,
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2025-12-15T17:00:01.659664Z",
-     "iopub.status.busy": "2025-12-15T17:00:01.659146Z",
-     "iopub.status.idle": "2025-12-15T17:00:03.161501Z",
-     "shell.execute_reply": "2025-12-15T17:00:03.160853Z",
-     "shell.execute_reply.started": "2025-12-15T17:00:01.659649Z"
-    },
     "tags": []
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'status': {'success': True,\n",
-       "  'info': [\"Successfully found 50 records in dr_list=['BOSS-DR17']\"],\n",
-       "  'warnings': []}}"
-      ]
-     },
-     "execution_count": 53,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "include = client.get_all_fields(dataset_list=['BOSS-DR17'])\n",
     "boss_spectra = client.retrieve_by_specid(specid_list=boss_ids['specobjid'].value.tolist(),\n",
@@ -2768,23 +1338,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 54,
+   "execution_count": null,
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2025-12-15T17:00:03.162489Z",
-     "iopub.status.busy": "2025-12-15T17:00:03.162326Z",
-     "iopub.status.idle": "2025-12-15T17:00:03.166385Z",
-     "shell.execute_reply": "2025-12-15T17:00:03.165812Z",
-     "shell.execute_reply.started": "2025-12-15T17:00:03.162476Z"
-    },
     "tags": []
    },
    "outputs": [],
    "source": [
-    "boss_records = sorted(boss_spectra.records, key=lambda x: x.specid)\n",
-    "assert (np.array([r.specid for r in boss_records]) == boss_ids['specobjid']).all()\n",
-    "assert all([r.plate == 9599 for r in boss_records])\n",
-    "assert all([r.mjd == 58131 for r in boss_records])"
+    "boss_spectra = boss_spectra.reorder(boss_ids['specobjid'].value.tolist())\n",
+    "assert (np.array([r.specid for r in boss_spectra.records]) == boss_ids['specobjid']).all()\n",
+    "assert all([r.plate == 9599 for r in boss_spectra.records])\n",
+    "assert all([r.mjd == 58131 for r in boss_spectra.records])"
    ]
   },
   {
@@ -2796,20 +1359,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 55,
+   "execution_count": null,
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2025-12-15T17:00:03.167160Z",
-     "iopub.status.busy": "2025-12-15T17:00:03.167020Z",
-     "iopub.status.idle": "2025-12-15T17:00:03.172639Z",
-     "shell.execute_reply": "2025-12-15T17:00:03.172092Z",
-     "shell.execute_reply.started": "2025-12-15T17:00:03.167148Z"
-    },
     "tags": []
    },
    "outputs": [],
    "source": [
-    "assert all([(r.wavelength == boss_records[0].wavelength).all() for r in boss_records])"
+    "assert all([(r.wavelength == boss_spectra.records[0].wavelength).all() for r in boss_spectra.records])"
    ]
   },
   {
@@ -2821,25 +1377,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 56,
+   "execution_count": null,
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2025-12-15T17:00:03.173441Z",
-     "iopub.status.busy": "2025-12-15T17:00:03.173302Z",
-     "iopub.status.idle": "2025-12-15T17:00:03.191944Z",
-     "shell.execute_reply": "2025-12-15T17:00:03.191326Z",
-     "shell.execute_reply.started": "2025-12-15T17:00:03.173429Z"
-    },
     "tags": []
    },
    "outputs": [],
    "source": [
-    "boss_fully_masked = np.zeros((len(boss_records), ), dtype=bool)\n",
+    "boss_fully_masked = np.zeros((len(boss_spectra.records), ), dtype=bool)\n",
     "\n",
-    "for k in range(len(boss_records)):\n",
-    "    assert np.isfinite(boss_records[k].flux).all()\n",
-    "    assert np.isfinite(boss_records[k].ivar).all()\n",
-    "    if (boss_records[k].mask > 0).all():\n",
+    "for k in range(len(boss_spectra.records)):\n",
+    "    assert np.isfinite(boss_spectra.records[k].flux).all()\n",
+    "    assert np.isfinite(boss_spectra.records[k].ivar).all()\n",
+    "    if (boss_spectra.records[k].mask > 0).all():\n",
     "        print(f\"WARNING: Spectrum record {k:d} is fully masked!\")\n",
     "        boss_fully_masked[k] = True"
    ]
@@ -2853,251 +1402,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 57,
+   "execution_count": null,
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2025-12-15T17:00:03.192893Z",
-     "iopub.status.busy": "2025-12-15T17:00:03.192655Z",
-     "iopub.status.idle": "2025-12-15T17:00:03.199845Z",
-     "shell.execute_reply": "2025-12-15T17:00:03.199282Z",
-     "shell.execute_reply.started": "2025-12-15T17:00:03.192880Z"
-    },
     "scrolled": true,
     "tags": []
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'redshift_err': 7.462430221494287e-05,\n",
-       " 'specprimary': True,\n",
-       " 'specid': -7639230456632420352,\n",
-       " 'wavemin': 3601.637451171875,\n",
-       " 'targetid': 1237665127987282622,\n",
-       " 'sparcl_id': '098d97da-252f-11f0-bc98-525400f334e1',\n",
-       " 'instrument': 'BOSS',\n",
-       " 'spectype': 'GALAXY',\n",
-       " 'ra': 134.30633999999998,\n",
-       " 'data_release': 'BOSS-DR17',\n",
-       " 'datasetgroup': 'SDSS_BOSS',\n",
-       " 'wavemax': 10332.37109375,\n",
-       " 'telescope': 'sloan25m',\n",
-       " 'dec': 23.560574,\n",
-       " 'redshift_warning': 0,\n",
-       " 'exptime': 3600.35,\n",
-       " 'site': 'apo',\n",
-       " 'redshift': 0.8864001035690308,\n",
-       " 'tcolumn': [0, 1, 2, 3, -1, -1, -1, -1, -1, -1],\n",
-       " 'spec2_g': 6.294640064239502,\n",
-       " 'run2d': 'v5_13_2',\n",
-       " 'elodie_feh': 0.0,\n",
-       " 'comments_person': '',\n",
-       " 'fracnsigma': [0.3162296712398529,\n",
-       "  0.055831827223300934,\n",
-       "  0.009041591547429562,\n",
-       "  0.0011301989434286952,\n",
-       "  0.0,\n",
-       "  0.0,\n",
-       "  0.0,\n",
-       "  0.0,\n",
-       "  0.0,\n",
-       "  0.0],\n",
-       " 'deredsn2': 5.500629901885986,\n",
-       " 'elodie_z': 0.0,\n",
-       " 'designid': 10182,\n",
-       " 'platequality': 'good',\n",
-       " 'spectrosynflux_ivar': [6.276416778564453,\n",
-       "  9.02142333984375,\n",
-       "  6.571553707122803,\n",
-       "  3.8821513652801514,\n",
-       "  1.8567394018173218],\n",
-       " 'survey': 'eboss',\n",
-       " 'tile': 17241,\n",
-       " 'ancillary_target1': 0,\n",
-       " 'chunk': 'eboss23',\n",
-       " 'cx': -0.6402665775983531,\n",
-       " 'spec2_r': 15.703800201416016,\n",
-       " 'elodie_logg': 0.0,\n",
-       " 'firstrelease': 'dr17',\n",
-       " 'lambda_eff': 7500.0,\n",
-       " 'sn_median': [0.2263146936893463,\n",
-       "  0.7281882166862488,\n",
-       "  0.8945983052253723,\n",
-       "  1.4738258123397827,\n",
-       "  1.3543939590454102],\n",
-       " 'ancillary_target2': 0,\n",
-       " 'eboss_target0': 0,\n",
-       " 'thing_id': 316262311,\n",
-       " 'mjd': 58131,\n",
-       " 'spectrographid': 1,\n",
-       " 'platesn2': 5.500629901885986,\n",
-       " 'subclass_noqso': '',\n",
-       " 'fiberid': 1,\n",
-       " 'subclass': '',\n",
-       " 'vdispchi2': 1443.5518798828125,\n",
-       " 'elodie_rchi2': 0.0,\n",
-       " 'anyandmask': 96731136,\n",
-       " 'targetobjid': '',\n",
-       " 'spec1_g': 5.500629901885986,\n",
-       " 'spectroskyflux': [9.836366653442383,\n",
-       "  13.262933731079102,\n",
-       "  29.112598419189453,\n",
-       "  63.5466194152832,\n",
-       "  171.4568634033203],\n",
-       " 'rchi2diff_noqso': 0.08232581615447998,\n",
-       " 'vdispz_err': 0.0,\n",
-       " 'elodie_z_err': 0.0,\n",
-       " 'spectrosynflux': [0.7843775153160095,\n",
-       "  1.2373796701431274,\n",
-       "  1.8416348695755005,\n",
-       "  3.9133851528167725,\n",
-       "  5.673061847686768],\n",
-       " 'cy': 0.6559603107653976,\n",
-       " 'calibflux_ivar': [5.2025065422058105,\n",
-       "  34.74420928955078,\n",
-       "  10.3529052734375,\n",
-       "  3.913039207458496,\n",
-       "  0.20810265839099884],\n",
-       " 'specsegue1': 0,\n",
-       " 'eboss_target1': 17592186044416,\n",
-       " 'tfile': 'spEigenGal-56436.fits',\n",
-       " 'segue1_target1': 0,\n",
-       " 'rchi2': 1.0829224586486816,\n",
-       " 'spec1_r': 19.635000228881836,\n",
-       " 'specsegue': 0,\n",
-       " 'specsegue2': 0,\n",
-       " 'marvels_target1': 0,\n",
-       " 'chi68p': 0.9948847889900208,\n",
-       " 'xfocal': 266.6521301269531,\n",
-       " 'eboss_target2': 562949953421312,\n",
-       " 'sectarget': 0,\n",
-       " 'elodie_teff': 0.0,\n",
-       " 'sourcetype': 'ELG',\n",
-       " 'bluefiber': 1,\n",
-       " 'elodie_object': '',\n",
-       " 'segue2_target2': 0,\n",
-       " 'anyormask': 265224192,\n",
-       " 'run1d': 0,\n",
-       " 'elodie_filename': '',\n",
-       " 'specsdss': 0,\n",
-       " 'sn_median_all': 0.9232138395309448,\n",
-       " 'special_target1': 0,\n",
-       " 'npoly': 3,\n",
-       " 'plate': 9599,\n",
-       " 'fracnsighi': [0.16229656338691711,\n",
-       "  0.03096744976937771,\n",
-       "  0.006103074178099632,\n",
-       "  0.0009041591547429562,\n",
-       "  0.0,\n",
-       "  0.0,\n",
-       "  0.0,\n",
-       "  0.0,\n",
-       "  0.0,\n",
-       "  0.0],\n",
-       " 'segue2_target1': 0,\n",
-       " 'vdisp_err': 178.60658264160156,\n",
-       " 'eboss_target_id': 2990008,\n",
-       " 'class_noqso': 'GALAXY',\n",
-       " 'primtarget': 0,\n",
-       " 'zwarning_noqso': 0,\n",
-       " 'calibflux': [0.8216304183006287,\n",
-       "  0.8483012318611145,\n",
-       "  1.568734049797058,\n",
-       "  3.4619531631469727,\n",
-       "  5.181345462799072],\n",
-       " 'spectroflux_ivar': [2.5664212703704834,\n",
-       "  9.050325393676758,\n",
-       "  5.572259902954102,\n",
-       "  2.5301566123962402,\n",
-       "  0.08179719746112823],\n",
-       " 'rchi2diff': 0.06786668300628662,\n",
-       " 'programname': 'ELG_NGC',\n",
-       " 'zoffset': 0.0,\n",
-       " 'speclegacy': 0,\n",
-       " 'z_person': 0.0,\n",
-       " 'boss_specobj_id': 3188821,\n",
-       " 'targettype': 'SCIENCE',\n",
-       " 'theta': [-0.001900560106150806,\n",
-       "  -0.2047363519668579,\n",
-       "  0.6663264632225037,\n",
-       "  0.09140719473361969,\n",
-       "  -2.2184066772460938,\n",
-       "  4.503273963928223,\n",
-       "  -2.028078317642212,\n",
-       "  0.0,\n",
-       "  0.0,\n",
-       "  0.0],\n",
-       " 'class_person': 0,\n",
-       " 'elodie_dof': 0,\n",
-       " 'nturnoff': 0,\n",
-       " 'platerun': '2016.11.b.eboss',\n",
-       " 'z_conf_person': 0,\n",
-       " 'objid': [0, 0, 0, 0, 0],\n",
-       " 'boss_target2': 0,\n",
-       " 'elodie_sptype': '',\n",
-       " 'z_err_noqso': 7.462430221494287e-05,\n",
-       " 'vdispz': 0.0,\n",
-       " 'segue1_target2': 0,\n",
-       " 'thing_id_targeting': 0,\n",
-       " 'fracnsiglo': [0.1539330929517746,\n",
-       "  0.024864375591278076,\n",
-       "  0.0029385171364992857,\n",
-       "  0.00022603978868573904,\n",
-       "  0.0,\n",
-       "  0.0,\n",
-       "  0.0,\n",
-       "  0.0,\n",
-       "  0.0,\n",
-       "  0.0],\n",
-       " 'elodie_z_modelerr': 0.0,\n",
-       " 'marvels_target2': 0,\n",
-       " 'special_target2': 0,\n",
-       " 'nspecobs': 1,\n",
-       " 'spec1_i': 15.253999710083008,\n",
-       " 'elodie_bv': 0.0,\n",
-       " 'wcoverage': 0.4424000084400177,\n",
-       " 'specboss': 1,\n",
-       " 'legacy_target2': 0,\n",
-       " 'fluxobjid': '1237665127987282622',\n",
-       " 'legacy_target1': 0,\n",
-       " 'z_noqso': 0.8864001035690308,\n",
-       " 'vdisp': 427.2975158691406,\n",
-       " 'vdispdof': 1018,\n",
-       " 'snturnoff': 0.0,\n",
-       " 'spectroflux': [3.7370755672454834,\n",
-       "  1.2999285459518433,\n",
-       "  2.04257869720459,\n",
-       "  3.88021183013916,\n",
-       "  6.065510272979736],\n",
-       " 'spec2_i': 16.18160057067871,\n",
-       " 'vdispnpix': 1242.0,\n",
-       " 'cz': 0.3997183762488972,\n",
-       " 'boss_target1': 0,\n",
-       " 'dof': 4417,\n",
-       " 'plateid': '10807513342203146240',\n",
-       " 'yfocal': -139.72686767578125,\n",
-       " 'mask': array([88080384, 88080384, 88080384, ..., 83886080, 83886080, 83886080]),\n",
-       " 'wave_sigma': array([0., 0., 0., ..., 0., 0., 0.]),\n",
-       " 'model': array([0.61179036, 0.59592736, 0.58086985, ..., 0.90960234, 0.90695798,\n",
-       "        0.91079909]),\n",
-       " 'wavelength': array([ 3585.91507517,  3586.7408577 ,  3587.56683039, ...,\n",
-       "        10351.42166679, 10353.80544415, 10356.18977045]),\n",
-       " 'ivar': array([0., 0., 0., ..., 0., 0., 0.]),\n",
-       " 'flux': array([-1.16054475, -1.16002548, -1.15950704, ..., -0.8605082 ,\n",
-       "        -0.860511  , -0.86051393]),\n",
-       " 'sky': array([0., 0., 0., ..., 0., 0., 0.]),\n",
-       " 'dateobs': '[\"2018-01-13 05:57:56+00\",\"2018-01-13 05:57:56+00\"]',\n",
-       " 'dateobs_center': '2018-01-13 05:57:56+00',\n",
-       " '_dr': 'BOSS-DR17'}"
-      ]
-     },
-     "execution_count": 57,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "boss_records[0]"
+    "boss_spectra.records[0]"
    ]
   },
   {
@@ -3116,41 +1428,18 @@
     "\n",
     "#### Spectrum object\n",
     "\n",
-    "First we assemble the components of the spectrum object"
+    "First we assemble the components of the spectrum object. Most of the work is done simply by converting the retrieved results to a `specutils` object."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 58,
+   "execution_count": null,
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2025-12-15T17:00:03.200981Z",
-     "iopub.status.busy": "2025-12-15T17:00:03.200503Z",
-     "iopub.status.idle": "2025-12-15T17:00:03.206035Z",
-     "shell.execute_reply": "2025-12-15T17:00:03.205446Z",
-     "shell.execute_reply.started": "2025-12-15T17:00:03.200969Z"
-    },
     "tags": []
    },
    "outputs": [],
    "source": [
-    "flux = np.zeros((len(boss_records), boss_records[0].flux.shape[0]),\n",
-    "                dtype=boss_records[0].flux.dtype)\n",
-    "uncertainty = np.zeros((len(boss_records), boss_records[0].ivar.shape[0]),\n",
-    "                       dtype=boss_records[0].ivar.dtype)\n",
-    "mask = np.zeros((len(boss_records), boss_records[0].mask.shape[0]),\n",
-    "                dtype=boss_records[0].mask.dtype)\n",
-    "\n",
-    "meta = {'sparcl_id': list(), 'data_release': list()}\n",
-    "sparcl_id = list()\n",
-    "data_release = list()\n",
-    "\n",
-    "for k in range(len(boss_records)):\n",
-    "    flux[k, :] = boss_records[k].flux\n",
-    "    uncertainty[k, :] = boss_records[k].ivar\n",
-    "    mask[k, :] = boss_records[k].mask\n",
-    "    meta['sparcl_id'].append(boss_records[k].sparcl_id)\n",
-    "    meta['data_release'].append(boss_records[k].data_release)"
+    "boss_specutils = boss_spectra.to_specutils()"
    ]
   },
   {
@@ -3159,20 +1448,13 @@
     "tags": []
    },
    "source": [
-    "And the \"plugmap\" table. We'll start with photometric quantities."
+    "We need a \"plugmap\" table. We'll start with photometric quantities."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 59,
+   "execution_count": null,
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2025-12-15T17:00:03.206993Z",
-     "iopub.status.busy": "2025-12-15T17:00:03.206679Z",
-     "iopub.status.idle": "2025-12-15T17:00:04.425759Z",
-     "shell.execute_reply": "2025-12-15T17:00:04.425070Z",
-     "shell.execute_reply.started": "2025-12-15T17:00:03.206980Z"
-    },
     "tags": []
    },
    "outputs": [],
@@ -3192,16 +1474,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 60,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2025-12-15T17:00:04.427051Z",
-     "iopub.status.busy": "2025-12-15T17:00:04.426864Z",
-     "iopub.status.idle": "2025-12-15T17:00:04.432972Z",
-     "shell.execute_reply": "2025-12-15T17:00:04.432362Z",
-     "shell.execute_reply.started": "2025-12-15T17:00:04.427035Z"
-    }
-   },
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": [
     "for col in plugmap.colnames:\n",
@@ -3214,7 +1488,7 @@
     "plugmap.add_column(boss_ids['eboss_target0'], name='EBOSS_TARGET0')\n",
     "plugmap.add_column(boss_ids['eboss_target1'], name='EBOSS_TARGET1')\n",
     "plugmap.add_column(boss_ids['eboss_target2'], name='EBOSS_TARGET2')\n",
-    "meta['plugmap'] = plugmap[~boss_fully_masked]"
+    "boss_specutils.meta['plugmap'] = plugmap[~boss_fully_masked]"
    ]
   },
   {
@@ -3228,15 +1502,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 61,
+   "execution_count": null,
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2025-12-15T17:00:04.434197Z",
-     "iopub.status.busy": "2025-12-15T17:00:04.433746Z",
-     "iopub.status.idle": "2025-12-15T17:00:04.451868Z",
-     "shell.execute_reply": "2025-12-15T17:00:04.451245Z",
-     "shell.execute_reply.started": "2025-12-15T17:00:04.434180Z"
-    },
     "tags": []
    },
    "outputs": [],
@@ -3255,24 +1522,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 62,
+   "execution_count": null,
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2025-12-15T17:00:04.452905Z",
-     "iopub.status.busy": "2025-12-15T17:00:04.452613Z",
-     "iopub.status.idle": "2025-12-15T17:00:04.459585Z",
-     "shell.execute_reply": "2025-12-15T17:00:04.458985Z",
-     "shell.execute_reply.started": "2025-12-15T17:00:04.452890Z"
-    },
     "tags": []
    },
    "outputs": [],
    "source": [
-    "boss_prospect = Spectrum1D(flux=flux[~boss_fully_masked, :] * u.Unit('1e-17 erg / (Angstrom cm2 s)'),\n",
-    "                           spectral_axis=boss_records[0].wavelength * u.Unit('Angstrom'),\n",
-    "                           uncertainty=InverseVariance(uncertainty[~boss_fully_masked, :]),\n",
-    "                           mask=mask[~boss_fully_masked, :] != 0,\n",
-    "                           meta=meta)"
+    "boss_prospect = Spectrum1D(flux=boss_specutils.flux[~boss_fully_masked, :],\n",
+    "                           spectral_axis=boss_specutils.spectral_axis,\n",
+    "                           uncertainty=boss_specutils.uncertainty[~boss_fully_masked, :],\n",
+    "                           mask=boss_specutils.mask[~boss_fully_masked, :] != 0,\n",
+    "                           meta=boss_specutils.meta)"
    ]
   },
   {
@@ -3288,81 +1548,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 63,
+   "execution_count": null,
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2025-12-15T17:00:04.460855Z",
-     "iopub.status.busy": "2025-12-15T17:00:04.460420Z",
-     "iopub.status.idle": "2025-12-15T17:00:04.469843Z",
-     "shell.execute_reply": "2025-12-15T17:00:04.469231Z",
-     "shell.execute_reply.started": "2025-12-15T17:00:04.460838Z"
-    },
     "tags": []
    },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div><i>Table length=50</i>\n",
-       "<table id=\"table140046222957184\" class=\"table-striped table-bordered table-condensed\">\n",
-       "<thead><tr><th>SPECOBJID</th><th>BESTOBJID</th><th>Z</th><th>Z_ERR</th><th>ZWARNING</th><th>CLASS</th><th>SUBCLASS</th><th>RCHI2DIFF</th><th>BOSS_TARGET1</th><th>EBOSS_TARGET0</th><th>EBOSS_TARGET1</th><th>EBOSS_TARGET2</th></tr></thead>\n",
-       "<thead><tr><th>int64</th><th>int64</th><th>float64</th><th>float64</th><th>int64</th><th>str6</th><th>int64</th><th>float64</th><th>int64</th><th>int64</th><th>int64</th><th>int64</th></tr></thead>\n",
-       "<tr><td>-7639230456632420352</td><td>1237665127987282622</td><td>0.8864001</td><td>7.46243e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>0.06786668</td><td>0</td><td>0</td><td>17592186044416</td><td>562949953421312</td></tr>\n",
-       "<tr><td>-7639227982731257856</td><td>1237665098459972441</td><td>0.9110273</td><td>0.00010862139</td><td>0</td><td>GALAXY</td><td>--</td><td>0.017336488</td><td>0</td><td>0</td><td>17592186044416</td><td>562949953421312</td></tr>\n",
-       "<tr><td>-7639227707853350912</td><td>1237665128524284395</td><td>0.38422197</td><td>3.6719743e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>0.04284048</td><td>0</td><td>0</td><td>17592186044416</td><td>562949953421312</td></tr>\n",
-       "<tr><td>-7639227432975443968</td><td>1237665098459972179</td><td>0.800372</td><td>7.3419695e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>0.026912212</td><td>0</td><td>0</td><td>17592186044416</td><td>562949953421312</td></tr>\n",
-       "<tr><td>-7639226333463816192</td><td>1237665128524350020</td><td>0.7552478</td><td>0.00021523784</td><td>0</td><td>GALAXY</td><td>--</td><td>0.013269424</td><td>0</td><td>0</td><td>17592186044416</td><td>562949953421312</td></tr>\n",
-       "<tr><td>-7639225783708002304</td><td>1237665128524415517</td><td>0.8210997</td><td>8.6923865e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>0.023777902</td><td>0</td><td>0</td><td>17592186044416</td><td>562949953421312</td></tr>\n",
-       "<tr><td>-7639225233952188416</td><td>1237665098460037767</td><td>1.4448175</td><td>0.7513441</td><td>0</td><td>GALAXY</td><td>--</td><td>0.011829615</td><td>0</td><td>0</td><td>17592186044416</td><td>562949953421312</td></tr>\n",
-       "<tr><td>-7639224959074281472</td><td>1237665128524153288</td><td>0.92107</td><td>0.000118537646</td><td>0</td><td>GALAXY</td><td>--</td><td>0.017925024</td><td>0</td><td>0</td><td>17592186044416</td><td>562949953421312</td></tr>\n",
-       "<tr><td>-7639224409318467584</td><td>1237665097923035567</td><td>0.98253536</td><td>0.00013488902</td><td>0</td><td>GALAXY</td><td>--</td><td>0.0124723315</td><td>0</td><td>0</td><td>17592186044416</td><td>562949953421312</td></tr>\n",
-       "<tr><td>-7639224134440560640</td><td>1237665128524153695</td><td>0.7265247</td><td>0.00017648208</td><td>0</td><td>GALAXY</td><td>--</td><td>0.012127399</td><td>0</td><td>0</td><td>17592186044416</td><td>562949953421312</td></tr>\n",
-       "<tr><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td></tr>\n",
-       "<tr><td>-7639198570795214848</td><td>1237665129060959070</td><td>0.880374</td><td>0.00012446102</td><td>0</td><td>GALAXY</td><td>--</td><td>0.011144221</td><td>0</td><td>0</td><td>17592186044416</td><td>562949953421312</td></tr>\n",
-       "<tr><td>-7639198021039400960</td><td>1237664834855306140</td><td>0.8465685</td><td>0.0001428312</td><td>0</td><td>GALAXY</td><td>--</td><td>0.010542035</td><td>0</td><td>0</td><td>17592186044416</td><td>562949953421312</td></tr>\n",
-       "<tr><td>-7639197196405680128</td><td>1237665097385771894</td><td>0.95612645</td><td>0.00012754179</td><td>0</td><td>GALAXY</td><td>--</td><td>0.016105115</td><td>0</td><td>0</td><td>17592186044416</td><td>562949953421312</td></tr>\n",
-       "<tr><td>-7639196371771959296</td><td>1237665097385772080</td><td>0.9289423</td><td>0.00012436773</td><td>0</td><td>GALAXY</td><td>--</td><td>0.020461261</td><td>0</td><td>0</td><td>17592186044416</td><td>562949953421312</td></tr>\n",
-       "<tr><td>-7639191698847541248</td><td>1237665098459644688</td><td>0.8261564</td><td>6.6143366e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>0.044942915</td><td>0</td><td>0</td><td>17592186044416</td><td>562949953421312</td></tr>\n",
-       "<tr><td>-7639191423969634304</td><td>1237665128523891276</td><td>0.8741866</td><td>0.0001341164</td><td>0</td><td>GALAXY</td><td>--</td><td>0.0131188035</td><td>0</td><td>0</td><td>17592186044416</td><td>562949953421312</td></tr>\n",
-       "<tr><td>-7639190874213820416</td><td>1237665098459644459</td><td>0.8458714</td><td>0.00012319988</td><td>0</td><td>GALAXY</td><td>--</td><td>0.019765258</td><td>0</td><td>0</td><td>17592186044416</td><td>562949953421312</td></tr>\n",
-       "<tr><td>-7639190599335913472</td><td>1237665098459644444</td><td>0.8814687</td><td>0.0001139445</td><td>0</td><td>GALAXY</td><td>--</td><td>0.013265789</td><td>0</td><td>0</td><td>17592186044416</td><td>562949953421312</td></tr>\n",
-       "<tr><td>-7639190049580099584</td><td>1237665098459710264</td><td>0.29381013</td><td>5.2243926e-05</td><td>0</td><td>GALAXY</td><td>--</td><td>0.017308354</td><td>0</td><td>0</td><td>17592186044416</td><td>562949953421312</td></tr>\n",
-       "<tr><td>-7639188950068471808</td><td>1237665098459644427</td><td>0.9214909</td><td>0.00020075552</td><td>0</td><td>GALAXY</td><td>--</td><td>0.011227965</td><td>0</td><td>0</td><td>17592186044416</td><td>562949953421312</td></tr>\n",
-       "</table></div>"
-      ],
-      "text/plain": [
-       "<Table length=50>\n",
-       "     SPECOBJID            BESTOBJID      ... EBOSS_TARGET1   EBOSS_TARGET2 \n",
-       "       int64                int64        ...     int64           int64     \n",
-       "-------------------- ------------------- ... -------------- ---------------\n",
-       "-7639230456632420352 1237665127987282622 ... 17592186044416 562949953421312\n",
-       "-7639227982731257856 1237665098459972441 ... 17592186044416 562949953421312\n",
-       "-7639227707853350912 1237665128524284395 ... 17592186044416 562949953421312\n",
-       "-7639227432975443968 1237665098459972179 ... 17592186044416 562949953421312\n",
-       "-7639226333463816192 1237665128524350020 ... 17592186044416 562949953421312\n",
-       "-7639225783708002304 1237665128524415517 ... 17592186044416 562949953421312\n",
-       "-7639225233952188416 1237665098460037767 ... 17592186044416 562949953421312\n",
-       "-7639224959074281472 1237665128524153288 ... 17592186044416 562949953421312\n",
-       "-7639224409318467584 1237665097923035567 ... 17592186044416 562949953421312\n",
-       "-7639224134440560640 1237665128524153695 ... 17592186044416 562949953421312\n",
-       "                 ...                 ... ...            ...             ...\n",
-       "-7639198570795214848 1237665129060959070 ... 17592186044416 562949953421312\n",
-       "-7639198021039400960 1237664834855306140 ... 17592186044416 562949953421312\n",
-       "-7639197196405680128 1237665097385771894 ... 17592186044416 562949953421312\n",
-       "-7639196371771959296 1237665097385772080 ... 17592186044416 562949953421312\n",
-       "-7639191698847541248 1237665098459644688 ... 17592186044416 562949953421312\n",
-       "-7639191423969634304 1237665128523891276 ... 17592186044416 562949953421312\n",
-       "-7639190874213820416 1237665098459644459 ... 17592186044416 562949953421312\n",
-       "-7639190599335913472 1237665098459644444 ... 17592186044416 562949953421312\n",
-       "-7639190049580099584 1237665098459710264 ... 17592186044416 562949953421312\n",
-       "-7639188950068471808 1237665098459644427 ... 17592186044416 562949953421312"
-      ]
-     },
-     "execution_count": 63,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "boss_zcatalog = boss_ids.copy()\n",
     "for col in boss_zcatalog.colnames:\n",
@@ -3384,26 +1574,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 64,
+   "execution_count": null,
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2025-12-15T17:00:04.471019Z",
-     "iopub.status.busy": "2025-12-15T17:00:04.470687Z",
-     "iopub.status.idle": "2025-12-15T17:00:04.475043Z",
-     "shell.execute_reply": "2025-12-15T17:00:04.474469Z",
-     "shell.execute_reply.started": "2025-12-15T17:00:04.471003Z"
-    },
     "tags": []
    },
    "outputs": [],
    "source": [
-    "model_flux = np.zeros((len(boss_records), boss_records[0].model.shape[0]),\n",
-    "                      dtype=boss_records[0].model.dtype)\n",
-    "\n",
-    "for k in range(len(boss_records)):\n",
-    "        model_flux[k, :] = boss_records[k].model\n",
-    "\n",
-    "boss_model = (boss_records[0].wavelength, model_flux[~boss_fully_masked, :])"
+    "boss_model = (boss_specutils.spectral_axis, boss_specutils.meta['model'][~boss_fully_masked, :])"
    ]
   },
   {
@@ -3434,6 +1611,13 @@
     "            model_from_zcat=False,\n",
     "            model=boss_model)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/04_HowTos/SPARCL/Plot_SPARCL_Spectra_with_Prospect.ipynb
+++ b/04_HowTos/SPARCL/Plot_SPARCL_Spectra_with_Prospect.ipynb
@@ -8,7 +8,7 @@
    "source": [
     "__nbid__ = '0053'\n",
     "__author__ = 'Eric Armengaud, Benjamin Weaver <benjamin.weaver@noirlab.edu>, Alice Jacques <alice.jacques@noirlab.edu>'\n",
-    "__version__ = '20251215' # yyyymmdd\n",
+    "__version__ = '20260505' # yyyymmdd\n",
     "__datasets__ = ['boss_dr17', 'desi_dr1', 'sdss_dr17']\n",
     "__keywords__ = ['sparcl', 'spectroscopy', 'sdss spectra', 'desi spectra', 'tutorial', 'prospect', 'specutils']"
    ]


### PR DESCRIPTION
This PR updates the SPARCL + Prospect to use the `to_specutils()` method to simplify the code needed to prepare SPARCL results for input to Prospect.

In addition, the `.reorder()` method is used instead of a "roll-your-own" sorting.

Since the `to_specutils()` method is still in a PR, this notebook should be treated as a functional test of that PR, then merged only after a new version of sparclclient is deployed.